### PR TITLE
Fix indexer behavior when no kvblock-keys are generated

### DIFF
--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -126,6 +126,7 @@ func (k *Indexer) GetPodScores(ctx context.Context, prompt, modelName string,
 	blockKeys := k.tokensProcessor.TokensToKVBlockKeys(tokens, modelName)
 	if len(blockKeys) == 0 {
 		traceLogger.Info("no block keys found, returning empty scores")
+		//nolint:nilnil // no need to return an error
 		return nil, nil
 	}
 

--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -124,6 +124,11 @@ func (k *Indexer) GetPodScores(ctx context.Context, prompt, modelName string,
 
 	// 2. get block keys
 	blockKeys := k.tokensProcessor.TokensToKVBlockKeys(tokens, modelName)
+	if len(blockKeys) == 0 {
+		traceLogger.Info("no block keys found, returning empty scores")
+		return nil, nil
+	}
+
 	traceLogger.Info("found tokens", "tokens", tokens, "block-keys", blockKeys)
 
 	// 3. query kvblock indexer for pods


### PR DESCRIPTION
## Summary 
`kvcache.Indexer` to return empty-scores if `kvblock.TokenProcessor` does not generate keys.