### PR TITLE
fix: correct shell command substitution syntax in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,16 +366,16 @@ download-zmq: ## Install ZMQ dependencies based on OS/ARCH
 	else \
 	  echo "Installing ZMQ dependencies..."; \
 	  if [ "$(TARGETOS)" = "linux" ]; then \
-	    if [ -x "$(command -v apt)" ]; then \
+	    if [ -x "$$(command -v apt)" ]; then \
 	      apt update && apt install -y libzmq3-dev; \
-	    elif [ -x "$(command -v dnf)" ]; then \
+	    elif [ -x "$$(command -v dnf)" ]; then \
 	      dnf install -y zeromq-devel; \
 	    else \
 	      echo "Unsupported Linux package manager. Install libzmq manually."; \
 	      exit 1; \
 	    fi; \
 	  elif [ "$(TARGETOS)" = "darwin" ]; then \
-	    if [ -x "$(command -v brew)" ]; then \
+	    if [ -x "$$(command -v brew)" ]; then \
 	      brew install zeromq; \
 	    else \
 	      echo "Homebrew is not installed and is required to install zeromq. Install it from https://brew.sh/"; \


### PR DESCRIPTION
## Summary

Fix Makefile syntax issues by correcting shell command substitution and indentation errors.

The same as https://github.com/llm-d/llm-d-inference-scheduler/pull/276

## Problem Solved
Resolves "Unsupported Linux package manager" error when running `make download-zmq` on Ubuntu systems. logs: 
```
# make download-zmq
Checking if ZMQ is already installed...
Installing ZMQ dependencies...
Unsupported Linux package manager. Install libzmq manually.
make: *** [Makefile:364: download-zmq] Error 1
```
The issue was caused by incorrect Make variable substitution syntax, where $(command -v apt)was being evaluated by Make at parse time instead of being passed to the shell for runtime evaluation.

