### PR TITLE
Add @osswangxining as /services/uds_tokenizer owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,5 +6,4 @@
 
 # Package specific codeowners, including global owners
 /preprocessing @guygir
-/services/uds_tokenizer @delavet
-/services/uds_tokenizer @osswangxining
+/services/uds_tokenizer @delavet @osswangxining


### PR DESCRIPTION
This PR adds @osswangxining as codeowner over the UDS tokenizer service. Thank you for your contributions! Looking forward to the next.