### PR TITLE
[docs] Update KV-Events and KV-Cache examples with correct paths and commands

### DIFF
--- a/docs/deployment/v0.1.0/setup.md
+++ b/docs/deployment/v0.1.0/setup.md
@@ -91,7 +91,7 @@ Ensure you have a running deployment with vLLM and Redis as described above.
 
 ### Running the Example
 
-The vLLM node can be tested with the prompt found in `examples/kv-cache-index/main.go`.
+The vLLM node can be tested with the prompt found in `examples/kv_cache_index/main.go`.
 
 First, download the tokenizer bindings required by the `kvcache.Indexer` for prompt tokenization:
 
@@ -106,7 +106,7 @@ export HF_TOKEN=<token>
 export REDIS_ADDR=<redis://$user:$pass@localhost:6379/$db> # optional, defaults to localhost:6379
 export MODEL_NAME=<model_name_used_in_vllm_deployment> # optional, defaults to meta-llama/Llama-3.1-8B-Instruct
 
-go run -ldflags="-extldflags '-L$(pwd)/lib'" examples/kv-cache-index/main.go
+go run -ldflags="-extldflags '-L$(pwd)/lib'" examples/kv_cache_index/main.go
 ```
 
 Environment variables:

--- a/examples/kv_cache_index/README.md
+++ b/examples/kv_cache_index/README.md
@@ -19,9 +19,9 @@ This example demonstrates how to configure and use the `kvcache.Indexer` module 
 
 2. **Run the example:**
 
-   ```sh
-   go run main.go
-   ```
+```sh
+go run -ldflags="-extldflags '-L$(pwd)/lib'" examples/kv_cache_index/main.go
+```
 
 3. **What to expect:**
 

--- a/examples/kv_events/README.md
+++ b/examples/kv_events/README.md
@@ -8,17 +8,17 @@ The offline example demonstrates how the KV-Cache Manager handles KV-Events thro
 
 Set the following environment variables:
 ```
-    export HF_TOKEN="your-huggingface-token"
+export HF_TOKEN="your-huggingface-token"
 ```
 
 Download tokenizer bindings:
 ```bash
-    make download-tokenizer
+make download-tokenizer
 ```
 
 ### Running the Example
 ```
-    go run -ldflags="-extldflags '-L$(pwd)/lib'" examples/kv_events/offline/main.go examples/kv_events/offline/publisher.go
+go run -ldflags="-extldflags '-L$(pwd)/lib'" examples/kv_events/offline/main.go examples/kv_events/offline/publisher.go
 ```
 
 The example will start the KV-Cache Manager (indexer) and a dummy publisher that simulates KV-Events. 


### PR DESCRIPTION
## Summary
This PR fixes documentation inconsistencies and improves the clarity of example usage instructions.

Some of the examples currently have naming issues that prevent them from running: 
```
(llm-d-kv-cache-manager) root@gpu-3090:~/oss/llm-d-kv-cache-manager/examples/kv_cache_index# go run main.go
# command-line-arguments
/usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/gcc -m64 -s -Wl,--build-id=0x973d6510ce13a0cac48199eae657005028c03812 -o $WORK/b001/exe/main -Wl,--export-dynamic-symbol=_cgo_panic -Wl,--export-dynamic-symbol=_cgo_topofstack -Wl,--export-dynamic-symbol=crosscall2 -Wl,--compress-debug-sections=zlib /tmp/go-link-3726542565/go.o /tmp/go-link-3726542565/000000.o /tmp/go-link-3726542565/000001.o /tmp/go-link-3726542565/000002.o /tmp/go-link-3726542565/000003.o /tmp/go-link-3726542565/000004.o /tmp/go-link-3726542565/000005.o /tmp/go-link-3726542565/000006.o /tmp/go-link-3726542565/000007.o /tmp/go-link-3726542565/000008.o /tmp/go-link-3726542565/000009.o /tmp/go-link-3726542565/000010.o /tmp/go-link-3726542565/000011.o /tmp/go-link-3726542565/000012.o /tmp/go-link-3726542565/000013.o /tmp/go-link-3726542565/000014.o /tmp/go-link-3726542565/000015.o /tmp/go-link-3726542565/000016.o /tmp/go-link-3726542565/000017.o /tmp/go-link-3726542565/000018.o /tmp/go-link-3726542565/000019.o /tmp/go-link-3726542565/000020.o /tmp/go-link-3726542565/000021.o /tmp/go-link-3726542565/000022.o /tmp/go-link-3726542565/000023.o /tmp/go-link-3726542565/000024.o -O2 -g -lresolv -O2 -g -O2 -g -lpthread -O2 -g -ltokenizers -ldl -lm -lstdc++ -no-pie
/usr/bin/ld: cannot find -ltokenizers: No such file or directory
collect2: error: ld returned 1 exit status
```

## Changes Made
- **Fixed path references**: Corrected `kv-cache-index` to `kv_cache_index` in setup documentation to match actual directory structure
- **Standardized build commands**: Updated all Go run commands to include proper ldflags for linking the tokenizer library
- **Improved formatting**: Enhanced code block formatting and indentation consistency in README files
