### PR TITLE
perf(prefixstore): sync.Map are much faster in read-intensive applications

### DIFF
--- a/pkg/tokenization/prefixstore/trie_store.go
+++ b/pkg/tokenization/prefixstore/trie_store.go
@@ -27,7 +27,6 @@ import (
 // A containedTokenTrie is a character-based prefix tree that stores
 // the last token fully contained within the prefix ending at each node.
 type ContainedTokenStore struct {
-	mu    sync.RWMutex
 	tries sync.Map // Key: modelName
 }
 


### PR DESCRIPTION
If you don't like `sync.Map`, using `RWMutex` is a good option as well.