### PR TITLE
fix: rename LookupHits metric to MaxHitsPerPod to better reflect what's tracked

### DIFF
--- a/pkg/kvcache/kvblock/instrumented_index.go
+++ b/pkg/kvcache/kvblock/instrumented_index.go
@@ -83,5 +83,6 @@ func recordHitMetrics(keyToPods map[Key][]string) {
 		}
 	}
 
+	metrics.MaxPodHitCount.Add(float64(maxHit))
 	metrics.LookupHits.Add(float64(maxHit))
 }

--- a/pkg/kvcache/metrics/collector.go
+++ b/pkg/kvcache/metrics/collector.go
@@ -40,6 +40,11 @@ var (
 		Namespace: "kvcache", Subsystem: "index", Name: "lookup_requests_total",
 		Help: "Total number of lookup calls",
 	})
+	// MaxPodHitCount counts the maximum cache hits on a single pod on Lookup().
+	MaxPodHitCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "kvcache", Subsystem: "index", Name: "max_pod_hit_count_total",
+		Help: "Maximum cache hits on a single pod on Lookup()",
+	})
 	// LookupHits counts how many keys were found in the cache on Lookup().
 	LookupHits = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "kvcache", Subsystem: "index", Name: "lookup_hits_total",

--- a/pkg/kvcache/metrics/collector_test.go
+++ b/pkg/kvcache/metrics/collector_test.go
@@ -45,7 +45,7 @@ func TestLogMetrics(t *testing.T) {
 		Admissions.Inc()       // 1 admission
 		Evictions.Add(2)       // 2 evictions
 		LookupRequests.Add(10) // 10 lookups
-		LookupHits.Add(5)      // 5 hits
+		MaxPodHitCount.Add(5)  // 5 hits
 
 		// Call logMetrics
 		logMetrics(ctx)


### PR DESCRIPTION
There's an issue with the way the lookup hit metric is computed. Currently, we compute and keep track of the pod with the maximum cache hits, though according to the [description of the metric](https://github.com/llm-d/llm-d-kv-cache-manager/blob/2f1eed3d36c07d0017a9fe5d05f8c2ae2ea3e39b/pkg/kvcache/metrics/collector.go#L46-L47), we want the number of keys found in the cache on `Lookup()`. 

This PR fixes this 