### PR TITLE
Add @delavet as /services/uds_tokenizer owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,3 +6,4 @@
 
 # Package specific codeowners, including global owners
 /preprocessing @guygir
+/services/uds_tokenizer @delavet


### PR DESCRIPTION
This PR adds @delavet as codeowner over the UDS tokenizer service. Thank you for your contributions! Looking forward to the next.