### PR TITLE
update repo docs and scope

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,33 +1,26 @@
-# KVCache
+# Documentation
 
-## Overview
+## Component Documentation
 
-The KVCache libraries are designed to connect high-level serving-stack goals with concrete system capabilities 
-through a layered objective structure:
+| Document | Description |
+|:---------|:------------|
+| [Architecture](architecture.md) | High-level system design and data flows |
+| [KV-Cache Indexer](indexer.md) | Block hashing, index backends, event ingestion, pod discovery |
+| [Tokenization](tokenization.md) | Tokenizer pool, backends, UDS service, chat preprocessing |
+| [Configuration](configuration.md) | Configuration reference for the indexer, event processing, tokenization, and index backends |
+| [Deployment](deployment/) | Kubernetes deployment guides and manifests |
 
-- **Improve user experience** 
-  - By reducing Time-To-First-Token (TTFT)
-     - Enabled through higher KVCache hit rates and reduced tensor transfers
-     - Supported by smart routing and distributed cache availability
-     - Optimized by proactive pre-placement of hot caches and session duplication/migration
-- **Reduce serving costs**
-  - By improving compute utilization
-     - Minimize re-compute via KVCache reuse and locality-aware request handling
-     - Leverage zero-copy cache transfers across nodes
-- **Enable system scalability**
-   - Through a distributed KVCache pool
-      - Allows cache offloading and reuse across multiple serving instances
-   - User session duplication/migration for true and seamless load balancing
+## Component-Specific READMEs
 
+- [UDS Tokenizer Service](../services/uds_tokenizer/README.md) - Python gRPC tokenizer sidecar (setup, API reference, Kubernetes deployment)
+- [FS Backend Connector](../kv_connectors/llmd_fs_backend/README.md) - vLLM file-system offloading connector (installation, configuration, deployment)
 
-## Vision 
+## Examples
 
-This goal structure above is shaped by our vision for emerging use cases like RAG and agentic workflows, 
-which involve heavy context-reuse across sessions and instances. 
-Shared documents, tool prompts, and workflow steps create overlapping token streams that benefit significantly from 
-cross-instance KVCache coordination. 
+See the [examples/](../examples/) directory for runnable demos:
 
-To implement this vision, the KVCache libraries incorporate proactive cache placement, session duplication, 
-and cluster-level cache APIs - bridging gaps in current serving stacks where KVCache management and utilization is 
-not yet treated as a first-class concern.
-
+- [KV-Cache Index](../examples/kv_cache_index/README.md) - Using the `kvcache.Indexer` library directly
+- [KV-Cache Aware Scorer](../examples/kv_cache_aware_scorer/README.md) - Integrating the indexer into a scheduler
+- [KV-Events](../examples/kv_events/README.md) - Offline and online KV-event processing demos
+- [KV-Cache Index Service](../examples/kv_cache_index_service/) - gRPC-based indexer service (client/server)
+- [Valkey Example](../examples/valkey_example/README.md) - Using Valkey as the index backend

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,34 +1,33 @@
-# KV-Cache Indexer: Architecture
+# Architecture
 
-The **KV-Cache Indexer** is a high-performance library that keeps a global, near-real-time view of KV-Cache block locality across a fleet of vLLM pods. 
-Its purpose is the enablement of smart routing and scheduling by exposing a fast, intelligent scoring mechanism for vLLM pods based on their cached KV-blocks.
+This document gives a high-level overview of the Go library system: how the KV-Cache Indexer, KV-Event processing, tokenization, and block index fit together.
 
------
-
-## System Architecture
-
-The Indexer is built from several modules that work together, each with clear responsibilities.
-Separating concerns is a guiding principle in the design of this system.
-
-| Module | Purpose                                                      | Default Implementation                                          |
-| :--- |:-------------------------------------------------------------|:----------------------------------------------------------------|
-| **`kvcache.Indexer`** | The main orchestrator that handles scoring requests          | Coordinates all internal modules                                |
-| **`kvevents.Pool`** | Ingests and processes KV-cache events from vLLM pods         | A sharded worker pool using ZMQ for event subscription          |
-| **`kvblock.Index`** | The core data store mapping KV-block hashes to pod locations | An in-memory, two-level LRU cache                               |
-| **`kvblock.TokenProcessor`**| Converts token sequences into KV-block keys                  | Uses a chunking and hashing algorithm compatible with vLLM      |
-| **`kvblock.Scorer`** | Scores pods based on the sequence of cache hits              | Implements a longest consecutive prefix matching strategy       |
+For component deep dives see:
+- [KV-Cache Indexer](indexer.md) - block hashing, index backends, event ingestion, pod discovery
+- [Tokenization](tokenization.md) - tokenizer pool, backends, UDS service, chat preprocessing
 
 -----
 
-## Data Flow & Processes
+## Modules
+
+| Module | Purpose | Default Implementation |
+| :--- |:---|:---|
+| **`kvcache.Indexer`** | Main orchestrator that handles scoring requests | Coordinates all internal modules |
+| **`kvevents.Pool`** | Ingests and processes KV-cache events from vLLM pods | A sharded worker pool using ZMQ for event subscription |
+| **`kvblock.Index`** | Core data store mapping KV-block hashes to pod locations | An in-memory, two-level LRU cache |
+| **`kvblock.TokenProcessor`** | Converts token sequences into KV-block keys | Chunking and hashing algorithm compatible with vLLM |
+| **`kvblock.Scorer`** | Scores pods based on the sequence of cache hits | Longest consecutive prefix matching strategy |
+
+-----
+
+## Data Flow
 
 The system has two primary data flows: the **Read Path** for scoring pods and the **Write Path** for ingesting cache events.
 
 ### Read Path: Scoring a Prompt
 
-When a router needs to pick the best pod for a new prompt, it triggers the Read Path. 
+When a router needs to pick the best pod for a new prompt, it triggers the Read Path.
 The goal is to find the pod that has the longest sequence of relevant KV-blocks already in its cache.
-A list of pods with their scores is returned to the router.
 
 ```mermaid
 sequenceDiagram
@@ -39,34 +38,38 @@ sequenceDiagram
     participant Scorer as kvblock.Scorer
 
     Router->>Indexer: GetPodScores(prompt, model, pods[])
-    
+
     Note over Indexer: Synchronously tokenizes prompt using pool
-    
+
     Indexer->>TokenProcessor: TokensToKVBlockKeys(tokens[], model)
     TokenProcessor-->>Indexer: blockKeys[]
-    
+
     Indexer->>Index: Lookup(blockKeys[], podSet)
     Index-->>Indexer: hitKeys[], keyToPodsMap
-    
+
     Indexer->>Scorer: Score(hitKeys[], keyToPodsMap)
     Scorer-->>Indexer: podScoresMap
-    
+
     Indexer-->>Router: podScoresMap[string]int
 ```
 
-**Key Steps:**
+1. **Tokenization**: The `Indexer` tokenizes the prompt synchronously using the worker pool.
+2. **Key Generation**: The `TokenProcessor` chunks and hashes the tokens into deterministic KV-block keys that match vLLM's logic.
+3. **Index Lookup**: The `Indexer` queries the `kvblock.Index` to find which pods have those blocks. The lookup finds the longest *consecutive* chain of hits from the start.
+4. **Scoring**: The `Scorer` scores each pod based on its number of consecutive matching blocks.
+5. **Response**: A map of pod scores is returned to the router.
 
-1.  **Tokenization**: The `Indexer` performs synchronous tokenization of the prompt using the worker pool.
-2.  **Key Generation**: The tokenized sequence is sent to the `TokenProcessor`, which chunks and hashes them into a sequence of deterministic KV-block keys that match vLLM's logic.
-3.  **Index Lookup**: With the keys, the `Indexer` queries the `kvblock.Index` to see which pods have them. The lookup is optimized to find the longest *consecutive* chain of hits from the start.
-4.  **Scoring**: The `Scorer` takes the hit data and scores each pod based on its number of consecutive matching blocks.
-5.  **Response**: A final map of pod scores is sent back to the router.
-
-Note: The tokenization pool now supports both asynchronous (fire-and-forget) and synchronous modes, ensuring scoring requests can always return complete results.
+The tokenization pool supports both asynchronous (fire-and-forget) and synchronous modes, ensuring scoring requests can always return complete results.
 
 ### Write Path: Processing Cache Events
 
 The Write Path keeps the index up-to-date by processing a constant stream of events from the vLLM fleet.
+
+Each `KVEvent` (e.g., `BlockStored`) carries the engine's own block hashes, the tokens stored in the block, and metadata (device tier, LoRA ID, etc.).
+The library does **not** use the engine hashes as index keys directly. Instead, it recomputes its own **request keys** from the tokens using the same deterministic hashing scheme used in the read path (FNV-64a over CBOR-encoded tuples).
+The index stores a mapping from engine keys to request keys so that subsequent events (e.g., `BlockRemoved`) can be resolved back.
+
+This two-key design decouples the library from vLLM's internal hash implementation while ensuring that the write path and read path always agree on block identity.
 
 ```mermaid
 sequenceDiagram
@@ -74,85 +77,43 @@ sequenceDiagram
     participant Subscriber as kvevents.zmqSubscriber
     participant Pool as kvevents.Pool
     participant Worker as Pool Worker
+    participant TokenProcessor as kvblock.TokenProcessor
     participant Index as kvblock.Index
 
     vLLM->>Subscriber: Publishes ZMQ Message (msgpack encoded)
     Note over Subscriber: Topic parsed to get Pod ID & Model: kv@pod-id@model
-    
+
     Subscriber->>Pool: AddTask(Message)
     Note over Pool: Hashes pod-id (FNV-1a) to select a worker shard
-    
+
     Pool->>Worker: Enqueues message
-    
+
     Worker->>Worker: Decodes EventBatch (BlockStored, BlockRemoved, etc.)
     loop For each event
         alt BlockStored
-            Worker->>Index: Add(keys[], podEntry)
+            Worker->>TokenProcessor: TokensToKVBlockKeys(parentRequestKey, tokens, model)
+            TokenProcessor-->>Worker: requestKeys[]
+            Worker->>Index: Add(engineKeys[], requestKeys[], podEntry)
         else BlockRemoved
-            Worker->>Index: Evict(key, podEntry)
+            Worker->>Index: Evict(engineKey, podEntry)
         else AllBlocksCleared
             Note over Worker: No-op
         end
     end
 ```
 
-**Key Steps:**
+1. **Event Publication**: A vLLM pod emits an event when its cache changes, published to a ZMQ topic. `BlockStored` events include the engine block hashes, parent hash, token IDs, and metadata.
+2. **Message Reception**: The `zmqSubscriber` receives the message and parses the topic to get `podIdentifier` and `modelName`.
+3. **Sharded Queuing**: The `kvevents.Pool` hashes the pod identifier (FNV-1a) to select a worker queue, guaranteeing in-order processing per pod.
+4. **Event Decoding**: A worker decodes the msgpack payload, which can contain a batch of events.
+5. **Key Recomputation**: For `BlockStored` events, the worker resolves the parent engine hash to its request key (via the index), then uses the `TokenProcessor` to compute request keys from the event's tokens.
+6. **Index Update**: The worker stores both the engine-to-request key mapping and the request-key-to-pod entries in the index.
 
-1.  **Event Publication**: A vLLM pod emits an event, like `BlockStored`, when its cache changes. The event is published to a ZMQ topic.
-2.  **Message Reception**: The `zmqSubscriber` receives the message and parses the topic to get the `podIdentifier` and `modelName`.
-3.  **Sharded Queuing**: The message goes to the `kvevents.Pool`, where the pod identifier is hashed (using FNV-1a) to select a specific worker queue. This guarantees that events from the same pod are always processed in order.
-4.  **Event Decoding**: A worker pulls the message and decodes the msgpack payload, which can contain a batch of events.
-5.  **Index Update**: The worker applies the event to the `kvblock.Index`, either adding a new block location or evicting an old one.
-
------
-
-## Component Deep Dives
-
-#### KV-Block Hashing & Generation
-
-To guarantee compatibility, the indexer perfectly matches vLLM's content-addressing logic.
-
-* **Token Chunking**: Prompts are converted to tokens, which are then grouped into fixed-size chunks (default: 16).
-* **Hash Algorithm**: A chained hash is computed. Each block's key is an **FNV-64a hash**, generated from the CBOR-encoded `[parentHash, tokenChunk, extra]` tuple.
-* **Initialization**: The hash chain starts with a configurable `HashSeed`. This value's source **must** align with the `PYTHONHASHSEED` environment variable in the vLLM pods to ensure hashes are consistent across the entire system.
-* **Extra Parameter**: The third component of the hash tuple enables cache differentiation:
-  - **nil** (default): Standard prompts without LoRA or multi-modal content
-  - **int**: LoRA adapter ID (e.g., 42)
-  - **string**: Adapter name or content-affecting identifier (e.g., "lora-v2")
-  - **map**: Structured metadata (e.g., `{"lora_id": 42, "medium": "gpu"}`)
-Different `extra` values produce different block hashes, preventing cache pollution when the same tokens are used with different adapters or multi-modal inputs.
-#### Index Backends
-
-The `kvblock.Index` is an interface with swappable backends.
-
-* **In-Memory (Default)**: A very fast, thread-safe, two-level LRU cache using `hashicorp/golang-lru`. The first level maps a block key to a second-level cache of pods that have the block. It prioritizes speed over persistence, which is usually the right trade-off for ephemeral cache data.
-* **Cost-Aware Memory (Optional)**: A memory-efficient implementation using the `hypermodeinc/ristretto` cache library that provides cost-aware eviction based on actual memory usage. Unlike the basic in-memory backend, this implementation calculates the memory footprint of each cache entry and uses this information for intelligent eviction decisions. This is particularly useful when memory usage patterns vary significantly across different keys.
-* **Redis (Optional)**: A distributed backend that can be shared by multiple indexer replicas. It can offer scalability and persistence, but this may be overkill given the short lifetime of most KV-cache blocks.
-* **Valkey (Optional)**: A Redis-compatible, open-source alternative that provides the same distributed capabilities as Redis but remains under the BSD license. Valkey offers additional performance benefits through RDMA support for reduced latency, making it particularly suitable for high-performance LLM inference workloads. Since Valkey is API-compatible with Redis, it can be used as a drop-in replacement.
-
-#### Tokenization Subsystem
-
-Efficiently handling tokenization is critical for performance. The system is designed to tokenize prompts quickly using a worker pool that supports both asynchronous and synchronous operations.
-
-* **Tokenization Pool**: The `tokenization.Pool` provides both asynchronous (fire-and-forget) and synchronous tokenization modes. For scoring requests, synchronous tokenization ensures complete results are always returned. The pool uses a configurable number of workers to process requests efficiently.
-* **Tokenizer Backends**: The system supports multiple tokenizer backends with a composite fallback strategy:
-    * **`CachedLocalTokenizer`**: Loads tokenizers from local files on disk. This is particularly useful for air-gapped environments, custom tokenizers, or when models are pre-loaded. It supports:
-        * **Manual Configuration**: Direct mapping from model names to tokenizer file paths
-        * **Auto-Discovery**: Automatic scanning of directories to find tokenizer files
-        * **HuggingFace Cache Structure**: Automatically detects and parses HF cache directories (e.g., `models--Qwen--Qwen3-0.6B/snapshots/{hash}/tokenizer.json` → `Qwen/Qwen3-0.6B`)
-        * **Custom Directory Structures**: Supports arbitrary nesting (e.g., `/mnt/models/org/model/tokenizer.json` → `org/model`)
-    * **`CachedHFTokenizer`**: Downloads and caches tokenizers from HuggingFace. It wraps Hugging Face's high-performance Rust tokenizers and maintains an LRU cache of active tokenizer instances to avoid repeated loading from disk.
-    * **`CompositeTokenizer` (Default)**: Tries tokenizer backends in order, enabling graceful fallback. The default configuration attempts local tokenizers first, then falls back to HuggingFace if the model isn't found locally. This provides the best of both worlds: fast local access when available, with automatic fallback to remote fetching.
-* **Tokenizer Caching**: All tokenizer implementations maintain an LRU cache of loaded tokenizer instances to minimize the overhead of repeatedly loading models from disk.
+See the [KV-Cache Indexer](indexer.md#kv-event-processing) doc for a deeper look at the event processing pipeline.
 
 -----
 
 ## Dependencies
 
-The Indexer relies on several libraries and tools:
-  * Used for tokenization of prompts. 
-* **[pebbe/zmq4](https://github.com/pebbe/zmq4)**: Go bindings for ZeroMQ.
-  * Used for the event processing pool and communication between components.
-  * Requires `libzmq` library to be installed on the system.
-* **Python**: Required to run a CGO binding for the `chat_completions_template` package.
-  * Used for vllm templating of chat completions requests.
+* **[pebbe/zmq4](https://github.com/pebbe/zmq4)**: Go bindings for ZeroMQ. Used for event subscription. Requires `libzmq` installed on the system.
+* **Python 3.12**: Required for the CGO binding used by the `chat_completions` preprocessing package (vLLM Jinja2 templating).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,17 +1,23 @@
 # Configuration
 
-This document describes all configuration options available in the llm-d KV Cache libraries. 
-All configurations are JSON-serializable.
+This document describes the configuration options for the Go libraries: the KV-Cache Indexer, KV-Event processing, and tokenization.
+
+For configuration of other components, see:
+- [UDS Tokenizer Service](../services/uds_tokenizer/README.md#environment-variables) - environment variables and gRPC service config
+- [FS Backend Connector](../kv_connectors/llmd_fs_backend/README.md#configuration-flags) - connector parameters and environment variables
+
+All configurations below are JSON-serializable.
 
 ## Main Configuration
 
-This package consists of two components:
+The Go library has three top-level configuration areas:
 1. **KV Cache Indexer**: Manages the KV cache index, allowing efficient retrieval of cached blocks.
 2. **KV Event Processing**: Handles events from vLLM to update the cache index.
+3. **Token Processing**: Converts token sequences into KV-block keys.
 
-See the [Architecture Overview](architecture.md) for a high-level view of how these components work and interact.
+See the [Architecture](architecture.md) for a high-level view of how these components work and interact.
 
-The two components are configured separately, but share both the index backend for storing KV block localities and the token processor for converting tokens into blocks.
+The indexer and event processing components share the index backend for storing KV block localities and the token processor for converting tokens into blocks.
 The token processor is configured via the `tokenProcessorConfig` field in the main configuration.
 The index backend is configured via the `kvBlockIndexConfig` field in the KV Cache Indexer configuration.
 

--- a/docs/indexer.md
+++ b/docs/indexer.md
@@ -1,0 +1,103 @@
+# KV-Cache Indexer
+
+The KV-Cache Indexer is a high-performance Go library that maintains a global, near-real-time view of KV-Cache block locality across a fleet of vLLM pods.
+It ingests `KVEvents` streamed from vLLM, tracks which blocks reside on which nodes and tiers, and exposes a scoring API for KV-cache-aware scheduling.
+
+See [Architecture](architecture.md) for high-level data flow diagrams showing how the indexer, event processing, and block index interact.
+
+-----
+
+## Block Hashing & Key Generation
+
+To guarantee compatibility, the block key generation logic exactly matches vLLM's content-addressing scheme.
+
+* **Token Chunking**: Prompts are converted to tokens, then grouped into fixed-size chunks (default: 16).
+* **Hash Algorithm**: A chained hash is computed. Each block's key is an **FNV-64a hash** generated from the CBOR-encoded `[parentHash, tokenChunk, extra]` tuple.
+* **Initialization**: The hash chain starts with a configurable `HashSeed`.
+* **Extra Parameter**: The third component of the hash tuple enables cache differentiation:
+  - **nil** (default): Standard prompts without LoRA or multi-modal content
+  - **int**: LoRA adapter ID (e.g., 42)
+  - **string**: Adapter name or content-affecting identifier (e.g., "lora-v2")
+  - **map**: Structured metadata (e.g., `{"lora_id": 42, "medium": "gpu"}`)
+
+Different `extra` values produce different block hashes, preventing cache pollution when the same tokens are used with different adapters or multi-modal inputs.
+
+-----
+
+## Index Backends
+
+The `kvblock.Index` is an interface with swappable backends.
+
+### In-Memory (Default)
+
+A fast, thread-safe, two-level LRU cache using `hashicorp/golang-lru`. The first level maps a block key to a second-level cache of pods that have the block. Prioritizes speed over persistence, which is usually the right trade-off for ephemeral cache data.
+
+### Cost-Aware Memory
+
+A memory-efficient implementation using `hypermodeinc/ristretto` that provides cost-aware eviction based on actual memory usage. Unlike the basic in-memory backend, it calculates the memory footprint of each cache entry and uses this for eviction decisions. Useful when memory usage patterns vary significantly across different keys.
+
+### Redis
+
+A distributed backend that can be shared by multiple indexer replicas. Offers scalability and persistence, but may be overkill given the short lifetime of most KV-cache blocks.
+
+### Valkey
+
+A Redis-compatible, open-source alternative under the BSD license. Provides the same distributed capabilities as Redis with additional RDMA support for reduced latency. API-compatible with Redis, so it can be used as a drop-in replacement.
+
+-----
+
+## KV-Event Processing
+
+The `kvevents` package handles ingestion and processing of KV-cache events streamed from vLLM pods, keeping the block index up to date in near-real-time.
+
+### Engine Keys vs. Request Keys
+
+The index maintains two types of block keys:
+
+- **Engine keys**: Opaque block hashes produced by vLLM's engine and carried inside `KVEvents`. These arrive in `BlockStored` and `BlockRemoved` events.
+- **Request keys**: Deterministic hashes computed by the library from the event's token IDs using the same FNV-64a + CBOR scheme used in the read path (see [Block Hashing](#block-hashing--key-generation) above).
+
+When a `BlockStored` event arrives, the library resolves the parent engine hash to its request key (via the index), then recomputes request keys from the tokens. Both the engine-to-request key mapping and the request-key-to-pod entries are stored. `BlockRemoved` events reference engine keys, which are resolved to request keys through the stored mapping.
+
+This design decouples the index from vLLM's internal hash implementation: the read path computes request keys from a prompt's tokens, and the write path independently computes the same request keys from the event's tokens, so the two always agree on block identity without depending on engine hash stability.
+
+### Event Processing Pool
+
+The `kvevents.Pool` is a sharded worker pool that consumes ZMQ messages from vLLM pods.
+
+**Message flow:**
+
+1. A `zmqSubscriber` receives a ZMQ message and parses the topic (`kv@pod-id@model`) to extract the pod identifier and model name.
+2. The pool hashes the pod identifier (FNV-1a) to select a worker shard. This guarantees that events from the same pod are always processed in order.
+3. The worker decodes the msgpack payload (which can contain a batch of events), recomputes request keys from the event tokens, and updates the index.
+
+**Event types:**
+
+| Event | Data | Action |
+|:------|:-----|:-------|
+| `BlockStored` | Engine block hashes, parent hash, token IDs, device tier, LoRA metadata | Recompute request keys from tokens; store engine→request mapping and request→pod entries |
+| `BlockRemoved` | Engine block hash | Resolve to request key; evict pod entry |
+| `AllBlocksCleared` | - | No-op (pod-level cleanup) |
+
+### Pod Discovery
+
+The pool supports two modes for connecting to vLLM pods:
+
+**Static Endpoint Mode** - Connects to a single ZMQ endpoint. Useful for development or when a ZMQ proxy aggregates events.
+
+**Auto-Discovery Mode (Default)** - Uses a Kubernetes pod reconciler to automatically discover vLLM pods and create per-pod ZMQ subscribers.
+The reconciler watches pods matching a label selector and manages subscriber lifecycle based on pod readiness.
+
+A pod must meet all of the following conditions for a subscriber to be created:
+- Labels match the configured `podLabelSelector`
+- `pod.Status.Phase == Running`
+- `pod.Status.PodIP != ""`
+- Pod has condition `PodReady == ConditionTrue`
+
+When any condition becomes false, the subscriber is automatically removed.
+
+-----
+
+## Configuration
+
+See [Configuration](configuration.md) for all indexer, block index, and event processing options including pod discovery settings and RBAC requirements.

--- a/docs/tokenization.md
+++ b/docs/tokenization.md
@@ -1,0 +1,85 @@
+# Tokenization
+
+Tokenization and prompt preprocessing for the KV-Cache subsystem. This component includes a Go tokenizer pool with pluggable backends,
+a Python gRPC sidecar, and vLLM-compatible chat template rendering.
+
+See [Architecture](architecture.md) for how tokenization fits into the scoring (read) path.
+
+-----
+
+## Tokenization Pool
+
+The `tokenization.Pool` (`pkg/tokenization/`) manages a configurable number of worker goroutines for tokenization requests.
+The tokenization output feeds into the `kvblock.TokenProcessor` for block key generation (see [Indexer](indexer.md)).
+
+It supports two modes:
+
+- **Synchronous**: Used by scoring requests to ensure complete results are always returned.
+- **Asynchronous** (fire-and-forget): Used for background/preemptive tokenization.
+
+-----
+
+## Tokenizer Backends
+
+The system supports multiple tokenizer backends with a composite fallback strategy.
+
+### CachedLocalTokenizer
+
+Loads tokenizers from local files on disk. Useful for air-gapped environments, custom tokenizers, or pre-loaded models.
+
+Supports:
+- **Manual Configuration**: Direct mapping from model names to tokenizer file paths.
+- **Auto-Discovery**: Recursive scanning of a directory for tokenizer files.
+- **HuggingFace Cache Structure**: Automatically detects and parses HF cache directories (e.g., `models--Qwen--Qwen3-0.6B/snapshots/{hash}/tokenizer.json` → `Qwen/Qwen3-0.6B`).
+- **Custom Directory Structures**: Arbitrary nesting (e.g., `/mnt/models/org/model/tokenizer.json` → `org/model`).
+
+### CachedHFTokenizer
+
+Downloads and caches tokenizers from HuggingFace Hub. Wraps HuggingFace's Rust tokenizers and maintains an LRU cache of active instances.
+
+### UDS Tokenizer Client
+
+Delegates tokenization to the UDS Tokenizer Service (see below) over gRPC via Unix Domain Sockets.
+This avoids the need for embedded Python/cgo tokenizers in the Go process.
+
+### CompositeTokenizer (Default)
+
+Tries backends in order, enabling graceful fallback. The default configuration attempts local tokenizers first, then falls back to HuggingFace if the model isn't found locally.
+
+### Caching
+
+All tokenizer implementations maintain an LRU cache of loaded tokenizer instances to minimize repeated loading from disk.
+
+-----
+
+## UDS Tokenizer Service
+
+**Python service** - [`services/uds_tokenizer/`](../services/uds_tokenizer/)
+
+A sidecar service that provides tokenization and chat template rendering via gRPC over Unix Domain Sockets.
+Designed to run alongside the inference scheduler in Kubernetes, it eliminates the need for embedded Python/cgo tokenizers in the Go process.
+
+The service supports HuggingFace and ModelScope models, with automatic downloading and caching.
+It exposes a health check endpoint for Kubernetes probes.
+
+See the [UDS Tokenizer README](../services/uds_tokenizer/README.md) for setup, API reference, environment variables, and Kubernetes deployment.
+
+-----
+
+## Chat Completions Preprocessing
+
+**Go/Python (cgo)** - [`pkg/preprocessing/chat_completions/`](../pkg/preprocessing/chat_completions/)
+
+Applies vLLM-compatible chat template rendering so that `/v1/chat/completions` requests can be preprocessed before scoring.
+Uses a Python binding under the hood to match vLLM's Jinja2 templating behavior exactly.
+
+This is required when the indexer needs to score chat-format requests - the messages must first be rendered into a flat prompt string
+before tokenization and block key generation can proceed.
+
+-----
+
+## Configuration
+
+See [Configuration - Tokenization](configuration.md#tokenization-configuration) for all options including pool size, backend selection, and auto-discovery settings.
+
+For UDS Tokenizer Service configuration, see the [UDS Tokenizer README](../services/uds_tokenizer/README.md#environment-variables).

--- a/examples/valkey_example/README.md
+++ b/examples/valkey_example/README.md
@@ -159,5 +159,5 @@ When RDMA support becomes available, it will require migrating from `go-redis/re
 ## See Also
 
 - [Valkey Configuration Guide](../valkey_configuration.md)
-- [KV-Cache Architecture](../../docs/architecture.md)
+- [Architecture](../../docs/architecture.md)
 - [Configuration Reference](../../docs/configuration.md)


### PR DESCRIPTION
## Summary

The current repository README and documentation are still focused on KV-cache indexing, which has become only one component of the libraries provided here since a while. This PR updates documentation across the repository to better reflect the current scope and state