### PR TITLE
cleanup: remove redundant warnings from make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ run: build ## Run the application locally
 build: check-go download-tokenizer install-python-deps download-zmq ## Build the application binary
 	@printf "\033[33;1m==== Building application binary ====\033[0m\n"
 	@go build -o bin/$(PROJECT_NAME) examples/kv_events/online/main.go
-
+	@echo "✅ Built examples/kv_events/online/main.go -> bin/$(PROJECT_NAME)"
 
 .PHONY:	image-build
 image-build: check-container-tool load-version-json ## Build Docker image

--- a/pkg/preprocessing/chat_completions/cgo_functions.c
+++ b/pkg/preprocessing/chat_completions/cgo_functions.c
@@ -71,7 +71,10 @@ int Py_InitializeGo() {
         Py_Initialize();
 
         // Initialize threading support BEFORE any other operations
+        // PyEval_InitThreads is deprecated in Python 3.9+, only call for older versions
+#if PY_VERSION_HEX < 0x03090000
         PyEval_InitThreads();
+#endif
 
         // Release the GIL so other threads can acquire it
         PyEval_ReleaseThread(PyThreadState_Get());

--- a/pkg/preprocessing/chat_completions/cgo_functions.go
+++ b/pkg/preprocessing/chat_completions/cgo_functions.go
@@ -24,6 +24,7 @@ import (
 	"unsafe"
 
 	/*
+		#cgo CFLAGS: -Wno-unused-variable
 		#include "cgo_functions.h"
 	*/
 	"C"


### PR DESCRIPTION
Remove unnecessary or misleading warnings emitted during make build. These changes reduce build log noise and prevent false positives in CI and code review.

Beforce Change (The warnings appear concerning but are actually harmless ):
```
==== Building application binary ====
# github.com/llm-d/llm-d-kv-cache/pkg/preprocessing/chat_completions
cgo-gcc-prolog: In function ‘_cgo_367a76e2eb4a_Cfunc_Py_CleanupChatTemplateModule’:
cgo-gcc-prolog:85:49: warning: unused variable ‘_cgo_a’ [-Wunused-variable]
cgo-gcc-prolog: In function ‘_cgo_367a76e2eb4a_Cfunc_Py_FinalizeGo’:
cgo-gcc-prolog:114:49: warning: unused variable ‘_cgo_a’ [-Wunused-variable]
# github.com/llm-d/llm-d-kv-cache/pkg/preprocessing/chat_completions
cgo_functions.c: In function ‘Py_InitializeGo’:
cgo_functions.c:74:9: warning: ‘PyEval_InitThreads’ is deprecated [-Wdeprecated-declarations]
   74 |         PyEval_InitThreads();
      |         ^~~~~~~~~~~~~~~~~~
In file included from /usr/include/python3.12/Python.h:95,
                 from cgo_functions.h:20,
                 from cgo_functions.c:19:
/usr/include/python3.12/ceval.h:132:37: note: declared here
  132 | Py_DEPRECATED(3.9) PyAPI_FUNC(void) PyEval_InitThreads(void);
      |                                     ^~~~~~~~~~~~~~~~~~
```

After Cleanup
```
(llm-d-kv-cache) root@gpu-3090:~/oss/llm-d-kv-cache# make build
==== Building application binary ====
✅ Built examples/kv_events/online/main.go -> bin/llm-d-kv-cache-manager
```