### PR TITLE
Implement Metrics Logging Configuration in Indexer

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,8 @@ Here's a complete configuration example with all options:
       "size": 100000000,
       "podCacheSize": 10
     },
-    "enableMetrics": true
+    "enableMetrics": true,
+    "metricsLoggingInterval": "1m0s"
   },
   "tokenizersPoolConfig": {
     "workersCount": 8,
@@ -81,6 +82,7 @@ Configures the KV-block index backend. Multiple backends can be configured, but 
 | `inMemoryConfig` | [InMemoryIndexConfig](#in-memory-index-configuration) | In-memory index configuration | See defaults |
 | `redisConfig` | [RedisIndexConfig](#redis-index-configuration)        | Redis index configuration | `null` |
 | `enableMetrics` | `boolean`                                             | Enable admissions/evictions/hits/misses recording | `false` |
+| `metricsLoggingInterval` | `string` (duration) | Interval at which metrics are logged (e.g., `"1m0s"`). If zero or omitted, metrics logging is disabled. Requires `enableMetrics` to be `true`. | `"0s"` |
 
 ### In-Memory Index Configuration (`InMemoryIndexConfig`)
 

--- a/examples/kv_cache_index/main.go
+++ b/examples/kv_cache_index/main.go
@@ -94,8 +94,7 @@ func setupKVCacheIndexer(ctx context.Context) (*kvcache.Indexer, error) {
 		return nil, err
 	}
 
-	//nolint:contextcheck // NewKVCacheIndexer does not accept context parameter
-	kvCacheIndexer, err := kvcache.NewKVCacheIndexer(config)
+	kvCacheIndexer, err := kvcache.NewKVCacheIndexer(ctx, config)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/kv_events/offline/main.go
+++ b/examples/kv_events/offline/main.go
@@ -106,8 +106,7 @@ func main() {
 func setupKVCacheIndexer(ctx context.Context) (*kvcache.Indexer, error) {
 	logger := klog.FromContext(ctx)
 
-	//nolint:contextcheck // NewKVCacheIndexer does not accept context parameter
-	kvCacheIndexer, err := kvcache.NewKVCacheIndexer(getKVCacheIndexerConfig())
+	kvCacheIndexer, err := kvcache.NewKVCacheIndexer(ctx, getKVCacheIndexerConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/redis_mock/e2e_suite_test.go
+++ b/tests/e2e/redis_mock/e2e_suite_test.go
@@ -69,7 +69,7 @@ func (s *KVCacheSuite) SetupTest() {
 
 	s.Pod1IP = "10.0.0.1"
 
-	s.indexer, err = kvcache.NewKVCacheIndexer(s.config)
+	s.indexer, err = kvcache.NewKVCacheIndexer(s.ctx, s.config)
 	s.kvBlockIndex = s.indexer.KVBlockIndex()
 	s.Require().NoError(err)
 


### PR DESCRIPTION
## Summary

This PR implements metrics registration and logging in the indexer instead of delegating it to indexer users such as prefix-cache-scorer.