### PR TITLE
fix: Truncate prompt if `truncate_prompt_tokens` set in request

### DIFF
--- a/pkg/preprocessing/chat_completions/cgo_functions.go
+++ b/pkg/preprocessing/chat_completions/cgo_functions.go
@@ -58,6 +58,7 @@ type ApplyChatTemplateRequest struct {
 	ReturnAssistantTokensMask bool                   `json:"return_assistant_tokens_mask,omitempty"`
 	ContinueFinalMessage      bool                   `json:"continue_final_message,omitempty"`
 	AddGenerationPrompt       bool                   `json:"add_generation_prompt,omitempty"`
+	TruncatePromptTokens      *int                   `json:"truncate_prompt_tokens,omitempty"`
 	ChatTemplateKWArgs        map[string]interface{} `json:"chat_template_kwargs,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
Implements `truncate_prompt_tokens` support in the kvcache indexer. When set, the indexer now truncates to the last N tokens before scoring pods, ensuring cache-aware scheduling matches the tokens the LLM actually processes.

As per #193, the indexer was scoring pods based on all tokenized prompt tokens, even when `truncate_prompt_tokens` was set. This caused incorrect pod selection because scoring was based on tokens the LLM would discard after truncation. **For example**, a 2048 token prompt with `truncate_prompt_tokens=1024` would score based on all 2048 tokens, potentially selecting a pod with good cache for the first 1024 tokens (which get discarded) instead of the last 1024 tokens (which actually get used) since truncation happens from the end of the prompt to keep the most recent context.

- [x] Added `TruncatePromptTokens` field to `ApplyChatTemplateRequest` to match vLLM's Chat Completions API parameter.
- [x] Implemented truncation logic as suggested in the aforementioned issue. 

Works correctly with `add_generation_prompt` since the generation prompt is added before tokenization (no changes needed). 

## Test plan

## Related Issues
- #193