### PR TITLE
add metrics for tokenizaion and rendering chat template

### DIFF
--- a/pkg/kvcache/metrics/collector.go
+++ b/pkg/kvcache/metrics/collector.go
@@ -56,6 +56,22 @@ var (
 		Help:    "Latency of Lookup calls in seconds",
 		Buckets: prometheus.DefBuckets,
 	})
+
+	RenderChatTemplateLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "kvcache", Subsystem: "tokenization", Name: "render_chat_template_latency_seconds",
+		Help:    "Latency of RenderChatTemplate calls in seconds",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"tokenizer"})
+	TokenizationLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "kvcache", Subsystem: "tokenization", Name: "tokenization_latency_seconds",
+		Help:    "Latency of Tokenization calls in seconds",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"tokenizer"})
+	TokenizedTokensCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "kvcache", Subsystem: "tokenization", Name: "tokenized_tokens_total",
+			Help: "Number of tokens tokenized",
+		}, []string{"tokenizer"})
 )
 
 // Collectors returns a slice of all registered Prometheus collectors.
@@ -63,6 +79,7 @@ func Collectors() []prometheus.Collector {
 	return []prometheus.Collector{
 		Admissions, Evictions,
 		LookupRequests, LookupHits, LookupLatency,
+		RenderChatTemplateLatency, TokenizationLatency, TokenizedTokensCount,
 	}
 }
 

--- a/pkg/tokenization/pool_test.go
+++ b/pkg/tokenization/pool_test.go
@@ -62,6 +62,10 @@ func (m *MockTokenizer) Encode(input, modelName string) ([]uint32, []tokenizers.
 	return args.Get(0).([]uint32), args.Get(1).([]tokenizers.Offset), args.Error(2) //nolint:errcheck // return mocked values
 }
 
+func (m *MockTokenizer) Type() string {
+	return "mock"
+}
+
 // MockIndexer implements the prefixstore.Indexer interface for testing.
 type MockIndexer struct {
 	mock.Mock

--- a/pkg/tokenization/uds_tokenizer.go
+++ b/pkg/tokenization/uds_tokenizer.go
@@ -177,6 +177,10 @@ func (u *UdsTokenizer) RenderChatTemplate(
 	return string(body), nil
 }
 
+func (u *UdsTokenizer) Type() string {
+	return "external-uds"
+}
+
 // executeRequest executes an HTTP request with timeout and retry logic.
 func (u *UdsTokenizer) executeRequest(req *http.Request,
 	timeout time.Duration, maxRetries int,


### PR DESCRIPTION
This PR, as part of #155, introduces corresponding observable metrics for the `Encode` call (tokenization) and `RenderChatTemplate` call of the tokenizers.
Additionally, considering the current situation where we have multiple implementations of tokenizers and use a `CompositeTokenizer` to manage them, it is important to observe differences between these implementations using metrics.
This PR also introduces a metrics server for the online example, allowing us to first measure the performance of the `llm-d-kv-cache-manager` module independently through the online example itself, isolating it from the rest of the EPP.