### PR TITLE
Ignore large reformatting PRs in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# Commits to ignore in git blame
+
+# 2026-02-26 Remove services/ exclusion from pre-commit checks (#362)
+e5338a369bacd92f27379edd2933660a7ecbd8d9
+
+# 2026-02-24 build: Add pre-commit checks to CI (#342)
+10df45fa8bd0ab58ca8f246a540bafb0049f142d

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -39,6 +39,7 @@ header:
     - "**/*.cu"
     - "**/*.cuh"
     - ".gitignore"
+    - ".git-blame-ignore-revs"
     - "LICENSE"
     - "NOTICE"
     - "CODEOWNERS"


### PR DESCRIPTION
Add `.git-blame-ignore-revs` file to the repository. This file allows `git blame` to skip commits that only contain formatting or style changes (such as those from pre-commit hooks). This makes it easier to find the actual meaningful changes when investigating code history.

Relate: https://github.com/llm-d/llm-d-kv-cache/pull/342#issuecomment-3950780861
Pending by: #362
