### PR TITLE
Support new KVEvents format

### DIFF
--- a/pkg/kvcache/kvevents/events.go
+++ b/pkg/kvcache/kvevents/events.go
@@ -104,7 +104,7 @@ func (ac AllBlocksCleared) ToTaggedUnion() []any {
 func (AllBlocksCleared) isEvent() {}
 
 /*
- The following legacy event definitions for KV-cache events.
+ The following are legacy event definitions for KV-cache events.
  These definitions are kept and used for backward compatibility.
  This is due to the use of msgpack which relies on the exact structure of the data.
 */

--- a/pkg/kvcache/kvevents/events.go
+++ b/pkg/kvcache/kvevents/events.go
@@ -119,7 +119,7 @@ type LegacyBlockStored struct {
 	LoraID          *int `msgpack:",omitempty"`
 }
 
-// ToTaggedUnion converts the BlockStored event to a tagged union format.
+// ToTaggedUnion converts the LegacyBlockStored event to a tagged union format.
 func (bs LegacyBlockStored) ToTaggedUnion() []any {
 	result := []any{
 		BlockStoredEventTag,

--- a/pkg/kvcache/kvevents/events.go
+++ b/pkg/kvcache/kvevents/events.go
@@ -49,18 +49,25 @@ type BlockStored struct {
 	ParentBlockHash *uint64
 	TokenIds        []uint32
 	BlockSize       int
-	LoraID          *int
+	LoraID          *int    `msgpack:",omitempty"`
+	Medium          *string `msgpack:",omitempty"`
 }
 
+// ToTaggedUnion converts the BlockStored event to a tagged union format.
+//
+//nolint:gocritic // Keeping the receiver as a value
 func (bs BlockStored) ToTaggedUnion() []any {
-	return []any{
+	result := []any{
 		BlockStoredEventTag,
 		bs.BlockHashes,
 		bs.ParentBlockHash,
 		bs.TokenIds,
 		bs.BlockSize,
 		bs.LoraID,
+		bs.Medium,
 	}
+
+	return result
 }
 
 func (BlockStored) isEvent() {}
@@ -69,13 +76,16 @@ func (BlockStored) isEvent() {}
 type BlockRemoved struct {
 	_           struct{} `msgpack:",array"`
 	BlockHashes []uint64
+	Medium      *string `msgpack:",omitempty"`
 }
 
 func (br BlockRemoved) ToTaggedUnion() []any {
-	return []any{
+	result := []any{
 		BlockRemovedEventTag,
 		br.BlockHashes,
+		br.Medium,
 	}
+	return result
 }
 
 func (BlockRemoved) isEvent() {}
@@ -92,3 +102,52 @@ func (ac AllBlocksCleared) ToTaggedUnion() []any {
 }
 
 func (AllBlocksCleared) isEvent() {}
+
+/*
+ The following legacy event definitions for KV-cache events.
+ These definitions are kept and used for backward compatibility.
+ This is due to the use of msgpack which relies on the exact structure of the data.
+*/
+
+// LegacyBlockStored event.
+type LegacyBlockStored struct {
+	_               struct{} `msgpack:",array"`
+	BlockHashes     []uint64
+	ParentBlockHash *uint64
+	TokenIds        []uint32
+	BlockSize       int
+	LoraID          *int `msgpack:",omitempty"`
+}
+
+// ToTaggedUnion converts the BlockStored event to a tagged union format.
+func (bs LegacyBlockStored) ToTaggedUnion() []any {
+	result := []any{
+		BlockStoredEventTag,
+		bs.BlockHashes,
+		bs.ParentBlockHash,
+		bs.TokenIds,
+		bs.BlockSize,
+		bs.LoraID,
+	}
+
+	return result
+}
+
+func (LegacyBlockStored) isEvent() {}
+
+// LegacyBlockRemoved event.
+type LegacyBlockRemoved struct {
+	_           struct{} `msgpack:",array"`
+	BlockHashes []uint64
+}
+
+func (br LegacyBlockRemoved) ToTaggedUnion() []any {
+	result := []any{
+		BlockRemovedEventTag,
+		br.BlockHashes,
+	}
+
+	return result
+}
+
+func (LegacyBlockRemoved) isEvent() {}

--- a/pkg/kvcache/kvevents/pool.go
+++ b/pkg/kvcache/kvevents/pool.go
@@ -16,6 +16,7 @@ package kvevents
 
 import (
 	"context"
+	"errors"
 	"hash/fnv"
 	"sync"
 
@@ -191,15 +192,26 @@ func (p *Pool) processEvent(ctx context.Context, msg *Message) {
 			debugLogger.Error(nil, "Malformed tagged union, no tag element", "parts", len(taggedUnion))
 			continue
 		}
+
+		var tag string
+		if err := msgpack.Unmarshal(taggedUnion[0], &tag); err != nil {
+			debugLogger.Error(err, "Failed to unmarshal tag from tagged union, skipping event")
+			continue
+		}
+
 		payloadBytes, err := msgpack.Marshal(taggedUnion[1:])
 		if err != nil {
 			debugLogger.Error(err, "Failed to re-marshal payload parts, skipping event")
 			continue
 		}
 
-		var tag string
-		if err := msgpack.Unmarshal(taggedUnion[0], &tag); err != nil {
-			debugLogger.Error(err, "Failed to unmarshal tag from tagged union, skipping event")
+		if isLegacyEvent(tag, len(taggedUnion)-1) {
+			legacyEvent, err := unmarshalLegacyEvent(payloadBytes, tag)
+			if err != nil {
+				debugLogger.Error(err, "Failed to unmarshal legacy event", "tag", tag)
+				continue
+			}
+			events = append(events, legacyEvent)
 			continue
 		}
 
@@ -265,10 +277,60 @@ func (p *Pool) digestEvents(ctx context.Context, podIdentifier, modelName string
 					continue // Continue processing other events even if one fails
 				}
 			}
+		case LegacyBlockStored:
+			keys := utils.SliceMap(ev.BlockHashes, func(hash uint64) kvblock.Key {
+				return kvblock.Key{ModelName: modelName, ChunkHash: hash}
+			})
+
+			if err := p.index.Add(ctx, keys, podEntries); err != nil {
+				debugLogger.Error(err, "Failed to add event to index",
+					"podIdentifier", podIdentifier, "event", ev)
+
+				continue // Continue processing other events even if one fails
+			}
+		case LegacyBlockRemoved:
+			for _, hash := range ev.BlockHashes {
+				key := kvblock.Key{ModelName: modelName, ChunkHash: hash}
+				if err := p.index.Evict(ctx, key, podEntries); err != nil {
+					debugLogger.Error(err, "Failed to remove event from index",
+						"podIdentifier", podIdentifier, "event", ev)
+					continue // Continue processing other events even if one fails
+				}
+			}
 		case AllBlocksCleared:
 			continue
 		default:
 			debugLogger.Info("Unknown event", "podIdentifier", podIdentifier, "event", ev)
 		}
+	}
+}
+
+func isLegacyEvent(tag string, length int) bool {
+	switch tag {
+	case "BlockStored":
+		return length == 5
+	case "BlockRemoved":
+		return length == 2
+	default:
+		return false
+	}
+}
+
+func unmarshalLegacyEvent(data []byte, tag string) (event, error) {
+	switch tag {
+	case "BlockStored":
+		var bs LegacyBlockStored
+		if err := msgpack.Unmarshal(data, &bs); err != nil {
+			return nil, err
+		}
+		return bs, nil
+	case "BlockRemoved":
+		var br LegacyBlockRemoved
+		if err := msgpack.Unmarshal(data, &br); err != nil {
+			return nil, err
+		}
+		return br, nil
+	default:
+		return nil, errors.New("unknown legacy event tag")
 	}
 }


### PR DESCRIPTION
## Summary

In vLLM v0.11.0, KVEvents got a new `medium` field to specify device type (GPU/CPU). This PR updates the schema of events internally, and maintains backwards compatibility through length-based unmarshalling, since `msgpack` does not support optional fields.