### PR TITLE
fix: increase gRPC keepalive ping interval to match server minimum

### DIFF
--- a/pkg/tokenization/uds_tokenizer.go
+++ b/pkg/tokenization/uds_tokenizer.go
@@ -77,7 +77,7 @@ func NewUdsTokenizer(ctx context.Context, config *UdsTokenizerConfig, modelName 
 		address,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                10 * time.Second,
+			Time:                5 * time.Minute,
 			Timeout:             time.Second,
 			PermitWithoutStream: true,
 		}),


### PR DESCRIPTION
The gRPC client was sending keepalive pings every 10 seconds, but the uds-tokenizer server enforces a 5-minute minimum between pings (grpc.http2.min_time_between_pings_ms=300000). This mismatch caused the server to send GOAWAY with ENHANCE_YOUR_CALM (too_many_pings).

Increase the client keepalive Time from 10s to 5m to align with the server's enforcement policy.

Closes #359