### PR TITLE
bump vLLM to v0.15.0 and tokenizers to v1.24.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ COPY --from=python-builder /workspace/build/venv/lib/python3.12/site-packages /w
 ENV PYTHONPATH=/workspace/pkg/preprocessing/chat_completions:/workspace/build/venv/lib/python3.12/site-packages
 RUN python3.12 -c "import tokenizer_wrapper"
 
-ARG RELEASE_VERSION=v1.22.1
+ARG RELEASE_VERSION=v1.24.0
 RUN TOKENIZER_VERSION=${RELEASE_VERSION} make build
 
 # Use distroless as minimal base image to package the manager binary

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PROD_VERSION ?= 0.0.0
 IMAGE_TAG_BASE ?= ghcr.io/llm-d/$(PROJECT_NAME)
 IMG = $(IMAGE_TAG_BASE):$(DEV_VERSION)
 NAMESPACE ?= hc4ai-operator
-VLLM_VERSION := 0.14.0
+VLLM_VERSION := 0.15.0
 
 TARGETOS ?= $(shell go env GOOS)
 TARGETARCH ?= $(shell go env GOARCH)


### PR DESCRIPTION
Tryign to resolve: https://github.com/llm-d/llm-d-kv-cache/actions/runs/21501134318/job/61947490489

Created RC and crashing the job with tokenizers / wheels version.