### PR TITLE
[Fix] Ensure Correct Logger Usage by Replacing `klog.FromContext` with `log.FromContext`

### DIFF
--- a/examples/helper/events.go
+++ b/examples/helper/events.go
@@ -24,13 +24,13 @@ import (
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/kvcache/kvevents"
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/utils"
 	"github.com/vmihailenco/msgpack/v5"
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const topic = "kv@vllm-pod1@" + testdata.ModelName
 
 func SimulateProduceEvent(ctx context.Context, publisher *Publisher) error {
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	logger.Info("@@@ Simulating vLLM engine publishing BlockStored events...")
 	blockStoredEvent := kvevents.BlockStored{
 		BlockHashes:     utils.SliceMap(testdata.PromptHashes, func(h uint64) any { return h }),
@@ -65,7 +65,7 @@ func SimulateProduceEvent(ctx context.Context, publisher *Publisher) error {
 }
 
 func SimulateRemoveEvent(ctx context.Context, publisher *Publisher) error {
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	logger.Info("@@@ Simulating vLLM engine removing some blocks...")
 	blockRemovedEvent := kvevents.BlockRemoved{
 		BlockHashes: []any{testdata.PromptHashes[2], testdata.PromptHashes[3]},
@@ -92,7 +92,7 @@ func SimulateRemoveEvent(ctx context.Context, publisher *Publisher) error {
 }
 
 func SetupEventsPool(ctx context.Context, kvBlockIndex kvblock.Index) *kvevents.Pool {
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	cfg := kvevents.DefaultConfig()
 

--- a/examples/helper/indexer.go
+++ b/examples/helper/indexer.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/llm-d/llm-d-kv-cache-manager/examples/testdata"
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/kvcache"
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -44,7 +44,7 @@ func getKVCacheIndexerConfig() (*kvcache.Config, error) {
 }
 
 func SetupKVCacheIndexer(ctx context.Context) (*kvcache.Indexer, error) {
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	cfg, err := getKVCacheIndexerConfig()
 	if err != nil {

--- a/examples/helper/publisher.go
+++ b/examples/helper/publisher.go
@@ -25,7 +25,7 @@ import (
 
 	zmq "github.com/pebbe/zmq4"
 	"github.com/vmihailenco/msgpack/v5"
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // Publisher sends KV cache events to a ZMQ endpoint.
@@ -57,7 +57,7 @@ func NewPublisher(endpoint string) (*Publisher, error) {
 // PublishEvent publishes a KV cache event batch to the ZMQ topic.
 // topic should include the pod identifier (e.g., "kv.pod1").
 func (p *Publisher) PublishEvent(ctx context.Context, topic string, batch interface{}) error {
-	logger := klog.FromContext(ctx).V(0)
+	logger := log.FromContext(ctx).V(0)
 
 	// Use an encoder configured for struct as array
 	var payload bytes.Buffer
@@ -91,7 +91,7 @@ func (p *Publisher) Close() error {
 }
 
 func SetupPublisher(ctx context.Context) (*Publisher, error) {
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	endpoint := "tcp://localhost:5557"
 	logger.Info("Creating ZMQ publisher (simulating vLLM engines)", "endpoint", endpoint)

--- a/examples/kv_cache_index/main.go
+++ b/examples/kv_cache_index/main.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/utils"
 	"github.com/redis/go-redis/v9"
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/llm-d/llm-d-kv-cache-manager/examples/testdata"
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/kvcache"
@@ -75,7 +75,7 @@ func getModelName() string {
 
 func main() {
 	ctx := context.Background()
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	kvCacheIndexer, err := setupKVCacheIndexer(ctx)
 	if err != nil {
@@ -90,7 +90,7 @@ func main() {
 }
 
 func setupKVCacheIndexer(ctx context.Context) (*kvcache.Indexer, error) {
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	config, err := getKVCacheIndexerConfig()
 	if err != nil {
@@ -114,7 +114,7 @@ func setupKVCacheIndexer(ctx context.Context) (*kvcache.Indexer, error) {
 }
 
 func runPrompts(ctx context.Context, kvCacheIndexer *kvcache.Indexer) error {
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	modelName := getModelName()
 	logger.Info("Started Indexer", "model", modelName)

--- a/examples/kv_cache_index_service/server/main.go
+++ b/examples/kv_cache_index_service/server/main.go
@@ -22,7 +22,7 @@ import (
 	"github.com/llm-d/llm-d-kv-cache-manager/examples/helper"
 	"github.com/llm-d/llm-d-kv-cache-manager/examples/testdata"
 	"google.golang.org/grpc"
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	indexerpb "github.com/llm-d/llm-d-kv-cache-manager/api"
 )
@@ -33,7 +33,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	logger.Info("Starting KV cache index service Example")
 
 	lc := &net.ListenConfig{}
@@ -77,7 +77,7 @@ func main() {
 }
 
 func setupIndexerService(ctx context.Context) (*IndexerService, error) {
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	indexer, err := helper.SetupKVCacheIndexer(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create indexer: %w", err)

--- a/examples/kv_events/offline/main.go
+++ b/examples/kv_events/offline/main.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/llm-d/llm-d-kv-cache-manager/examples/helper"
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/llm-d/llm-d-kv-cache-manager/examples/testdata"
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/kvcache"
@@ -55,7 +55,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	logger.Info("Starting KV Events Pool Example")
 
 	kvCacheIndexer, err := setupKVCacheIndexer(ctx)
@@ -106,7 +106,7 @@ func main() {
 }
 
 func setupKVCacheIndexer(ctx context.Context) (*kvcache.Indexer, error) {
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	cfg, err := getKVCacheIndexerConfig()
 	if err != nil {
@@ -127,7 +127,7 @@ func setupKVCacheIndexer(ctx context.Context) (*kvcache.Indexer, error) {
 }
 
 func RunEventsDemo(ctx context.Context, kvCacheIndexer *kvcache.Indexer, publisher *helper.Publisher) error {
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	logger.Info("@@@ Starting KV Events Demo", "model", testdata.ModelName)
 

--- a/examples/kv_events/online/main.go
+++ b/examples/kv_events/online/main.go
@@ -28,13 +28,12 @@ import (
 	"syscall"
 	"time"
 
-	"k8s.io/klog/v2"
-
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/kvcache"
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/kvcache/kvblock"
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/kvcache/kvevents"
 	preprocessing "github.com/llm-d/llm-d-kv-cache-manager/pkg/preprocessing/chat_completions"
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/tokenization"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -66,7 +65,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Setup graceful shutdown
 	sigChan := make(chan os.Signal, 1)
@@ -84,7 +83,7 @@ func main() {
 }
 
 func run(ctx context.Context) error {
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Setup Python path environment for chat completions
 	logger.Info("Setting up Python path environment...")
@@ -140,7 +139,7 @@ func run(ctx context.Context) error {
 }
 
 func setupPythonPath(ctx context.Context) error {
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Check if PYTHONPATH is already set
 	pythonPath := os.Getenv("PYTHONPATH")
@@ -221,7 +220,7 @@ func getEventsPoolConfig() *kvevents.Config {
 }
 
 func setupKVCacheIndexer(ctx context.Context) (*kvcache.Indexer, error) {
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	cfg, err := getKVCacheIndexerConfig()
 	if err != nil {
@@ -242,7 +241,7 @@ func setupKVCacheIndexer(ctx context.Context) (*kvcache.Indexer, error) {
 }
 
 func setupEventsPool(ctx context.Context, kvBlockIndex kvblock.Index) *kvevents.Pool {
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	cfg := getEventsPoolConfig()
 
@@ -257,7 +256,7 @@ func setupUnifiedHTTPEndpoints(
 	kvCacheIndexer *kvcache.Indexer,
 	chatTemplatingProcessor *preprocessing.ChatTemplatingProcessor,
 ) *http.Server {
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	mux := http.NewServeMux()
 

--- a/examples/valkey_example/main.go
+++ b/examples/valkey_example/main.go
@@ -26,7 +26,7 @@ import (
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/kvcache"
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/kvcache/kvblock"
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/utils"
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -37,7 +37,7 @@ const (
 
 func main() {
 	ctx := context.Background()
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Create KV-Cache Manager configuration with Valkey backend
 	config, err := createValkeyConfig()
@@ -109,7 +109,7 @@ func createValkeyConfig() (*kvcache.Config, error) {
 }
 
 func demonstrateValkeyOperations(ctx context.Context, indexer *kvcache.Indexer) error {
-	logger := klog.FromContext(ctx).WithName("valkey-demo")
+	logger := log.FromContext(ctx).WithName("valkey-demo")
 
 	modelName := testdata.ModelName
 	prompt := testdata.Prompt

--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/kvcache/kvblock"
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/tokenization"
@@ -72,7 +72,7 @@ type Indexer struct {
 
 // NewKVCacheIndexer creates a KVCacheIndex given a Config.
 func NewKVCacheIndexer(ctx context.Context, config *Config) (*Indexer, error) {
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	if config != nil && config.TokenProcessorConfig != nil {
 		logger.Info("NewKVCacheIndexer config", "blockSize", config.TokenProcessorConfig.BlockSize)
 	}
@@ -131,7 +131,7 @@ func (k *Indexer) KVBlockIndex() kvblock.Index {
 func (k *Indexer) GetPodScores(ctx context.Context, prompt, modelName string,
 	podIdentifiers []string,
 ) (map[string]float64, error) {
-	traceLogger := klog.FromContext(ctx).V(logging.TRACE).WithName("kvcache.GetPodScores")
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvcache.GetPodScores")
 
 	// 1. tokenize prompt
 	tokens := k.tokenizersPool.Tokenize(prompt, modelName)

--- a/pkg/kvcache/kvblock/cost_aware_memory.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/dgraph-io/ristretto/v2"
 	"github.com/dustin/go-humanize"
@@ -153,7 +153,7 @@ func (m *CostAwareMemoryIndex) Add(ctx context.Context, keys []Key, entries []Po
 		return fmt.Errorf("no keys or entries provided for adding to index")
 	}
 
-	traceLogger := klog.FromContext(ctx).V(logging.TRACE).WithName("kvblock.CostAwareMemoryIndex.Add")
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.CostAwareMemoryIndex.Add")
 
 	for _, key := range keys {
 		keyStr := key.String()
@@ -185,7 +185,7 @@ func (m *CostAwareMemoryIndex) Lookup(ctx context.Context, keys []Key,
 		return nil, fmt.Errorf("no keys provided for lookup")
 	}
 
-	traceLogger := klog.FromContext(ctx).V(logging.TRACE).WithName("kvblock.CostAwareMemoryIndex.Lookup")
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.CostAwareMemoryIndex.Lookup")
 
 	podsPerKey := make(map[Key][]PodEntry)
 	highestHitIdx := 0
@@ -239,7 +239,7 @@ func (m *CostAwareMemoryIndex) Evict(ctx context.Context, key Key, entries []Pod
 		return fmt.Errorf("no entries provided for eviction from index")
 	}
 
-	traceLogger := klog.FromContext(ctx).V(logging.TRACE).WithName("kvblock.CostAwareMemoryIndex.Evict")
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.CostAwareMemoryIndex.Evict")
 	keyStr := key.String()
 	podCache, found := m.data.Get(keyStr)
 	if !found || podCache == nil {

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -23,7 +23,7 @@ import (
 
 	lru "github.com/hashicorp/golang-lru/v2"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/utils"
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/utils/logging"
@@ -101,7 +101,7 @@ func (m *InMemoryIndex) Lookup(ctx context.Context, keys []Key,
 		return nil, fmt.Errorf("no keys provided for lookup")
 	}
 
-	traceLogger := klog.FromContext(ctx).V(logging.TRACE).WithName("kvblock.InMemoryIndex.Lookup")
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.InMemoryIndex.Lookup")
 
 	podsPerKey := make(map[Key][]PodEntry)
 	highestHitIdx := 0
@@ -143,7 +143,7 @@ func (m *InMemoryIndex) Add(ctx context.Context, keys []Key, entries []PodEntry)
 		return fmt.Errorf("no keys or entries provided for adding to index")
 	}
 
-	traceLogger := klog.FromContext(ctx).V(logging.TRACE).WithName("kvblock.InMemoryIndex.Add")
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.InMemoryIndex.Add")
 
 	for _, key := range keys {
 		var podCache *PodCache
@@ -197,7 +197,7 @@ func (m *InMemoryIndex) Evict(ctx context.Context, key Key, entries []PodEntry) 
 		return fmt.Errorf("no entries provided for eviction from index")
 	}
 
-	traceLogger := klog.FromContext(ctx).V(logging.TRACE).WithName("kvblock.InMemoryIndex.Evict")
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.InMemoryIndex.Evict")
 
 	podCache, found := m.data.Get(key)
 	if !found || podCache == nil {

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/redis/go-redis/v9"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // RedisIndexConfig holds the configuration for the RedisIndex.
@@ -158,7 +158,7 @@ func (r *RedisIndex) Lookup(ctx context.Context, keys []Key,
 		return make(map[Key][]PodEntry), nil
 	}
 
-	logger := klog.FromContext(ctx).WithName("kvblock.RedisIndex.Lookup")
+	logger := log.FromContext(ctx).WithName("kvblock.RedisIndex.Lookup")
 	podsPerKey := make(map[Key][]PodEntry)
 
 	// pipeline for single RTT

--- a/pkg/kvcache/kvblock/token_processor.go
+++ b/pkg/kvcache/kvblock/token_processor.go
@@ -22,7 +22,7 @@ import (
 	"encoding/binary"
 
 	"github.com/fxamacker/cbor/v2"
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/utils"
 )
@@ -84,13 +84,13 @@ func (db *ChunkedTokenDatabase) getInitHash() []byte {
 
 	encMode, err := cbor.CanonicalEncOptions().EncMode() // deterministic
 	if err != nil {
-		klog.FromContext(context.Background()).Error(err, "failed to create CBOR encoder")
+		log.FromContext(context.Background()).Error(err, "failed to create CBOR encoder")
 		return nil
 	}
 
 	b, err := encMode.Marshal(db.HashSeed)
 	if err != nil {
-		klog.FromContext(context.Background()).Error(err, "failed to marshal payload to CBOR")
+		log.FromContext(context.Background()).Error(err, "failed to marshal payload to CBOR")
 		return nil
 	}
 
@@ -106,13 +106,13 @@ func (db *ChunkedTokenDatabase) hash(parent []byte, tokens []uint32, extra inter
 
 	encMode, err := cbor.CanonicalEncOptions().EncMode() // deterministic
 	if err != nil {
-		klog.FromContext(context.Background()).Error(err, "failed to create CBOR encoder")
+		log.FromContext(context.Background()).Error(err, "failed to create CBOR encoder")
 		return nil
 	}
 
 	b, err := encMode.Marshal(payload)
 	if err != nil {
-		klog.FromContext(context.Background()).Error(err, "failed to marshal payload to CBOR")
+		log.FromContext(context.Background()).Error(err, "failed to marshal payload to CBOR")
 		return nil
 	}
 

--- a/pkg/kvcache/kvevents/pool.go
+++ b/pkg/kvcache/kvevents/pool.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/vmihailenco/msgpack/v5"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/kvcache/kvblock"
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/utils/logging"
@@ -98,7 +98,7 @@ func NewPool(cfg *Config, index kvblock.Index) *Pool {
 // Start begins the worker pool and the ZMQ subscriber.
 // It is non-blocking.
 func (p *Pool) Start(ctx context.Context) {
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	logger.Info("Starting sharded event processing pool", "workers", p.concurrency)
 
 	p.wg.Add(p.concurrency)
@@ -112,7 +112,7 @@ func (p *Pool) Start(ctx context.Context) {
 
 // Shutdown gracefully stops the pool and its subscriber.
 func (p *Pool) Shutdown(ctx context.Context) {
-	logger := klog.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	logger.Info("Shutting down event processing pool...")
 
 	for _, queue := range p.queues {
@@ -172,7 +172,7 @@ func (p *Pool) worker(ctx context.Context, workerIndex int) {
 // processEvent deserializes the message payload and calls the appropriate
 // index method based on the event type. It returns an error to trigger retries.
 func (p *Pool) processEvent(ctx context.Context, msg *Message) {
-	debugLogger := klog.FromContext(ctx).V(logging.DEBUG)
+	debugLogger := log.FromContext(ctx).V(logging.DEBUG)
 	debugLogger.Info("Processing event", "topic", msg.Topic, "seq", msg.Seq)
 
 	var eventBatch EventBatch
@@ -243,7 +243,7 @@ func (p *Pool) processEvent(ctx context.Context, msg *Message) {
 func (p *Pool) digestEvents(ctx context.Context, podIdentifier, modelName string,
 	events []event,
 ) {
-	debugLogger := klog.FromContext(ctx).V(logging.DEBUG)
+	debugLogger := log.FromContext(ctx).V(logging.DEBUG)
 	debugLogger.Info("Digesting events", "count", len(events))
 
 	// Process each event in the batch

--- a/pkg/kvcache/kvevents/zmq_subscriber.go
+++ b/pkg/kvcache/kvevents/zmq_subscriber.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	zmq "github.com/pebbe/zmq4"
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/utils/logging"
 )
@@ -53,7 +53,7 @@ func newZMQSubscriber(pool *Pool, endpoint, topicFilter string) *zmqSubscriber {
 // wraps them in Message structs, and pushes them into the pool.
 // This loop will run until the provided context is canceled.
 func (z *zmqSubscriber) Start(ctx context.Context) {
-	logger := klog.FromContext(ctx).WithName("zmq-subscriber")
+	logger := log.FromContext(ctx).WithName("zmq-subscriber")
 
 	for {
 		select {
@@ -79,7 +79,7 @@ func (z *zmqSubscriber) Start(ctx context.Context) {
 // runSubscriber connects to the ZMQ PUB socket, subscribes to the topic filter,
 // and listens for messages.
 func (z *zmqSubscriber) runSubscriber(ctx context.Context) {
-	logger := klog.FromContext(ctx).WithName("zmq-subscriber")
+	logger := log.FromContext(ctx).WithName("zmq-subscriber")
 	sub, err := zmq.NewSocket(zmq.SUB)
 	if err != nil {
 		logger.Error(err, "Failed to create subscriber socket")

--- a/pkg/kvcache/metrics/collector.go
+++ b/pkg/kvcache/metrics/collector.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
@@ -128,7 +128,7 @@ func logMetrics(ctx context.Context) {
 		latencyAvg = latencySum / float64(latencyCount)
 	}
 
-	klog.FromContext(ctx).WithName("metrics").Info("metrics beat",
+	log.FromContext(ctx).WithName("metrics").Info("metrics beat",
 		"admissions", admissions,
 		"evictions", evictions,
 		"lookups", lookups,

--- a/pkg/preprocessing/chat_completions/cgo_functions.go
+++ b/pkg/preprocessing/chat_completions/cgo_functions.go
@@ -28,9 +28,8 @@ import (
 	*/
 	"C"
 
-	"k8s.io/klog/v2"
-
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/utils/logging"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // ChatMessage represents a single message in a conversation.
@@ -120,7 +119,7 @@ func (w *ChatTemplatingProcessor) Finalize() {
 func (w *ChatTemplatingProcessor) RenderChatTemplate(ctx context.Context,
 	req *RenderJinjaTemplateRequest,
 ) (*RenderJinjaTemplateResponse, error) {
-	traceLogger := klog.FromContext(ctx).V(logging.TRACE).WithName("RenderChatTemplate")
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("RenderChatTemplate")
 	if req == nil {
 		traceLogger.Error(nil, "Received nil request")
 		return nil, fmt.Errorf("received nil request")
@@ -158,7 +157,7 @@ func (w *ChatTemplatingProcessor) FetchChatTemplate(
 	ctx context.Context,
 	req FetchChatTemplateRequest,
 ) (string, map[string]interface{}, error) {
-	traceLogger := klog.FromContext(ctx).V(logging.TRACE).WithName("FetchChatTemplate")
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("FetchChatTemplate")
 
 	// Convert request to JSON
 	reqJSON, err := json.Marshal(req)
@@ -187,7 +186,7 @@ func (w *ChatTemplatingProcessor) FetchChatTemplate(
 
 // ClearCaches clears all caches for testing purposes.
 func ClearCaches(ctx context.Context) error {
-	traceLogger := klog.FromContext(ctx).V(logging.TRACE).WithName("clearCaches")
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("clearCaches")
 
 	// Call the C function
 	cResult := C.Py_ClearCaches()


### PR DESCRIPTION
## Summary

This PR resolves an issue where the globally configured logger was ignored during execution by replacing calls to **`klog.FromContext(ctx)`** with **`log.FromContext(ctx)`**. This ensures the system retrieves the intended logger instance.

**Context/Discussion:**
For background and detailed discussion on this issue, please see the following [Slack thread](https://llm-d.slack.com/archives/C09QG40A3GW/p1763343954427709)

---

## Motivation & Problem

The current setup suffers from a mismatch between logger configuration and logger retrieval:

1. The runner sets the intended logger globally via **`ctrl.SetLogger(logger)`**.
2. Some components retrieve the logger via **`klog.FromContext(ctx)`**.

Because `klog.FromContext(ctx)` relies heavily on the logger being explicitly bound to the context (via `logr.FromContext`), the globally configured logger is often **ignored** when the context is not explicitly set, leading to the usage of a default/unconfigured logger instance.

## Detailed Changes

* **Change:** All occurrences of **`klog.FromContext(ctx)`** have been replaced with **`log.FromContext(ctx)`**.
* **Rationale:** The `log.FromContext(ctx)` ensuring that the globally configured root logger (set by `ctrl.SetLogger`) is correctly used when a contextual logger is not explicitly found.

## Expected Impact

* The intended logger configuration (set by `ctrl.SetLogger`) will be correctly utilized across all affected components.