### PR TITLE
docs: fix mermaid chart arrow syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ graph TD
         G[...]
     end
 
-    A -->|"(1) Score(prompt, pods)"| B
-    B -->|"(2) Query Index"| C
-    B -->|"(3) Return Scores"| A
+    A--"(1) Score(prompt, pods)"-->B
+    B--"(2) Query Index"-->C
+    B--"(3) Return Scores"-->A
     
-    E -->|"(A) Emit KVEvents"| D
-    F -->|"(A) Emit KVEvents"| D
-    D -->|"(B) Update Index"| C
+    E--"(A) Emit KVEvents"-->D
+    F--"(A) Emit KVEvents"-->D
+    D--"(B) Update Index"-->C
 ```
 **Read Path:**
 - (1)  **Scoring Request**: A scheduler asks the **KVCache Indexer** to score a set of pods for a given prompt


### PR DESCRIPTION
## Summary
Fixed mermaid chart arrow syntax in README.md to follow proper mermaid formatting standards.

## Changes
- Changed arrow syntax from `-->|"label"|` to `--"label"-->` format in the architecture diagram
- Updated all 6 arrows in the mermaid chart to use consistent formatting

## Details
The mermaid chart in the README was using an older/incorrect arrow syntax. This change updates the syntax to be compatible with modern mermaid renderers and follows the standard format.

<table border="1">
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="955" height="650" alt="Screenshot 2025-08-21 at 10 21 29 AM" src="https://github.com/user-attachments/assets/07ed97dd-7fdb-4028-a4f1-0bfa1e1b6c92" /></td>
      <td><img width="955" height="650" alt="Screenshot 2025-08-21 at 10 21 20 AM" src="https://github.com/user-attachments/assets/92cde940-2dd6-497c-9bb3-220eaa876902" /></td>
    </tr>
  </tbody>
</table>
