### PR TITLE
fix: trivy scan should exit with failure code

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -14,5 +14,5 @@ runs:
 
     - name: Scan image
       run: |
-        trivy image --severity HIGH,CRITICAL --no-progress ${{ inputs.image }}
+        trivy image --severity HIGH,CRITICAL --exit-code 1 --no-progress ${{ inputs.image }}
       shell: bash


### PR DESCRIPTION
Not sure if it runs for information purpose only but without the exit code param, it does not fail the build.