### PR TITLE
`kvevents` Package Build Data Exportation

### DIFF
--- a/pkg/kvcache/kvevents/doc.go
+++ b/pkg/kvcache/kvevents/doc.go
@@ -1,0 +1,9 @@
+//go:build !ignore
+
+// Package kvevents contains the implementation of the KV-events processing
+// system. It provides a pool for handling events coming from a distributed
+// KV-cache pool, allowing for cache-tracking and real-time updates
+// to the KV-cache index. The package is designed to work with the
+// kvcache.Indexer to maintain an up-to-date state of the KV-cache
+// and to facilitate the scoring of pods based on the KV-cache index state.
+package kvevents


### PR DESCRIPTION
## Summary

Fix CI lint failure (no export data for kvevents)
- Adds pkg/kvcache/kvevents/doc.go, an un-tagged, code-free stub that is always compiled
- Guarantees the Go toolchain produces an export file (kvevents.a), allowing go vet / golangci-lint to load the package in CI