### PR TITLE
[build]: Add pre-commit config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,12 +14,14 @@
 
 BasedOnStyle: Google
 UseTab: Never
-IndentWidth: 4
-ColumnLimit: 140
+IndentWidth: 2
+ColumnLimit: 80
 
 # Disable argument and parameter bin-packing for consistent multi-line formatting
 BinPackArguments: false
 BinPackParameters: false
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
 
 # Force pointers to the type for C++.
 DerivePointerAlignment: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,46 @@
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+default_stages:
+  - pre-commit # Run locally
+  - manual # Run in CI
+# exclude: './third_party/.*'
+repos:
+- repo: https://github.com/google/yapf
+  rev: v0.43.0
+  hooks:
+  - id: yapf
+    args: [--in-place, --verbose]
+    # Keep the same list from yapfignore here to avoid yapf failing without any inputs
+    exclude: '(.buildkite|benchmarks|build|examples)/.*'
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.11.7
+  hooks:
+  - id: ruff
+    args: [--output-format, github, --fix]
+  - id: ruff-format
+    files: ^(.buildkite|benchmarks|examples)/.*
+- repo: https://github.com/crate-ci/typos
+  rev: v1.34.0
+  hooks:
+  - id: typos
+- repo: https://github.com/PyCQA/isort
+  rev: 6.0.1
+  hooks:
+  - id: isort
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v20.1.3
+  hooks:
+  - id: clang-format
+    types_or: [c++, cuda]
+    args: [--style=file, --verbose]
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.45.0
+  hooks:
+  - id: markdownlint
+    exclude: '.*\.inc\.md'
+    stages: [manual] # Only run in CI
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.7.7
+  hooks:
+  - id: actionlint

--- a/kv_connectors/llmd_fs_backend/src/csrc/storage/numa_utils.cpp
+++ b/kv_connectors/llmd_fs_backend/src/csrc/storage/numa_utils.cpp
@@ -31,88 +31,88 @@
 
 // Return NUMA node associated with a given GPU
 int get_gpu_numa_node(int device_id) {
-    int numa_node = -1;
+  int numa_node = -1;
 
-    cudaError_t err =
-        cudaDeviceGetAttribute(&numa_node, cudaDevAttrHostNumaId, device_id);
-    if (err != cudaSuccess) {
-        std::cerr << "[WARN] Failed to query NUMA node for GPU " << device_id
-                  << ": " << cudaGetErrorString(err) << "\n";
-        return -1;
-    }
+  cudaError_t err =
+      cudaDeviceGetAttribute(&numa_node, cudaDevAttrHostNumaId, device_id);
+  if (err != cudaSuccess) {
+    std::cerr << "[WARN] Failed to query NUMA node for GPU " << device_id
+              << ": " << cudaGetErrorString(err) << "\n";
+    return -1;
+  }
 
-    return numa_node;
+  return numa_node;
 }
 
 // Return list of CPU cores that belong to a NUMA node
 std::vector<int> get_cpus_in_numa_node(int node) {
-    std::vector<int> cpus;
+  std::vector<int> cpus;
 
-    if (node < 0) {
-        std::cerr << "[WARN] Requested NUMA node " << node
-                  << " (negative index) – returning empty CPU list\n";
-        return cpus;
-    }
-
-    // Sysfs cpulist path for this NUMA node
-    std::string path =
-        "/sys/devices/system/node/node" + std::to_string(node) + "/cpulist";
-    std::ifstream f(path);
-    if (!f.is_open()) {
-        std::cerr << "[WARN] NUMA node " << node
-                  << " cpulist not found or not readable: " << path << "\n";
-        return cpus;
-    }
-
-    // Read full cpulist line (format: "0-13,84-97")
-    std::string line;
-    if (!std::getline(f, line) || line.empty()) {
-        std::cerr << "[WARN] NUMA node " << node
-                  << " cpulist is empty or unreadable: " << path << "\n";
-        return cpus;
-    }
-
-    // Parse comma-separated tokens (ranges like "0-13" or single "7")
-    size_t start = 0;
-    while (start < line.size()) {
-        // Extract next comma-separated token
-        size_t comma = line.find(',', start);
-        std::string token = line.substr(
-            start,
-            (comma == std::string::npos ? std::string::npos : comma - start));
-
-        if (!token.empty()) {
-            size_t dash = token.find('-');
-            try {
-                if (dash != std::string::npos) {
-                    // Range form: "a-b" → expand to [a,b]
-                    int a = std::stoi(token.substr(0, dash));
-                    int b = std::stoi(token.substr(dash + 1));
-                    if (a <= b) {
-                        for (int c = a; c <= b; ++c) {
-                            cpus.push_back(c);
-                        }
-                    } else {
-                        // Invalid range (start > end)
-                        std::cerr << "[WARN] NUMA node " << node
-                                  << " has invalid CPU range '" << token
-                                  << "' (start > end) in " << path << "\n";
-                    }
-                } else {
-                    // Single CPU: "7"
-                    cpus.push_back(std::stoi(token));
-                }
-            } catch (const std::exception& e) {
-                // Malformed token (non-numeric, out-of-range, etc.): ignore
-                std::cerr << "[WARN] NUMA node " << node
-                          << " has malformed cpulist token '" << token
-                          << "' in " << path << ": " << e.what() << "\n";
-            }
-        }
-
-        if (comma == std::string::npos) break;
-        start = comma + 1;
-    }
-
+  if (node < 0) {
+    std::cerr << "[WARN] Requested NUMA node " << node
+              << " (negative index) – returning empty CPU list\n";
     return cpus;
+  }
+
+  // Sysfs cpulist path for this NUMA node
+  std::string path =
+      "/sys/devices/system/node/node" + std::to_string(node) + "/cpulist";
+  std::ifstream f(path);
+  if (!f.is_open()) {
+    std::cerr << "[WARN] NUMA node " << node
+              << " cpulist not found or not readable: " << path << "\n";
+    return cpus;
+  }
+
+  // Read full cpulist line (format: "0-13,84-97")
+  std::string line;
+  if (!std::getline(f, line) || line.empty()) {
+    std::cerr << "[WARN] NUMA node " << node
+              << " cpulist is empty or unreadable: " << path << "\n";
+    return cpus;
+  }
+
+  // Parse comma-separated tokens (ranges like "0-13" or single "7")
+  size_t start = 0;
+  while (start < line.size()) {
+    // Extract next comma-separated token
+    size_t comma = line.find(',', start);
+    std::string token = line.substr(
+        start,
+        (comma == std::string::npos ? std::string::npos : comma - start));
+
+    if (!token.empty()) {
+      size_t dash = token.find('-');
+      try {
+        if (dash != std::string::npos) {
+          // Range form: "a-b" -> expand to [a,b]
+          int a = std::stoi(token.substr(0, dash));
+          int b = std::stoi(token.substr(dash + 1));
+          if (a <= b) {
+            for (int c = a; c <= b; ++c) {
+              cpus.push_back(c);
+            }
+          } else {
+            // Invalid range (start > end)
+            std::cerr << "[WARN] NUMA node " << node
+                      << " has invalid CPU range '" << token
+                      << "' (start > end) in " << path << "\n";
+          }
+        } else {
+          // Single CPU: "7"
+          cpus.push_back(std::stoi(token));
+        }
+      } catch (const std::exception& e) {
+        // Malformed token (non-numeric, out-of-range, etc.): ignore
+        std::cerr << "[WARN] NUMA node " << node
+                  << " has malformed cpulist token '" << token << "' in "
+                  << path << ": " << e.what() << "\n";
+      }
+    }
+
+    if (comma == std::string::npos) break;
+    start = comma + 1;
+  }
+
+  return cpus;
 }


### PR DESCRIPTION
Add a general pre-commit configuration that enables:
- Python formatting and linting (yapf, ruff, isort).
- C++/CUDA formatting with clang-format.
- Typo checking and GitHub Actions validation.
- Heavier checks (markdownlint) to run only in CI via the manual stage.

For now, this is set up to run manually. In the future, it will be integrated into CI.