### PR TITLE
fix(kvcache): move in-memory indexer to fallback to respect external configs

### DIFF
--- a/pkg/kvcache/kvblock/index.go
+++ b/pkg/kvcache/kvblock/index.go
@@ -65,11 +65,6 @@ func NewIndex(ctx context.Context, cfg *IndexConfig) (Index, error) {
 	var err error
 
 	switch {
-	case cfg.InMemoryConfig != nil:
-		idx, err = NewInMemoryIndex(cfg.InMemoryConfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create in-memory index: %w", err)
-		}
 	case cfg.CostAwareMemoryConfig != nil:
 		idx, err = NewCostAwareMemoryIndex(cfg.CostAwareMemoryConfig)
 		if err != nil {
@@ -86,6 +81,11 @@ func NewIndex(ctx context.Context, cfg *IndexConfig) (Index, error) {
 		idx, err = NewRedisIndex(cfg.RedisConfig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create Redis index: %w", err)
+		}
+	case cfg.InMemoryConfig != nil:
+		idx, err = NewInMemoryIndex(cfg.InMemoryConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create in-memory index: %w", err)
 		}
 	default:
 		return nil, fmt.Errorf("no valid index configuration provided")


### PR DESCRIPTION
Currently, the precise_prefix_cache in the scheduler initializes the configuration with default values (in-memory). Because the switch statement in the indexer evaluates the inmemory case first, it unintentionally overrides explicit Redis or Valkey configurations.

This PR refactors the switch logic to move the inmemory case to the bottom as a fallback. This ensures that user-defined configurations (Redis/Valkey) are correctly recognized and prioritized

https://llm-d.slack.com/archives/C09QG40A3GW/p1766471542097329