### PR TITLE
fix: Fix CI wheels to support arm64

### DIFF
--- a/.github/workflows/ci-wheels.yaml
+++ b/.github/workflows/ci-wheels.yaml
@@ -3,66 +3,77 @@ name: CI - Build CUDA Wheels
 on:
   push:
     tags:
-      - 'v*'
-  release:
-    types: [published]
-  workflow_dispatch:
+      - "v*"
 
 permissions:
   contents: write
 
 jobs:
-  cuda-wheels:
-    runs-on: ${{ matrix.runs_on }}
+  build-wheels:
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - arch: amd64
-            runs_on: [self-hosted, linux, x64, vllm-runner]
-          - arch: arm64
-            runs_on: [self-hosted, linux, arm64, vllm-runner-arm]
+          - os: ubuntu-24.04
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
 
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Set CUDA_HOME
-        run: echo "CUDA_HOME=/usr/local/cuda" >> $GITHUB_ENV
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Clean build artifacts
-        working-directory: kv_connectors/llmd_fs_backend
+      - name: Build wheel in Docker
         run: |
-          rm -rf build dist *.egg-info wheels
-          find . -name "*.so" -delete || true
+          cd kv_connectors/llmd_fs_backend
 
-      - name: Install build deps
-        working-directory: kv_connectors/llmd_fs_backend
-        run: |
-          python -m pip install -U pip setuptools wheel build ninja
-          python -m pip install -U torch==2.9.1
+          if [[ "${{ matrix.arch }}" == "arm64" ]]; then
+            PLATFORM="linux/arm64"
+          else
+            PLATFORM="linux/amd64"
+          fi
 
-      - name: Build wheel
-        working-directory: kv_connectors/llmd_fs_backend
-        run: |
-          mkdir -p wheels
-          make wheel
-          ls -lh wheels
+          DOCKER_BUILDKIT=1 docker build \
+            --platform=${PLATFORM} \
+            --build-arg CUDA_VERSION=12.9.1 \
+            --build-arg torch_cuda_arch_list='8.7 8.9 9.0 10.0+PTX' \
+            --build-arg max_jobs=4 \
+            --tag llmd-fs-backend:build-${{ matrix.arch }} \
+            --target build \
+            --progress plain \
+            -f Dockerfile.wheel .
 
-      - name: Upload wheels to Release assets
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v2
-        with:
-          files: kv_connectors/llmd_fs_backend/wheels/*.whl
+          mkdir -p wheel-release
+          docker run --rm -v "$(pwd)/wheel-release:/artifacts_host" llmd-fs-backend:build-${{ matrix.arch }} \
+            bash -lc 'cp -v dist/*.whl /artifacts_host/ && chmod -R a+rw /artifacts_host'
 
+          ls -lh wheel-release/
+
+      # -----------------------
+      # Upload artifacts
+      # -----------------------
       - name: Upload wheels as workflow artifact
-        if: github.event_name != 'release'
         uses: actions/upload-artifact@v4
         with:
           name: cuda-wheels-${{ matrix.arch }}
-          path: kv_connectors/llmd_fs_backend/wheels/*.whl
+          path: kv_connectors/llmd_fs_backend/wheel-release/*.whl
+
+  attach-assets:
+    needs: build-wheels
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Download wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release_wheels
+
+      - name: Attach wheels to the tag release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: release_wheels/**/*.whl
+          fail_on_unmatched_files: true
+          draft: true
+          prerelease: true

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -45,6 +45,7 @@ header:
     - "OWNERS"
     - "OWNERS_ALIASES"
     - "**/Dockerfile"
+    - "**/Dockerfile.*"
     - "**/dockerfile"
     - "**/Containerfile.*"
     - "hack/*.sh"

--- a/kv_connectors/llmd_fs_backend/Dockerfile.wheel
+++ b/kv_connectors/llmd_fs_backend/Dockerfile.wheel
@@ -1,0 +1,59 @@
+# syntax=docker/dockerfile:1
+
+ARG CUDA_VERSION=12.9.1
+FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04 AS build
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG max_jobs=16
+ARG torch_cuda_arch_list="8.7 8.9 9.0 10.0+PTX"
+
+# System deps
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      software-properties-common \
+      curl \
+      git \
+      ca-certificates \
+      build-essential \
+      ninja-build \
+      libnuma-dev && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      python3.12 \
+      python3.12-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# pip for Python 3.12
+RUN curl -sSL https://bootstrap.pypa.io/get-pip.py | python3.12
+
+# Make python/python3 point to 3.12
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3.12 1
+
+# CUDA env (must be set for torch.utils.cpp_extension)
+ENV CUDA_HOME=/usr/local/cuda
+ENV PATH=${CUDA_HOME}/bin:${PATH}
+ENV LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
+ENV TORCH_CUDA_ARCH_LIST=${torch_cuda_arch_list}
+ENV MAX_JOBS=${max_jobs}
+
+# Python build deps
+RUN python -m pip install --upgrade pip setuptools wheel ninja numpy
+
+# Install torch.
+RUN python -m pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cu129 torch==2.9.1
+
+# Copy source code
+WORKDIR /workspace
+COPY . /workspace/
+
+# Optional: sanity checks (helps debug CUDA_HOME / nvcc / torch)
+RUN echo "CUDA_HOME=$CUDA_HOME" && \
+    which nvcc && nvcc --version && \
+    python -c "import os; print('CUDA_HOME=', os.environ.get('CUDA_HOME')); import torch; print('torch cuda=', torch.version.cuda)"
+
+# Build wheel
+RUN rm -rf build dist *.egg-info wheels && \
+    mkdir -p dist && \
+    python setup.py bdist_wheel -d dist

--- a/kv_connectors/llmd_fs_backend/Makefile
+++ b/kv_connectors/llmd_fs_backend/Makefile
@@ -1,4 +1,4 @@
-PYTHON ?= python
+PYTHON ?= python3
 WHEEL_DIR = wheels
 DIST_DIR = dist
 
@@ -6,7 +6,7 @@ DIST_DIR = dist
 
 # Install build dependencies
 deps:
-	$(PYTHON) -m pip install --upgrade pip setuptools wheel build
+	$(PYTHON) -m pip install --upgrade pip setuptools wheel build ninja numpy
 
 # Build wheel into dist/ and copy .whl into wheels/
 wheel: deps

--- a/kv_connectors/llmd_fs_backend/pyproject.toml
+++ b/kv_connectors/llmd_fs_backend/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llmd_fs_connector"
-version = "0.1.0"
+version = "0.14.1"
 description = "Standalone llm-d fs storage connector"
 readme = "README.md"
 authors = [

--- a/kv_connectors/llmd_fs_backend/setup.py
+++ b/kv_connectors/llmd_fs_backend/setup.py
@@ -30,7 +30,7 @@ setup(
                 "csrc/storage/tensor_copier.cu",
                 "csrc/storage/tensor_copier_kernels.cu",
             ],
-            libraries=["numa", "cuda"],
+            libraries=["numa"],
             extra_compile_args={
                 "cxx": ["-O3", "-std=c++17", "-fopenmp"],
                 "nvcc": [


### PR DESCRIPTION
This PR fixes the CI workflow to build and publish CUDA wheels on arm64 and amd64. 
The update moves arm64 builds into Docker, fixes CUDA environment handling, and ensures only newly built wheels are attached to releases.