### PR TITLE
Fix kv_events offline example

### DIFF
--- a/examples/kv_events/README.md
+++ b/examples/kv_events/README.md
@@ -18,7 +18,7 @@ Download tokenizer bindings:
 
 ### Running the Example
 ```
-    go run -ldflags="-extldflags '-L$(pwd)/lib'" examples/kv-events/offline/main.go examples/kv-events/offline/publisher.go
+    go run -ldflags="-extldflags '-L$(pwd)/lib'" examples/kv_events/offline/main.go examples/kv_events/offline/publisher.go
 ```
 
 The example will start the KV-Cache Manager (indexer) and a dummy publisher that simulates KV-Events. 

--- a/examples/kv_events/offline/main.go
+++ b/examples/kv_events/offline/main.go
@@ -136,11 +136,10 @@ func setupEventsPool(ctx context.Context, kvBlockIndex kvblock.Index) *kvevents.
 func setupPublisher(ctx context.Context) (*Publisher, error) {
 	logger := klog.FromContext(ctx)
 
-	cfg := kvevents.DefaultConfig()
+	endpoint := "tcp://localhost:5557"
+	logger.Info("Creating ZMQ publisher (simulating vLLM engines)", "endpoint", endpoint)
 
-	logger.Info("Creating ZMQ publisher (simulating vLLM engines)", "endpoint", cfg.ZMQEndpoint)
-
-	publisher, err := NewPublisher(cfg.ZMQEndpoint)
+	publisher, err := NewPublisher(endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ZMQ publisher: %w", err)
 	}
@@ -212,7 +211,7 @@ func runEventsDemo(ctx context.Context, kvCacheIndexer *kvcache.Indexer, publish
 	//nolint // won't fail
 	enc.Encode(&kvevents.BlockRemovedEvent{
 		TypeField:    "BlockRemoved",
-		BlockRemoved: &kvevents.BlockRemoved{BlockHashes: testdata.PromptHashes[:2]},
+		BlockRemoved: &kvevents.BlockRemoved{BlockHashes: testdata.PromptHashes[2:]},
 	})
 
 	removeEventBatch := kvevents.EventBatch{

--- a/pkg/kvcache/kvevents/events.go
+++ b/pkg/kvcache/kvevents/events.go
@@ -63,6 +63,12 @@ type BlockStored struct {
 
 func (BlockStored) isEvent() {}
 
+type BlockStoredEvent struct {
+	_         struct{} `msgpack:",array"`
+	TypeField string
+	*BlockStored
+}
+
 // BlockRemoved event.
 type BlockRemoved struct {
 	_           struct{} `msgpack:",array"`
@@ -70,6 +76,12 @@ type BlockRemoved struct {
 }
 
 func (BlockRemoved) isEvent() {}
+
+type BlockRemovedEvent struct {
+	_         struct{} `msgpack:",array"`
+	TypeField string
+	*BlockRemoved
+}
 
 // AllBlocksCleared event.
 type AllBlocksCleared struct {

--- a/pkg/kvcache/kvevents/pool.go
+++ b/pkg/kvcache/kvevents/pool.go
@@ -193,13 +193,13 @@ func (p *Pool) processEvent(ctx context.Context, msg *Message) {
 		var unmarshalErr error
 		switch tag {
 		case "BlockStored":
-			var bs BlockStored
-			unmarshalErr = msgpack.Unmarshal(payloadBytes, &bs)
-			event = bs
+			var bs BlockStoredEvent
+			unmarshalErr = msgpack.Unmarshal(rawEvent, &bs)
+			event = bs.BlockStored
 		case "BlockRemoved":
-			var br BlockRemoved
-			unmarshalErr = msgpack.Unmarshal(payloadBytes, &br)
-			event = br
+			var br BlockRemovedEvent
+			unmarshalErr = msgpack.Unmarshal(rawEvent, &br)
+			event = br.BlockRemoved
 		case "AllBlocksCleared":
 			var ac AllBlocksCleared
 			unmarshalErr = msgpack.Unmarshal(payloadBytes, &ac)


### PR DESCRIPTION
This PR fixes the kv_events example by adding new structs for events to contain TagField, and changing the marshaling to encoding as array