### PR TITLE
Remove Default StorageClass:  "ocs-storagecluster-cephfs"

### DIFF
--- a/vllm-setup-helm/values.yaml
+++ b/vllm-setup-helm/values.yaml
@@ -196,7 +196,7 @@ persistence:
   # -- PVC storage size
   size: 50Gi
   # -- Optional: Storage class name for the PVC
-  storageClassName: "ocs-storagecluster-cephfs"
+  storageClassName: ""
   # -- Mount path inside the VLLM container for Hugging Face cache
   mountPath: /data
 


### PR DESCRIPTION
This PR removes setting a default storage (i.e., `ocs-storagecluster-cephfs`) so that PVC for the vLLM pod can use a default storageClass available in any k8s cluster. Consequently, this will allow the deployment of the vLLM pod on environment independently of their default storageClass. 