### PR TITLE
[CI] Add CI workflow to run and verify examples

### DIFF
--- a/.github/workflows/ci-examples.yaml
+++ b/.github/workflows/ci-examples.yaml
@@ -1,0 +1,53 @@
+name: Run Examples Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  run-examples:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache system (apt) dependencies
+        uses: actions/cache@v4
+        with:
+          path: /var/cache/apt/archives
+          key: ${{ runner.os }}-apt-${{ hashFiles('**/.github/workflows/ci-pr-checks.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-apt-
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo add-apt-repository ppa:deadsnakes/ppa -y
+          sudo apt-get install -y libzmq3-dev pkg-config python3.12 python3.12-dev python3.12-venv clang-format
+
+      - name: Extract Go version from go.mod
+        run: sed -En 's/^go (.*)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
+
+      - name: Set up Go with cache
+        uses: actions/setup-go@v5
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+          cache-dependency-path: ./go.sum
+
+      # This step is still useful to verify the Python config before subsequent steps
+      - name: Run detect-python
+        run: make detect-python
+
+      - name: Cache Python (pip) dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          # This key is based ONLY on the requirements file
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+
+      - name: Make verify-examples.sh executable
+        run: chmod +x hack/verify-examples.sh
+
+      - name: Run verify-examples.sh
+        run: ./hack/verify-examples.sh

--- a/docs/deployment/v0.1.0/setup.md
+++ b/docs/deployment/v0.1.0/setup.md
@@ -93,12 +93,6 @@ Ensure you have a running deployment with vLLM and Redis as described above.
 
 The vLLM node can be tested with the prompt found in `examples/kv_cache_index/main.go`.
 
-First, download the tokenizer bindings required by the `kvcache.Indexer` for prompt tokenization:
-
-```bash
-make download-tokenizer
-```
-
 Then, set the required environment variables and run example:
 
 ```bash
@@ -106,7 +100,7 @@ export HF_TOKEN=<token>
 export REDIS_ADDR=<redis://$user:$pass@localhost:6379/$db> # optional, defaults to localhost:6379
 export MODEL_NAME=<model_name_used_in_vllm_deployment> # optional, defaults to meta-llama/Llama-3.1-8B-Instruct
 
-go run -ldflags="-extldflags '-L$(pwd)/lib'" examples/kv_cache_index/main.go
+make run-example kv_cache_index
 ```
 
 Environment variables:

--- a/examples/helper/indexer.go
+++ b/examples/helper/indexer.go
@@ -39,7 +39,7 @@ func getKVCacheIndexerConfig() (*kvcache.Config, error) {
 	}
 
 	config.TokenProcessorConfig.BlockSize = 256
-
+	config.TokenizersPoolConfig.ModelName = testdata.ModelName
 	return config, nil
 }
 

--- a/examples/kv_cache_index/README.md
+++ b/examples/kv_cache_index/README.md
@@ -20,7 +20,7 @@ This example demonstrates how to configure and use the `kvcache.Indexer` module 
 2. **Run the example:**
 
 ```sh
-go run -ldflags="-extldflags '-L$(pwd)/lib'" examples/kv_cache_index/main.go
+make run-example kv_cache_index
 ```
 
 3. **What to expect:**

--- a/examples/kv_cache_index/main.go
+++ b/examples/kv_cache_index/main.go
@@ -102,6 +102,7 @@ func setupKVCacheIndexer(ctx context.Context) (*kvcache.Indexer, error) {
 	}
 
 	config.TokenProcessorConfig.BlockSize = 256
+	config.TokenizersPoolConfig.ModelName = testdata.ModelName
 
 	kvCacheIndexer, err := kvcache.NewKVCacheIndexer(ctx, config)
 	if err != nil {

--- a/examples/kv_events/README.md
+++ b/examples/kv_events/README.md
@@ -11,14 +11,9 @@ Set the following environment variables:
 export HF_TOKEN="your-huggingface-token"
 ```
 
-Download tokenizer bindings:
-```bash
-make download-tokenizer
-```
-
 ### Running the Example
 ```
-go run -ldflags="-extldflags '-L$(pwd)/lib'" examples/kv_events/offline/main.go
+make run-example offline
 ```
 
 The example will start the KV-Cache indexer and a dummy publisher that simulates KV-Events. 

--- a/examples/kv_events/offline/main.go
+++ b/examples/kv_events/offline/main.go
@@ -48,6 +48,7 @@ func getKVCacheIndexerConfig() (*kvcache.Config, error) {
 	}
 
 	config.TokenProcessorConfig.BlockSize = 256
+	config.TokenizersPoolConfig.ModelName = testdata.ModelName
 
 	return config, nil
 }

--- a/examples/kv_events/online/main.go
+++ b/examples/kv_events/online/main.go
@@ -28,6 +28,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/llm-d/llm-d-kv-cache/examples/testdata"
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache"
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvevents"
@@ -186,9 +187,11 @@ func getKVCacheIndexerConfig() (*kvcache.Config, error) {
 	}
 
 	blockSize, err := strconv.Atoi(os.Getenv(blockSizeEnvVar))
+
 	if err == nil && blockSize >= 0 {
 		config.TokenProcessorConfig.BlockSize = blockSize
 	}
+	config.TokenizersPoolConfig.ModelName = testdata.ModelName
 
 	useExternalTokenization, err := strconv.ParseBool(os.Getenv(envExternalTokenization))
 	if err == nil && useExternalTokenization {

--- a/examples/valkey_example/README.md
+++ b/examples/valkey_example/README.md
@@ -37,10 +37,10 @@ Valkey is a community-forked version of Redis that remains under the original BS
 
 ```bash
 # Run with default Valkey configuration
-go run main.go
+make run-example valkey
 
 # Run with custom Valkey address
-VALKEY_ADDR="valkey://your-valkey-server:6379" go run main.go
+VALKEY_ADDR="valkey://your-valkey-server:6379" make run-example valkey
 ```
 
 ### With RDMA Support
@@ -51,7 +51,7 @@ VALKEY_ADDR="valkey://your-valkey-server:6379" go run main.go
 # This will run but RDMA will not be active (falls back to TCP)
 VALKEY_ADDR="valkey://rdma-valkey-server:6379" \
 VALKEY_ENABLE_RDMA="true" \
-go run main.go
+make run-example valkey
 ```
 
 ### Environment Variables

--- a/examples/valkey_example/main.go
+++ b/examples/valkey_example/main.go
@@ -108,7 +108,7 @@ func createValkeyConfig() (*kvcache.Config, error) {
 
 	// Set a reasonable block size for demonstration
 	config.TokenProcessorConfig.BlockSize = 128
-
+	config.TokenizersPoolConfig.ModelName = testdata.ModelName
 	return config, nil
 }
 

--- a/hack/verify-examples.sh
+++ b/hack/verify-examples.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# verify-examples.sh: Verify example builds and basic runtime checks for examples.
+set -euo pipefail
+
+fail() {
+  echo "[FAIL] $1" >&2
+  exit 1
+}
+
+# 1. Test build
+if ! make build-examples; then
+  fail "make build-examples failed."
+fi
+
+echo "[OK] build-examples succeeded."
+
+# 2. Test offline example
+(
+  set -m
+  echo "[INFO] Running offline example..."
+  timeout 30s make run-example offline >offline.log 2>&1 &
+  pid=$!
+  found=0
+  for i in {1..30}; do
+    if grep -q 'Events demo completed.' offline.log; then
+      found=1
+      break
+    fi
+    sleep 1
+  done
+  if [ $found -eq 1 ]; then
+    echo "[OK] offline example completed."
+    kill -INT $pid || true
+    wait $pid || true
+  else
+    kill -INT $pid || true
+    wait $pid || true
+    cat offline.log
+    fail "offline example did not complete successfully."
+  fi
+)
+
+# 3. Test online example
+(
+  set -m
+  echo "[INFO] Running online example..."
+  timeout 30s make run-example online >online.log 2>&1 &
+  pid=$!
+  found=0
+  for i in {1..30}; do
+    if grep -q '8080' online.log; then
+      found=1
+      break
+    fi
+    sleep 1
+  done
+  if [ $found -eq 1 ]; then
+    echo "[OK] online example is listening on 8080."
+    kill -INT $pid || true
+    wait $pid || true
+  else
+    # Try checking if port 8080 is open (Linux/macOS)
+    if command -v lsof >/dev/null && lsof -i:8080 | grep LISTEN; then
+      echo "[OK] online example is listening on 8080 (lsof check)."
+      kill -INT $pid || true
+      wait $pid || true
+    else
+      kill -INT $pid || true
+      wait $pid || true
+      cat online.log
+      fail "online example did not listen on 8080."
+    fi
+  fi
+)
+
+# 4. Test kv_cache_index example
+(
+  set -m
+  echo "[INFO] Running kv_cache_index example..."
+  if make run-example kv_cache_index >kv_cache_index.log 2>&1; then
+    echo "[OK] kv_cache_index example completed."
+  else
+    cat kv_cache_index.log
+    fail "kv_cache_index example did not complete successfully."
+  fi
+)
+
+# TODO: Add more example verifications as needed.
+
+echo "[SUCCESS] All example verifications passed."


### PR DESCRIPTION
This PR introduces a new CI workflow to automatically run and verify the project's examples on pull requests targeting the main  branches. This ensures examples remain functional and helps catch issues early in the development process.

fix: #206

Key Changes:
* New Makefile targets:
  * make build-examples: Builds all example binaries.
  * make run-example: Runs a specified example for testing.
* Documentation updates: Modified relevant docs to reference make run-example for consistent example execution.
* Verification script: Added verify-examples.sh to automate runtime checks, including build verification and basic functionality tests for offline, online, and kv_cache_index examples.
* GitHub Actions workflow: Addedci-examples.yaml to trigger automated example testing on PRs, with system dependency setup, Go caching, and timeout handling for reliability.

