### PR TITLE
🌱 Standardize governance workflows via llm-d-infra

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,71 @@
+# Canonical Dependabot configuration for llm-d repos
+# Copy this file to .github/dependabot.yml in your repo
+#
+# Covers: Go modules, GitHub Actions, Docker base images
+# Remove sections that don't apply to your repo
+
+version: 2
+updates:
+
+  # Go module updates
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps(go)"
+    labels:
+      - "dependencies"
+      - "release-note-none"
+    ignore:
+      # Ignore major and minor updates to Go toolchain
+      - dependency-name: "go"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Ignore major and minor version updates to k8s packages
+      - dependency-name: "k8s.io/*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "sigs.k8s.io/*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Ignore major updates for all packages
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "release-note-none"
+    commit-message:
+      prefix: "deps(actions)"
+
+  # Docker base image updates
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps(docker)"
+
+  # Python dependencies (uncomment if repo uses pip/requirements.txt)
+  # - package-ecosystem: "pip"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #   labels:
+  #     - "dependencies"
+  #   commit-message:
+  #     prefix: "deps(pip)"

--- a/.github/workflows/check-typos.yaml
+++ b/.github/workflows/check-typos.yaml
@@ -1,0 +1,8 @@
+name: Check Typos
+on:
+  pull_request:
+  push:
+
+jobs:
+  typos:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-typos.yml@2b273d6

--- a/.github/workflows/ci-signed-commits.yaml
+++ b/.github/workflows/ci-signed-commits.yaml
@@ -1,0 +1,9 @@
+name: Check Signed Commits
+on: pull_request_target
+
+jobs:
+  signed-commits:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yml@2b273d6
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -1,0 +1,11 @@
+name: Markdown Link Check
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  links:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-md-link-check.yml@2b273d6

--- a/.github/workflows/non-main-gatekeeper.yml
+++ b/.github/workflows/non-main-gatekeeper.yml
@@ -1,0 +1,8 @@
+name: Non-Main Gatekeeper
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  gatekeeper:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-non-main-gatekeeper.yml@2b273d6

--- a/.github/workflows/prow-github.yml
+++ b/.github/workflows/prow-github.yml
@@ -1,37 +1,12 @@
-# Run specified actions or jobs for issue and PR comments
-
-name: "Prow github actions"
+name: Prow Commands
 on:
   issue_comment:
     types: [created]
 
-# Grant additional permissions to the GITHUB_TOKEN
 permissions:
-  # Allow labeling issues
   issues: write
-  # Allow adding a review to a pull request
   pull-requests: write
 
 jobs:
-  prow-execute:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: jpmcb/prow-github-actions@v2.0.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          prow-commands: "/assign
-            /unassign
-            /approve
-            /retitle
-            /area
-            /kind
-            /priority
-            /remove
-            /lgtm
-            /close
-            /reopen
-            /lock
-            /milestone
-            /hold
-            /cc
-            /uncc"
+  prow:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-commands.yml@2b273d6

--- a/.github/workflows/prow-pr-automerge.yml
+++ b/.github/workflows/prow-pr-automerge.yml
@@ -1,18 +1,8 @@
-# This Github workflow will check every hour for PRs with the lgtm label and will attempt to automatically merge them.
-# If the hold label is present, it will block automatic merging.
-
-name: "Prow merge on lgtm label"
+name: Prow Auto-merge
 on:
   schedule:
-  - cron: "*/5 * * * *" # every 5 minutes
+    - cron: "*/5 * * * *"
 
 jobs:
   auto-merge:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: jpmcb/prow-github-actions@v2.0.0
-        with:
-          jobs: 'lgtm'
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          merge-method: 'squash'
-          
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-automerge.yml@2b273d6

--- a/.github/workflows/prow-pr-remove-lgtm.yml
+++ b/.github/workflows/prow-pr-remove-lgtm.yml
@@ -1,11 +1,6 @@
-name: Run Jobs on PR
+name: Prow Remove LGTM
 on: pull_request
 
 jobs:
-  execute:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: jpmcb/prow-github-actions@v2.0.0
-        with:
-          jobs: lgtm
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
+  remove-lgtm:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-remove-lgtm.yml@2b273d6

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,11 @@
+name: Mark Stale Issues
+on:
+  schedule:
+    - cron: '0 1 * * *'
+
+jobs:
+  stale:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-stale.yml@2b273d6
+    permissions:
+      issues: write
+      pull-requests: write

--- a/.github/workflows/unstale.yaml
+++ b/.github/workflows/unstale.yaml
@@ -1,0 +1,12 @@
+name: Unstale Issues
+on:
+  issues:
+    types: [reopened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  unstale:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-unstale.yml@2b273d6
+    permissions:
+      issues: write


### PR DESCRIPTION
## Summary
- Replace 3 local Prow workflows (commands, automerge, remove-lgtm) with thin callers to `llm-d/llm-d-infra` reusable workflows
- Add 6 new governance workflows: stale/unstale, signed-commits, typos, md-link-check, non-main-gatekeeper
- Add Dependabot config for Go modules, GitHub Actions, and Docker

## Test plan
- [ ] Verify Prow commands (`/lgtm`, `/approve`) still work
- [ ] Confirm new workflows trigger correctly
- [ ] Review Dependabot config

Depends on: https://github.com/llm-d/llm-d-infra/pull/2 (already merged)