### PR TITLE
Align with recent vLLM kv-block hashing changes

### DIFF
--- a/examples/kv_events/offline/main.go
+++ b/examples/kv_events/offline/main.go
@@ -25,6 +25,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/llm-d/llm-d-kv-cache-manager/pkg/utils"
 	"github.com/vmihailenco/msgpack/v5"
 	"k8s.io/klog/v2"
 
@@ -166,7 +167,7 @@ func runEventsDemo(ctx context.Context, kvCacheIndexer *kvcache.Indexer, publish
 	logger.Info("@@@ Simulating vLLM engine publishing BlockStored events...")
 
 	blockStoredEvent := kvevents.BlockStored{
-		BlockHashes:     testdata.PromptHashes,
+		BlockHashes:     utils.SliceMap(testdata.PromptHashes, func(h uint64) any { return h }),
 		ParentBlockHash: nil,
 		TokenIds:        []uint32{1, 2, 3},
 		BlockSize:       256,
@@ -203,7 +204,7 @@ func runEventsDemo(ctx context.Context, kvCacheIndexer *kvcache.Indexer, publish
 	logger.Info("@@@ Simulating vLLM engine removing some blocks...")
 
 	blockRemovedEvent := kvevents.BlockRemoved{
-		BlockHashes: testdata.PromptHashes[2:], // Remove last blocks
+		BlockHashes: []any{testdata.PromptHashes[0], testdata.PromptHashes[1]},
 	}
 
 	//nolint // won't fail

--- a/pkg/kvcache/kvblock/token_processor.go
+++ b/pkg/kvcache/kvblock/token_processor.go
@@ -38,8 +38,8 @@ type TokenProcessorConfig struct {
 	// This should be aligned with vLLM's `PYTHONHASHSEED` environment variable.
 	// The system's deployer is responsible for aligning the vLLM deployments
 	// with the same seed value.
-	HashSeed string  `json:"hashSeed"`
-	initHash *uint64 // cache once
+	HashSeed string `json:"hashSeed"`
+	initHash []byte // cache once
 }
 
 // DefaultTokenProcessorConfig returns the default configuration for the token processor.
@@ -76,8 +76,8 @@ func NewChunkedTokenDatabase(config *TokenProcessorConfig) TokenProcessor {
 	}
 }
 
-// getInitHash returns the root parent hash.
-func (db *ChunkedTokenDatabase) getInitHash() *uint64 {
+// getInitHash returns the root parent hash as a full byte slice.
+func (db *ChunkedTokenDatabase) getInitHash() []byte {
 	if db.initHash != nil {
 		return db.initHash
 	}
@@ -95,36 +95,35 @@ func (db *ChunkedTokenDatabase) getInitHash() *uint64 {
 	}
 
 	sum := sha256.Sum256(b)
-	hashVal := binary.BigEndian.Uint64(sum[24:])
-	db.initHash = &hashVal
+	db.initHash = sum[:] // Return the full 32-byte hash
 	return db.initHash
 }
 
-// hash computes a uint64 hash (lower 64 bits of SHA256).
-// The format, serialization and hashing is aligned with that of vLLM.
-func (db *ChunkedTokenDatabase) hash(parent uint64, tokens []uint32, extra interface{}) uint64 {
+// hash computes the full 32-byte SHA256 hash.
+// The parent hash is now a byte slice.
+func (db *ChunkedTokenDatabase) hash(parent []byte, tokens []uint32, extra interface{}) []byte {
 	payload := []interface{}{parent, tokens, extra}
 
 	encMode, err := cbor.CanonicalEncOptions().EncMode() // deterministic
 	if err != nil {
 		klog.FromContext(context.Background()).Error(err, "failed to create CBOR encoder")
-		return 0
+		return nil
 	}
 
 	b, err := encMode.Marshal(payload)
 	if err != nil {
 		klog.FromContext(context.Background()).Error(err, "failed to marshal payload to CBOR")
-		return 0
+		return nil
 	}
 
 	sum := sha256.Sum256(b)
-	return binary.BigEndian.Uint64(sum[24:])
+	return sum[:] // Return the full 32-byte hash
 }
 
-// prefixHashes returns a slice of uint64 hashes.
-func (db *ChunkedTokenDatabase) prefixHashes(parentHash uint64, tokenChunks [][]uint32) []uint64 {
+// prefixHashes returns a slice of full 32-byte hashes.
+func (db *ChunkedTokenDatabase) prefixHashes(parentHash []byte, tokenChunks [][]uint32) [][]byte {
 	prefix := parentHash
-	hashes := make([]uint64, len(tokenChunks))
+	hashes := make([][]byte, len(tokenChunks))
 	for i, chunk := range tokenChunks {
 		prefix = db.hash(prefix, chunk, nil)
 		hashes[i] = prefix
@@ -149,14 +148,19 @@ func (db *ChunkedTokenDatabase) chunkTokens(tokens []uint32) [][]uint32 {
 
 // TokensToKVBlockKeys converts tokens into kv_block.Keys.
 func (db *ChunkedTokenDatabase) TokensToKVBlockKeys(tokens []uint32, modelName string) []Key {
-	parentPtr := db.getInitHash()
-	if parentPtr == nil {
+	parentBytes := db.getInitHash()
+	if parentBytes == nil {
 		return nil
 	}
 
 	chunks := db.chunkTokens(tokens)
-	ph := db.prefixHashes(*parentPtr, chunks)
-	return utils.SliceMap(ph, func(hashVal uint64) Key {
+	// ph is now a slice of 32-byte hashes
+	ph := db.prefixHashes(parentBytes, chunks)
+
+	// Convert the final byte hashes to uint64 for the Key struct
+	return utils.SliceMap(ph, func(hashBytes []byte) Key {
+		// Truncate to 64 bits at the very end by taking the last 8 bytes
+		hashVal := binary.BigEndian.Uint64(hashBytes[24:])
 		return Key{
 			ModelName: modelName,
 			ChunkHash: hashVal,

--- a/pkg/kvcache/kvblock/token_processor.go
+++ b/pkg/kvcache/kvblock/token_processor.go
@@ -99,8 +99,8 @@ func (db *ChunkedTokenDatabase) getInitHash() []byte {
 	return db.initHash
 }
 
-// hash computes the full 32-byte SHA256 hash.
-// The parent hash is now a byte slice.
+// hash computes the full 32-byte SHA256 hash of the given parent, tokens,
+// and extra keys, mimicking the vLLM implementation.
 func (db *ChunkedTokenDatabase) hash(parent []byte, tokens []uint32, extra interface{}) []byte {
 	payload := []interface{}{parent, tokens, extra}
 
@@ -154,7 +154,6 @@ func (db *ChunkedTokenDatabase) TokensToKVBlockKeys(tokens []uint32, modelName s
 	}
 
 	chunks := db.chunkTokens(tokens)
-	// ph is now a slice of 32-byte hashes
 	ph := db.prefixHashes(parentBytes, chunks)
 
 	// Convert the final byte hashes to uint64 for the Key struct

--- a/pkg/kvcache/kvevents/events.go
+++ b/pkg/kvcache/kvevents/events.go
@@ -43,10 +43,12 @@ type EventBatch struct {
 }
 
 // BlockStored event.
+// The BlockHashes and ParentBlockHash fields are `any` to handle
+// both the legacy uint64 format and the new []byte format from vLLM.
 type BlockStored struct {
 	_               struct{} `msgpack:",array"`
-	BlockHashes     []uint64
-	ParentBlockHash *uint64
+	BlockHashes     []any    // Changed from []uint64
+	ParentBlockHash any      // Changed from *uint64
 	TokenIds        []uint32
 	BlockSize       int
 	LoraID          *int    `msgpack:",omitempty"`
@@ -57,7 +59,7 @@ type BlockStored struct {
 //
 //nolint:gocritic // Keeping the receiver as a value
 func (bs BlockStored) ToTaggedUnion() []any {
-	result := []any{
+	return []any{
 		BlockStoredEventTag,
 		bs.BlockHashes,
 		bs.ParentBlockHash,
@@ -66,26 +68,24 @@ func (bs BlockStored) ToTaggedUnion() []any {
 		bs.LoraID,
 		bs.Medium,
 	}
-
-	return result
 }
 
 func (BlockStored) isEvent() {}
 
 // BlockRemoved event.
+// The BlockHashes field is `any` to handle both uint64 and []byte formats.
 type BlockRemoved struct {
 	_           struct{} `msgpack:",array"`
-	BlockHashes []uint64
+	BlockHashes []any
 	Medium      *string `msgpack:",omitempty"`
 }
 
 func (br BlockRemoved) ToTaggedUnion() []any {
-	result := []any{
+	return []any{
 		BlockRemovedEventTag,
 		br.BlockHashes,
 		br.Medium,
 	}
-	return result
 }
 
 func (BlockRemoved) isEvent() {}
@@ -102,52 +102,3 @@ func (ac AllBlocksCleared) ToTaggedUnion() []any {
 }
 
 func (AllBlocksCleared) isEvent() {}
-
-/*
- The following are legacy event definitions for KV-cache events.
- These definitions are kept and used for backward compatibility.
- This is due to the use of msgpack which relies on the exact structure of the data.
-*/
-
-// LegacyBlockStored event.
-type LegacyBlockStored struct {
-	_               struct{} `msgpack:",array"`
-	BlockHashes     []uint64
-	ParentBlockHash *uint64
-	TokenIds        []uint32
-	BlockSize       int
-	LoraID          *int `msgpack:",omitempty"`
-}
-
-// ToTaggedUnion converts the LegacyBlockStored event to a tagged union format.
-func (bs LegacyBlockStored) ToTaggedUnion() []any {
-	result := []any{
-		BlockStoredEventTag,
-		bs.BlockHashes,
-		bs.ParentBlockHash,
-		bs.TokenIds,
-		bs.BlockSize,
-		bs.LoraID,
-	}
-
-	return result
-}
-
-func (LegacyBlockStored) isEvent() {}
-
-// LegacyBlockRemoved event.
-type LegacyBlockRemoved struct {
-	_           struct{} `msgpack:",array"`
-	BlockHashes []uint64
-}
-
-func (br LegacyBlockRemoved) ToTaggedUnion() []any {
-	result := []any{
-		BlockRemovedEventTag,
-		br.BlockHashes,
-	}
-
-	return result
-}
-
-func (LegacyBlockRemoved) isEvent() {}


### PR DESCRIPTION
## Summary

In a recent [PR](https://github.com/vllm-project/vllm/pull/23673), vLLM's internal kv-block hash management underwent _unintended_ breaking changes that are not backwards compatible. For the coming release, we will sync with the changes, and sooner than later break the hashing dependency in indexing.

## Related Issues
- Fixes #127 