### PR TITLE
Minimize high-concurrency `kvblock.Index` PodCache maintenance race-condition window

### DIFF
--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -172,7 +172,7 @@ func (m *InMemoryIndex) Add(ctx context.Context, keys []Key, entries []PodEntry)
 			contains, _ := m.data.ContainsOrAdd(key, newPodCache)
 			if contains {
 				podCache, found = m.data.Get(key)
-				if !found {
+				if !found { // Extremely irregular workload pattern - key evicted
 					m.data.Add(key, newPodCache)
 					podCache = newPodCache
 				}

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -19,6 +19,7 @@ package kvblock
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	lru "github.com/hashicorp/golang-lru/v2"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -81,6 +82,8 @@ type PodCache struct {
 	// cache is an LRU cache that maps PodEntry to their last access time.
 	// thread-safe.
 	cache *lru.Cache[PodEntry, struct{}]
+	// mu protects the cache from concurrent access during check-and-set operations.
+	mu sync.Mutex
 }
 
 // Lookup receives a list of keys and a set of pod identifiers,
@@ -146,23 +149,44 @@ func (m *InMemoryIndex) Add(ctx context.Context, keys []Key, entries []PodEntry)
 	traceLogger := klog.FromContext(ctx).V(logging.TRACE).WithName("kvblock.InMemoryIndex.Add")
 
 	for _, key := range keys {
-		podCache, found := m.data.Get(key) // bumps LRU timestamp if found
+		var podCache *PodCache
+		var found bool
+
+		// Try to get existing cache first
+		podCache, found = m.data.Get(key)
+		//nolint:nestif // double-checked locking pattern
 		if !found {
+			// Create new cache
 			cache, err := lru.New[PodEntry, struct{}](m.podCacheSize)
 			if err != nil {
 				return fmt.Errorf("failed to create pod cache for key %s: %w", key.String(), err)
 			}
 
-			podCache = &PodCache{
+			newPodCache := &PodCache{
 				cache: cache,
 			}
 
-			m.data.ContainsOrAdd(key, podCache)
+			// Try to add, but use existing if another thread added it first
+			// This is a bounded retry (1) - not perfectly safe but for practical use-cases and scenarios
+			// this should be sufficient
+			contains, _ := m.data.ContainsOrAdd(key, newPodCache)
+			if contains {
+				podCache, found = m.data.Get(key)
+				if !found {
+					m.data.Add(key, newPodCache)
+					podCache = newPodCache
+				}
+			} else {
+				// We successfully added our cache
+				podCache = newPodCache
+			}
 		}
 
+		podCache.mu.Lock()
 		for _, entry := range entries {
-			podCache.cache.Add(entry, struct{}{}) // TODO: can this be batched to avoid multiple locks?
+			podCache.cache.Add(entry, struct{}{})
 		}
+		podCache.mu.Unlock()
 
 		traceLogger.Info("added pods to key", "key", key, "pods", entries)
 	}
@@ -184,15 +208,30 @@ func (m *InMemoryIndex) Evict(ctx context.Context, key Key, entries []PodEntry) 
 		return nil
 	}
 
+	podCache.mu.Lock()
 	for _, entry := range entries {
-		podCache.cache.Remove(entry) // TODO: can this be batched to avoid multiple locks?
+		podCache.cache.Remove(entry)
 	}
+
+	isEmpty := podCache.cache.Len() == 0
+	podCache.mu.Unlock()
 
 	traceLogger.Info("evicted pods from key", "key", key, "pods", entries)
 
-	if podCache.cache.Len() == 0 {
-		m.data.Remove(key)
-		traceLogger.Info("evicted key from index as no pods remain", "key", key)
+	// Remove key from main cache if empty
+	if isEmpty {
+		// Double-check after getting the cache again to MINIMIZE race window
+		// Worst case, we leave an empty cache behind which would be cleaned up by LRU if needed
+		if currentCache, stillExists := m.data.Get(key); stillExists && currentCache != nil {
+			currentCache.mu.Lock()
+			stillEmpty := currentCache.cache.Len() == 0
+			currentCache.mu.Unlock()
+
+			if stillEmpty {
+				m.data.Remove(key)
+				traceLogger.Info("evicted key from index as no pods remain", "key", key)
+			}
+		}
 	}
 
 	return nil

--- a/pkg/kvcache/kvblock/index_test.go
+++ b/pkg/kvcache/kvblock/index_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -56,7 +57,6 @@ func testCommonIndexBehavior(t *testing.T, indexFactory func(t *testing.T) Index
 	})
 
 	t.Run("ConcurrentOperations", func(t *testing.T) {
-		t.Skip("TODO: Re-enable this test after fixing https://github.com/llm-d/llm-d-kv-cache-manager/issues/104")
 		index := indexFactory(t)
 		testConcurrentOperations(t, ctx, index)
 	})
@@ -197,12 +197,13 @@ func testConcurrentOperations(t *testing.T, ctx context.Context, index Index) {
 	key := Key{ModelName: "test-model", ChunkHash: 1000}
 
 	var wg sync.WaitGroup
-	errChan := make(chan error, 30)
+	errChan := make(chan error, 1000)
 
 	// Run 100 goroutines doing concurrent operations
 	for goroutineID := 0; goroutineID < 100; goroutineID++ {
 		wg.Add(1)
 		go func(id int) {
+			time.Sleep(time.Millisecond * time.Duration(id%10)) // Stagger start times
 			defer wg.Done()
 			for operationIndex := 0; operationIndex < 10; operationIndex++ {
 				switch operationIndex % 3 {


### PR DESCRIPTION
## Summary

In #104 @yankay pointed out that there are data race-conditions within the `kvblock.InMemoryIndex` implementation. While the index is thread-safe, the race-condition windows come at the benefit of fewer lock contentions for faster KVEvent processing, at the cost of risking temporary "instability" (misses) at irregular workloads. The race-condition windows are when multiple threads simultaneously create a `PodCache` for the same key (several pods admit the same new KVBlocks at the exact same time), or when a key is simultaneously evicted and admitted from two sources.

The changes in this PR tighten the open windows while not fully resolving them, as an acceptable tradeoff of likelihood vs. stable benefits.

## Related Issues
- Fixes #104 