### PR TITLE
[Breaking] Remove redundant keys return from Index.Lookup interface

### DIFF
--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -133,7 +133,7 @@ func (k *Indexer) GetPodScores(ctx context.Context, prompt, modelName string,
 	traceLogger.Info("found tokens", "tokens", tokens, "block-keys", blockKeys)
 
 	// 3. query kvblock indexer for pods
-	strBlockKeys, keyToPods, err := k.kvBlockIndex.Lookup(ctx, blockKeys, sets.New(podIdentifiers...))
+	keyToPods, err := k.kvBlockIndex.Lookup(ctx, blockKeys, sets.New(podIdentifiers...))
 	if err != nil {
 		return nil, fmt.Errorf("failed to query kvblock indexer: %w", err)
 	}
@@ -141,7 +141,7 @@ func (k *Indexer) GetPodScores(ctx context.Context, prompt, modelName string,
 		"pods", podsPerKeyPrintHelper(keyToPods))
 
 	// 4. score pods
-	podScores, err := k.kvBlockScorer.Score(strBlockKeys, keyToPods)
+	podScores, err := k.kvBlockScorer.Score(blockKeys, keyToPods)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query kvblock scorer: %w", err)
 	}

--- a/pkg/kvcache/kvblock/index.go
+++ b/pkg/kvcache/kvblock/index.go
@@ -107,10 +107,9 @@ type Index interface {
 	// If the podIdentifierSet is empty, all pods are returned.
 	//
 	// It returns:
-	// 1. A slice of the hit keys.
-	// 2. A map where the keys are those in (1) and the values are pod-identifiers.
-	// 3. An error if any occurred during the operation.
-	Lookup(ctx context.Context, keys []Key, podIdentifierSet sets.Set[string]) ([]Key, map[Key][]string, error)
+	// 1. A map where the keys are those in (1) and the values are pod-identifiers.
+	// 2. An error if any occurred during the operation.
+	Lookup(ctx context.Context, keys []Key, podIdentifierSet sets.Set[string]) (map[Key][]string, error)
 	// Add adds a set of keys and their associated pod entries to the index backend.
 	Add(ctx context.Context, keys []Key, entries []PodEntry) error
 	// Evict removes a key and its associated pod entries from the index backend.

--- a/pkg/kvcache/kvblock/instrumented_index.go
+++ b/pkg/kvcache/kvblock/instrumented_index.go
@@ -34,14 +34,13 @@ func (m *instrumentedIndex) Lookup(
 	ctx context.Context,
 	keys []Key,
 	podIdentifierSet sets.Set[string],
-) ([]Key, map[Key][]string, error) {
+) (map[Key][]string, error) {
 	timer := prometheus.NewTimer(metrics.LookupLatency)
 	defer timer.ObserveDuration()
 
 	metrics.LookupRequests.Inc()
 
-	hitKeys, pods, err := m.next.Lookup(ctx, keys, podIdentifierSet)
-	metrics.LookupHits.Add(float64(len(hitKeys)))
+	pods, err := m.next.Lookup(ctx, keys, podIdentifierSet)
 
-	return hitKeys, pods, err
+	return pods, err
 }


### PR DESCRIPTION
Why This Change

1. Removes Misleading Interface: The returned []Key was not actually "hit keys" but all keys up to highest hit

2. Eliminates Redundancy: Hit keys are exactly 
maps.Keys(resultMap)

3. Cleaner API: Callers get exactly what they need - the map of keys to pods

Breaking Changes
⚠️ This is a breaking change that affects:

All callers of Index.Lookup()
All implementations of the Index interface
Test code that expects the old signature

Migration Guide
For callers that need the keys slice:

```python
// Before:
hitKeys, podsPerKey, err := index.Lookup(ctx, keys, podSet)

// After:
podsPerKey, err := index.Lookup(ctx, keys, podSet)
hitKeys := maps.Keys(pods) // If you need the actual hit keys
```

