### PR TITLE
Fix: division by zero in metrics logging 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/dgraph-io/ristretto/v2 v2.3.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fxamacker/cbor/v2 v2.7.0
+	github.com/go-logr/logr v1.4.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/pebbe/zmq4 v1.4.0
 	github.com/prometheus/client_golang v1.22.0
@@ -30,7 +31,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect

--- a/pkg/kvcache/metrics/collector.go
+++ b/pkg/kvcache/metrics/collector.go
@@ -118,6 +118,11 @@ func logMetrics(ctx context.Context) {
 	latencyCount := latencyMetric.GetHistogram().GetSampleCount()
 	latencySum := latencyMetric.GetHistogram().GetSampleSum()
 
+	latencyAvg := 0.0
+	if latencyCount > 0 {
+		latencyAvg = latencySum / float64(latencyCount)
+	}
+
 	klog.FromContext(ctx).WithName("metrics").Info("metrics beat",
 		"admissions", admissions,
 		"evictions", evictions,
@@ -125,6 +130,6 @@ func logMetrics(ctx context.Context) {
 		"hits", hits,
 		"latency_count", latencyCount,
 		"latency_sum", latencySum,
-		"latency_avg", latencySum/float64(latencyCount),
+		"latency_avg", latencyAvg,
 	)
 }

--- a/pkg/kvcache/metrics/collector_test.go
+++ b/pkg/kvcache/metrics/collector_test.go
@@ -1,0 +1,97 @@
+// Copyright 2025 The llm-d Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//nolint:testpackage // testing unexported functions
+package metrics
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"k8s.io/klog/v2"
+)
+
+func TestLogMetrics(t *testing.T) {
+	// Set up a buffer to capture log output
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})
+	logrLogger := logr.FromSlogHandler(handler)
+	klog.SetLogger(logrLogger)
+
+	ctx := context.Background()
+
+	t.Run("no_latency", func(t *testing.T) {
+		// Reset buffer
+		buf.Reset()
+
+		// Set test values for metrics
+		Admissions.Inc()       // 1 admission
+		Evictions.Add(2)       // 2 evictions
+		LookupRequests.Add(10) // 10 lookups
+		LookupHits.Add(5)      // 5 hits
+
+		// Call logMetrics
+		logMetrics(ctx)
+
+		// Get the logged output
+		output := buf.String()
+
+		// Verify that the log contains expected key-value pairs
+		expectedParts := []string{
+			"admissions=1",
+			"evictions=2",
+			"lookups=10",
+			"hits=5",
+			"latency_count=0",
+			"latency_sum=0",
+			"latency_avg=0",
+		}
+
+		for _, part := range expectedParts {
+			if !strings.Contains(output, part) {
+				t.Errorf("Expected '%s' in log output, but it was not found. Full output: %s", part, output)
+			}
+		}
+	})
+
+	t.Run("with_latency", func(t *testing.T) {
+		// Reset buffer
+		buf.Reset()
+
+		LookupLatency.Observe(0.1) // Observe latency
+		LookupLatency.Observe(0.2) // Another observation
+
+		logMetrics(ctx)
+		// Get the logged output
+		output := buf.String()
+		// Verify that the log contains expected key-value pairs
+		expectedParts := []string{
+			"latency_count=2",
+			"latency_sum=0.3",
+			"latency_avg=0.15",
+		}
+
+		for _, part := range expectedParts {
+			if !strings.Contains(output, part) {
+				t.Errorf("Expected '%s' in log output, but it was not found. Full output: %s", part, output)
+			}
+		}
+	})
+}


### PR DESCRIPTION
This PR addresses a potential division by zero error in the logMetrics.
Fix: #143 