### PR TITLE
refactor: Accept tokens in GetPodScores

### DIFF
--- a/examples/kv_cache_aware_scorer/kvcache_aware_scorer.go
+++ b/examples/kv_cache_aware_scorer/kvcache_aware_scorer.go
@@ -214,7 +214,11 @@ func (s *PrecisePrefixCacheScorer) Score(ctx context.Context, cycleState *types.
 		return nil
 	}
 
-	tokens := s.kvCacheIndexer.Tokenize(nil, request.Prompt)
+	tokens, err := s.kvCacheIndexer.Tokenize(nil, request.Prompt)
+	if err != nil {
+		logger.Error(err, "Failed to tokenize prompt")
+		return nil
+	}
 	scores, err := s.kvCacheIndexer.GetPodScores(ctx, tokens, request.TargetModel, nil)
 	if err != nil {
 		logger.Error(err, "Failed to get pod scores")

--- a/examples/kv_cache_index/main.go
+++ b/examples/kv_cache_index/main.go
@@ -130,7 +130,10 @@ func runPrompts(ctx context.Context, kvCacheIndexer *kvcache.Indexer) error {
 	logger.Info("Started Indexer", "model", modelName)
 
 	// Tokenize the prompt
-	tokens := kvCacheIndexer.Tokenize(testdata.RenderReq, testdata.Prompt)
+	tokens, err := kvCacheIndexer.Tokenize(testdata.RenderReq, testdata.Prompt)
+	if err != nil {
+		return fmt.Errorf("failed to tokenize prompt: %w", err)
+	}
 
 	// Get pods for the prompt
 	pods, err := kvCacheIndexer.GetPodScores(ctx, tokens, modelName, nil)

--- a/examples/kv_cache_index_service/server/main.go
+++ b/examples/kv_cache_index_service/server/main.go
@@ -60,7 +60,11 @@ func main() {
 	}
 
 	// Initial query - should be empty since no events have been published
-	tokens := indexerSvc.indexer.Tokenize(testdata.RenderReq, testdata.Prompt)
+	tokens, err := indexerSvc.indexer.Tokenize(testdata.RenderReq, testdata.Prompt)
+	if err != nil {
+		logger.Error(err, "failed to tokenize prompt")
+		return
+	}
 	pods, err := indexerSvc.indexer.GetPodScores(ctx, tokens, testdata.ModelName, nil)
 	if err != nil {
 		logger.Error(err, "failed to get pod scores")

--- a/examples/kv_cache_index_service/server/server.go
+++ b/examples/kv_cache_index_service/server/server.go
@@ -72,7 +72,10 @@ func (s *IndexerService) GetPodScores(ctx context.Context,
 	}
 
 	// Tokenize the prompt
-	tokens := s.indexer.Tokenize(nil, req.Prompt)
+	tokens, err := s.indexer.Tokenize(nil, req.Prompt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to tokenize prompt: %w", err)
+	}
 
 	// Call the underlying indexer
 	podScores, err := s.indexer.GetPodScores(ctx, tokens, req.ModelName,

--- a/examples/kv_events/offline/main.go
+++ b/examples/kv_events/offline/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	_ "embed"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -146,7 +147,10 @@ func RunEventsDemo(ctx context.Context, kvCacheIndexer *kvcache.Indexer, publish
 	logger.Info("@@@ Starting KV Events Demo", "model", testdata.ModelName)
 
 	// Tokenize the prompt
-	tokens := kvCacheIndexer.Tokenize(testdata.RenderReq, testdata.Prompt)
+	tokens, err := kvCacheIndexer.Tokenize(testdata.RenderReq, testdata.Prompt)
+	if err != nil {
+		return fmt.Errorf("failed to tokenize prompt: %w", err)
+	}
 
 	// Initial query - should be empty since no events have been published
 	pods, err := kvCacheIndexer.GetPodScores(ctx, tokens, testdata.ModelName, nil)

--- a/examples/kv_events/online/main.go
+++ b/examples/kv_events/online/main.go
@@ -297,7 +297,11 @@ func setupUnifiedHTTPEndpoints(
 			return
 		}
 
-		tokens := kvCacheIndexer.Tokenize(nil, req.Prompt)
+		tokens, err := kvCacheIndexer.Tokenize(nil, req.Prompt)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to tokenize: %v", err), http.StatusInternalServerError)
+			return
+		}
 		pods, err := kvCacheIndexer.GetPodScores(ctx, tokens, req.Model, nil)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("error: %v", err), http.StatusInternalServerError)
@@ -339,7 +343,11 @@ func setupUnifiedHTTPEndpoints(
 		}
 
 		// Tokenize and get score
-		tokens := kvCacheIndexer.Tokenize(nil, renderedPrompt)
+		tokens, err := kvCacheIndexer.Tokenize(nil, renderedPrompt)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to tokenize: %v", err), http.StatusInternalServerError)
+			return
+		}
 		pods, err := kvCacheIndexer.GetPodScores(ctx, tokens, req.Model, nil)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Failed to get score request: %v", err), http.StatusInternalServerError)

--- a/examples/valkey_example/main.go
+++ b/examples/valkey_example/main.go
@@ -134,7 +134,10 @@ func demonstrateValkeyOperations(ctx context.Context, indexer *kvcache.Indexer) 
 	logger.Info("Processing testdata prompt", "model", modelName, "promptLength", len(prompt))
 
 	// Tokenize the prompt
-	tokens := indexer.Tokenize(nil, prompt)
+	tokens, err := indexer.Tokenize(nil, prompt)
+	if err != nil {
+		return fmt.Errorf("failed to tokenize prompt: %w", err)
+	}
 
 	// First, let's demonstrate basic scoring without any cache entries
 	scores, err := indexer.GetPodScores(ctx, tokens, modelName, []string{"demo-pod-1", "demo-pod-2"})

--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -191,6 +191,6 @@ func (k *Indexer) SetTokenizer(tokenizer tokenization.Tokenizer, modelName strin
 // prompt is tokenized directly without chat template rendering.
 //
 // Returns the token IDs as a uint32 slice, or an error if tokenization fails.
-func (k *Indexer) Tokenize(renderReq *preprocessing.ApplyChatTemplateRequest, prompt string) []uint32 {
+func (k *Indexer) Tokenize(renderReq *preprocessing.ApplyChatTemplateRequest, prompt string) ([]uint32, error) {
 	return k.tokenizersPool.Tokenize(renderReq, prompt)
 }

--- a/pkg/tokenization/pool_test.go
+++ b/pkg/tokenization/pool_test.go
@@ -214,12 +214,20 @@ func TestPool_WorkerLoop(t *testing.T) {
 			},
 			verify: func(t *testing.T, pool *Pool, tasks []Task, resultCh chan tokenizationResponse) {
 				t.Helper()
-				require.Eventually(t, func() bool { // channel is closed, when max retries exceeded
-					if result, ok := <-resultCh; !ok {
-						assert.Equal(t, tokenizationResponse{}, result)
+				// When max retries exceeded, error should be sent before channel is closed
+				require.Eventually(t, func() bool {
+					if result, ok := <-resultCh; ok {
+						assert.NotNil(t, result.Err, "expected error in response")
+						assert.Nil(t, result.Tokens, "expected nil tokens on error")
 						return true
 					}
 					return false
+				}, time.Second, 10*time.Millisecond)
+
+				// Verify channel is closed after error is sent
+				require.Eventually(t, func() bool {
+					_, ok := <-resultCh
+					return !ok
 				}, time.Second, 10*time.Millisecond)
 
 				require.Eventually(t, func() bool {
@@ -411,7 +419,7 @@ func BenchmarkSyncTokenizationStress(b *testing.B) {
 			// Submit tokenization requests in a loop until limit
 			for i := 0; b.Loop(); i++ {
 				prompt := generateRandomSentence(benchmarkWordLength, benchmarkMaxWords, rng)
-				pool.Tokenize(nil, prompt)
+				_, _ = pool.Tokenize(nil, prompt)
 			}
 
 			b.StopTimer()

--- a/tests/e2e/redis_mock/e2e_test.go
+++ b/tests/e2e/redis_mock/e2e_test.go
@@ -121,7 +121,8 @@ func (s *KVCacheSuite) TestCacheHit() {
 	engineKeys, requestKeys := s.promptToEngineAndRequestKeys(prompt, defaultModelName)
 	s.addEntriesToIndex(engineKeys, requestKeys, fakePodList)
 
-	tokens := s.indexer.Tokenize(nil, prompt)
+	tokens, err := s.indexer.Tokenize(nil, prompt)
+	s.Require().NoError(err)
 	pods, err := s.indexer.GetPodScores(s.ctx, tokens, defaultModelName, fakePodList)
 	s.Require().NoError(err)
 	s.T().Logf("Received pod scores: %+v", pods)
@@ -133,7 +134,8 @@ func (s *KVCacheSuite) TestCacheMiss() {
 	prompt := "What is the capital of France?"
 	fakePodList := []string{s.Pod1IP}
 
-	tokens := s.indexer.Tokenize(nil, prompt)
+	tokens, err := s.indexer.Tokenize(nil, prompt)
+	s.Require().NoError(err)
 	pods, err := s.indexer.GetPodScores(s.ctx, tokens, defaultModelName, fakePodList)
 	s.Require().NoError(err)
 	s.T().Logf("Received pod scores: %+v", pods)
@@ -152,7 +154,8 @@ func (s *KVCacheSuite) TestPrefixReduction() {
 	fakePodList := []string{s.Pod1IP}
 
 	// Test 1: Full prompt (no match expected)
-	fullTokens := s.indexer.Tokenize(nil, fullPrompt)
+	fullTokens, err := s.indexer.Tokenize(nil, fullPrompt)
+	s.Require().NoError(err)
 	pods, err := s.indexer.GetPodScores(s.ctx, fullTokens, defaultModelName, []string{s.Pod1IP})
 	s.Require().NoError(err)
 	s.T().Logf("Received pod scores: %+v", pods)
@@ -161,7 +164,8 @@ func (s *KVCacheSuite) TestPrefixReduction() {
 	s.addEntriesToIndex(fullPromptEngineKeys, fullPromptRequestKeys, fakePodList)
 
 	// Test 2: mid-length prompt(should return a match)
-	midTokens := s.indexer.Tokenize(nil, midPrompt)
+	midTokens, err := s.indexer.Tokenize(nil, midPrompt)
+	s.Require().NoError(err)
 	pods, err = s.indexer.GetPodScores(s.ctx, midTokens, defaultModelName, []string{s.Pod1IP})
 	s.Require().NoError(err)
 
@@ -169,7 +173,8 @@ func (s *KVCacheSuite) TestPrefixReduction() {
 	s.Greater(int(pods[s.Pod1IP]), 0, "mid-prompt block keys should have been indexed")
 
 	// Test 3: short prompt(should return a match)
-	shortTokens := s.indexer.Tokenize(nil, shortPrompt)
+	shortTokens, err := s.indexer.Tokenize(nil, shortPrompt)
+	s.Require().NoError(err)
 	pods, err = s.indexer.GetPodScores(s.ctx, shortTokens, defaultModelName, []string{s.Pod1IP})
 	s.Require().NoError(err)
 
@@ -190,7 +195,8 @@ func (s *KVCacheSuite) TestPrefixExpansion() {
 	fakePodList := []string{s.Pod1IP}
 
 	// Test 1: short prompt
-	shortTokens := s.indexer.Tokenize(nil, shortPrompt)
+	shortTokens, err := s.indexer.Tokenize(nil, shortPrompt)
+	s.Require().NoError(err)
 	pods, err := s.indexer.GetPodScores(s.ctx, shortTokens, modelName, []string{s.Pod1IP})
 	s.Require().NoError(err)
 	s.T().Logf("Received pod scores: %+v", pods)
@@ -200,7 +206,8 @@ func (s *KVCacheSuite) TestPrefixExpansion() {
 	s.addEntriesToIndex(shortPromptEngineKeys, shortPromptRequestKeys, fakePodList)
 
 	// Test 2: mid prompt
-	midTokens := s.indexer.Tokenize(nil, midPrompt)
+	midTokens, err := s.indexer.Tokenize(nil, midPrompt)
+	s.Require().NoError(err)
 	pods, err = s.indexer.GetPodScores(s.ctx, midTokens, modelName, []string{s.Pod1IP})
 	s.Require().NoError(err)
 
@@ -211,7 +218,8 @@ func (s *KVCacheSuite) TestPrefixExpansion() {
 	s.addEntriesToIndex(midPromptEngineKeys, midPromptRequestKeys, fakePodList)
 
 	// Test 3: full prompt
-	fullTokens := s.indexer.Tokenize(nil, fullPrompt)
+	fullTokens, err := s.indexer.Tokenize(nil, fullPrompt)
+	s.Require().NoError(err)
 	pods, err = s.indexer.GetPodScores(s.ctx, fullTokens, modelName, []string{s.Pod1IP})
 	s.Require().NoError(err)
 
@@ -232,7 +240,8 @@ func (s *KVCacheSuite) TestLongPrefixExpansion() {
 	fakePodList := []string{s.Pod1IP}
 
 	// Test 1: short prompt (should return no pod scores yet)
-	shortTokens := s.indexer.Tokenize(nil, shortPrompt)
+	shortTokens, err := s.indexer.Tokenize(nil, shortPrompt)
+	s.Require().NoError(err)
 	pods, err := s.indexer.GetPodScores(s.ctx, shortTokens, modelName, []string{s.Pod1IP})
 	s.Require().NoError(err)
 	s.T().Logf("Short prompt scores: %+v", pods)
@@ -243,7 +252,8 @@ func (s *KVCacheSuite) TestLongPrefixExpansion() {
 	s.addEntriesToIndex(shortPromptEngineKeys, shortPromptRequestKeys, fakePodList)
 
 	// Test 2: mid prompt (should return partial match if indexer picks it up)
-	midTokens := s.indexer.Tokenize(nil, midPrompt)
+	midTokens, err := s.indexer.Tokenize(nil, midPrompt)
+	s.Require().NoError(err)
 	pods, err = s.indexer.GetPodScores(s.ctx, midTokens, modelName, []string{s.Pod1IP})
 	s.Require().NoError(err)
 	s.T().Logf("Mid prompt scores: %+v", pods)
@@ -254,7 +264,8 @@ func (s *KVCacheSuite) TestLongPrefixExpansion() {
 	s.addEntriesToIndex(midPromptEngineKeys, midPromptRequestKeys, fakePodList)
 
 	// Test 3: long prompt (should return higher score)
-	longTokens := s.indexer.Tokenize(nil, longPrompt)
+	longTokens, err := s.indexer.Tokenize(nil, longPrompt)
+	s.Require().NoError(err)
 	pods, err = s.indexer.GetPodScores(s.ctx, longTokens, modelName, []string{s.Pod1IP})
 	s.Require().NoError(err)
 	s.T().Logf("Long prompt scores: %+v", pods)
@@ -303,7 +314,8 @@ func (s *KVCacheSuite) TestChatCompletionsE2E() {
 	fakePodList := []string{s.Pod1IP}
 
 	// First lookup - should return no scores initially.
-	tokens := s.indexer.Tokenize(nil, flattenedPrompt)
+	tokens, err := s.indexer.Tokenize(nil, flattenedPrompt)
+	s.Require().NoError(err)
 	pods, err := s.indexer.GetPodScores(s.ctx, tokens, "ibm-granite/granite-3.3-8b-instruct", []string{s.Pod1IP})
 	s.Require().NoError(err)
 	s.T().Logf("First lookup - Received pod scores: %+v", pods)
@@ -378,7 +390,8 @@ func (s *KVCacheSuite) TestLongChatCompletionsE2E() {
 	fakePodList := []string{s.Pod1IP}
 
 	// First lookup.
-	tokens := s.indexer.Tokenize(nil, flattenedPrompt)
+	tokens, err := s.indexer.Tokenize(nil, flattenedPrompt)
+	s.Require().NoError(err)
 	pods, err := s.indexer.GetPodScores(s.ctx, tokens, "ibm-granite/granite-3.3-8b-instruct", []string{s.Pod1IP})
 	s.Require().NoError(err)
 	s.T().Logf("First lookup - Received pod scores: %+v", pods)
@@ -428,7 +441,8 @@ func (s *KVCacheSuite) TestCacheHitWithLocalTokenizer() {
 	s.addEntriesToIndex(engineKeys, requestKeys, fakePodList)
 
 	// Verify that we can retrieve the entries we just added using GetPodScores
-	promptTokens := s.indexer.Tokenize(nil, prompt)
+	promptTokens, err := s.indexer.Tokenize(nil, prompt)
+	s.Require().NoError(err)
 	pods, err := s.indexer.GetPodScores(s.ctx, promptTokens, modelName, fakePodList)
 	s.Require().NoError(err)
 	s.Require().NotEmpty(pods, "should find pod scores after adding entries")
@@ -569,7 +583,8 @@ func (s *KVCacheSuite) TestLocalTokenizerChatTemplateE2E() {
 			fakePodList := []string{s.Pod1IP}
 			s.addEntriesToIndex(engineKeys, requestKeys, fakePodList)
 			// Verify retrieval using GetPodScores with the rendered prompt
-			renderedTokens := s.indexer.Tokenize(nil, renderedPrompt)
+			renderedTokens, err := s.indexer.Tokenize(nil, renderedPrompt)
+			s.Require().NoError(err)
 			pods, err := s.indexer.GetPodScores(s.ctx, renderedTokens, tc.modelName, fakePodList)
 			s.Require().NoError(err)
 			s.Require().NotEmpty(pods, "should find pod scores after adding entries")
@@ -703,7 +718,8 @@ func (s *KVCacheSuite) TestLocalTokenizerChatTemplateMultiTurnE2E() {
 			s.addEntriesToIndex(extendedEngineKeys, extendedRequestKeys, fakePodList)
 
 			// Verify that querying with the short conversation still works (prefix sharing in KV-cache)
-			shortPromptTokens := s.indexer.Tokenize(nil, shortPrompt)
+			shortPromptTokens, err := s.indexer.Tokenize(nil, shortPrompt)
+			s.Require().NoError(err)
 			pods, err := s.indexer.GetPodScores(s.ctx, shortPromptTokens, tc.modelName, fakePodList)
 			s.Require().NoError(err)
 			s.Require().NotEmpty(pods, "Short conversation should still match after adding extended conversation")
@@ -782,7 +798,8 @@ func (s *KVCacheSuite) TestLocalVsHFChatTemplateConsistency() {
 			fakePodList := []string{s.Pod1IP}
 			s.addEntriesToIndex(engineKeys, requestKeys, fakePodList)
 
-			localRenderedTokens := s.indexer.Tokenize(nil, localRendered)
+			localRenderedTokens, err := s.indexer.Tokenize(nil, localRendered)
+			s.Require().NoError(err)
 			pods, err := s.indexer.GetPodScores(s.ctx, localRenderedTokens, tc.modelName, fakePodList)
 			s.Require().NoError(err)
 			s.Require().NotEmpty(pods, "should find pod scores after adding entries")
@@ -926,7 +943,8 @@ func (s *KVCacheSuite) TestLocalTokenizerChatTemplateLongConversation() {
 			s.addEntriesToIndex(engineKeys, requestKeys, fakePodList)
 			// Verify retrieval using GetPodScores
 			// Note: This works now because the test suite uses a composite tokenizer that includes the local models
-			promptTokens := s.indexer.Tokenize(nil, renderedPrompt)
+			promptTokens, err := s.indexer.Tokenize(nil, renderedPrompt)
+			s.Require().NoError(err)
 			pods, err := s.indexer.GetPodScores(s.ctx, promptTokens, tc.modelName, fakePodList)
 			s.Require().NoError(err)
 			s.Require().NotEmpty(pods, "should find pod scores after adding entries")


### PR DESCRIPTION
## Summary

Refactors `GetPodScores` to accept `tokens []uint32` instead of `renderReq` and `prompt` parameters.

- Adds `Tokenize` method to `Indexer` that returns `([]uint32, error)`
- Updates `GetPodScores` signature to accept `tokens []uint32` directly
- Propagates tokenization errors to callers instead of silently returning nil

Fixes #244