### PR TITLE
perf: cache ZMQ topic parsing to avoid re-parsing on every message

### DIFF
--- a/pkg/kvevents/zmq_subscriber.go
+++ b/pkg/kvevents/zmq_subscriber.go
@@ -39,6 +39,13 @@ type zmqSubscriber struct {
 	endpoint    string
 	remote      bool
 	topicFilter string
+
+	// Cached topic parsing results. Since a subscriber typically receives
+	// messages with the same topic repeatedly, we cache the last parsed
+	// result to avoid re-parsing on every message.
+	lastTopic         string
+	lastPodIdentifier string
+	lastModelName     string
 }
 
 // newZMQSubscriber creates a new ZMQ subscriber.
@@ -126,48 +133,75 @@ func (z *zmqSubscriber) runSubscriber(ctx context.Context) {
 			break // Exit on poll error to reconnect
 		}
 
-		if len(polled) > 0 {
-			parts, err := sub.RecvMessageBytes(0)
-			if err != nil {
-				debugLogger.Error(err, "Failed to receive message from zmq subscriber", "endpoint", z.endpoint)
-				break // Exit on receive error to reconnect
-			}
-			if len(parts) != 3 {
-				debugLogger.Error(err, "Failed to receive message from zmq subscriber", "endpoint", z.endpoint)
-				continue
-			}
-			topic := string(parts[0])
-			seqBytes := parts[1]
-			payload := parts[2]
-
-			seq := binary.BigEndian.Uint64(seqBytes)
-
-			// Extract pod identifier from topic, assuming "kv@<pod-id>@<model-name>" format
-			// TODO: optimize this to not occur for every message
-			topicParts := strings.Split(topic, "@")
-			var podIdentifier, modelName string
-			if len(topicParts) == 3 {
-				podIdentifier = topicParts[1]
-				modelName = topicParts[2]
-			} else {
-				debugLogger.Error(nil, "Failed to extract identifiers from topic, expected format kv@<pod-id>@<model-name>", "topic", topic)
-				continue // Useless if we can't extract pod identifier
-			}
-
-			debugLogger.V(logging.TRACE).Info("Received message from zmq subscriber",
-				"topic", topic,
-				"seq", seq,
-				"podIdentifier", podIdentifier,
-				"modelName", modelName,
-				"payloadSize", len(payload))
-
-			z.pool.AddTask(&Message{
-				Topic:         topic,
-				Payload:       payload,
-				Seq:           seq,
-				PodIdentifier: podIdentifier,
-				ModelName:     modelName,
-			})
+		if len(polled) == 0 {
+			continue
 		}
+
+		parts, err := sub.RecvMessageBytes(0)
+		if err != nil {
+			debugLogger.Error(err, "Failed to receive message from zmq subscriber", "endpoint", z.endpoint)
+			break // Exit on receive error to reconnect
+		}
+		if len(parts) != 3 {
+			debugLogger.Error(nil, "Unexpected message format from zmq subscriber, expected 3 parts", "parts", len(parts))
+			continue
+		}
+
+		topic := string(parts[0])
+		seq := binary.BigEndian.Uint64(parts[1])
+		payload := parts[2]
+
+		// Extract pod identifier from topic, assuming "kv@<pod-id>@<model-name>" format.
+		// Cache the result so repeated identical topics skip parsing.
+		podIdentifier, modelName, ok := z.resolveTopicIdentifiers(topic)
+		if !ok {
+			debugLogger.Error(nil, "Failed to extract identifiers from topic, expected format kv@<pod-id>@<model-name>", "topic", topic)
+			continue
+		}
+
+		debugLogger.V(logging.TRACE).Info("Received message from zmq subscriber",
+			"topic", topic,
+			"seq", seq,
+			"podIdentifier", podIdentifier,
+			"modelName", modelName,
+			"payloadSize", len(payload))
+
+		z.pool.AddTask(&Message{
+			Topic:         topic,
+			Payload:       payload,
+			Seq:           seq,
+			PodIdentifier: podIdentifier,
+			ModelName:     modelName,
+		})
 	}
+}
+
+// resolveTopicIdentifiers returns the pod identifier and model name for a topic,
+// using cached values when the topic matches the previous call.
+//
+//nolint:nonamedreturns // gocritic requires named results.
+func (z *zmqSubscriber) resolveTopicIdentifiers(topic string) (podID, model string, ok bool) {
+	if topic == z.lastTopic {
+		return z.lastPodIdentifier, z.lastModelName, true
+	}
+	podIdentifier, modelName, ok := parseTopic(topic)
+	if !ok {
+		return "", "", false
+	}
+	z.lastTopic = topic
+	z.lastPodIdentifier = podIdentifier
+	z.lastModelName = modelName
+	return podIdentifier, modelName, true
+}
+
+// parseTopic extracts the pod identifier and model name from a ZMQ topic string.
+// It expects the format "kv@<pod-id>@<model-name>".
+//
+//nolint:nonamedreturns // gocritic requires named results.
+func parseTopic(topic string) (podID, model string, ok bool) {
+	parts := strings.Split(topic, "@")
+	if len(parts) != 3 {
+		return "", "", false
+	}
+	return parts[1], parts[2], true
 }

--- a/pkg/kvevents/zmq_subscriber_test.go
+++ b/pkg/kvevents/zmq_subscriber_test.go
@@ -1,0 +1,138 @@
+// Copyright 2025 The llm-d Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvevents //nolint:testpackage // testing unexported parseTopic and zmqSubscriber internals.
+
+import (
+	"testing"
+)
+
+func TestParseTopic(t *testing.T) {
+	tests := []struct {
+		name      string
+		topic     string
+		wantPod   string
+		wantModel string
+		wantOK    bool
+	}{
+		{
+			name:      "valid topic",
+			topic:     "kv@pod-123@meta-llama/Llama-3.1-8B-Instruct",
+			wantPod:   "pod-123",
+			wantModel: "meta-llama/Llama-3.1-8B-Instruct",
+			wantOK:    true,
+		},
+		{
+			name:      "valid topic with simple names",
+			topic:     "kv@mypod@mymodel",
+			wantPod:   "mypod",
+			wantModel: "mymodel",
+			wantOK:    true,
+		},
+		{
+			name:   "model name containing @",
+			topic:  "kv@pod-1@model@extra",
+			wantOK: false,
+		},
+		{
+			name:   "missing model name",
+			topic:  "kv@pod-123",
+			wantOK: false,
+		},
+		{
+			name:   "no separator",
+			topic:  "kvpod123model",
+			wantOK: false,
+		},
+		{
+			name:   "empty string",
+			topic:  "",
+			wantOK: false,
+		},
+		{
+			name:      "empty pod and model",
+			topic:     "kv@@",
+			wantPod:   "",
+			wantModel: "",
+			wantOK:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod, model, ok := parseTopic(tt.topic)
+			if ok != tt.wantOK {
+				t.Errorf("parseTopic(%q) ok = %v, want %v", tt.topic, ok, tt.wantOK)
+				return
+			}
+			if !ok {
+				return
+			}
+			if pod != tt.wantPod {
+				t.Errorf("parseTopic(%q) pod = %q, want %q", tt.topic, pod, tt.wantPod)
+			}
+			if model != tt.wantModel {
+				t.Errorf("parseTopic(%q) model = %q, want %q", tt.topic, model, tt.wantModel)
+			}
+		})
+	}
+}
+
+func TestTopicCaching(t *testing.T) {
+	sub := &zmqSubscriber{}
+
+	// First call should parse and cache
+	topic := "kv@pod-1@model-a"
+	pod, model, ok := parseTopic(topic)
+	if !ok {
+		t.Fatal("expected parseTopic to succeed")
+	}
+	sub.lastTopic = topic
+	sub.lastPodIdentifier = pod
+	sub.lastModelName = model
+
+	if sub.lastPodIdentifier != "pod-1" || sub.lastModelName != "model-a" {
+		t.Errorf("unexpected cached values: pod=%q model=%q", sub.lastPodIdentifier, sub.lastModelName)
+	}
+
+	// Same topic should hit cache
+	if topic != sub.lastTopic {
+		t.Error("expected cache hit for same topic")
+	}
+
+	// Different topic should miss cache and update
+	topic2 := "kv@pod-2@model-b"
+	if topic2 == sub.lastTopic {
+		t.Error("expected cache miss for different topic")
+	}
+	pod2, model2, ok2 := parseTopic(topic2)
+	if !ok2 {
+		t.Fatal("expected parseTopic to succeed for topic2")
+	}
+	sub.lastTopic = topic2
+	sub.lastPodIdentifier = pod2
+	sub.lastModelName = model2
+
+	if sub.lastPodIdentifier != "pod-2" || sub.lastModelName != "model-b" {
+		t.Errorf("unexpected cached values after update: pod=%q model=%q", sub.lastPodIdentifier, sub.lastModelName)
+	}
+}
+
+func BenchmarkParseTopic(b *testing.B) {
+	topic := "kv@vllm-pod-abc123@meta-llama/Llama-3.1-8B-Instruct"
+	b.ReportAllocs()
+	for b.Loop() {
+		parseTopic(topic)
+	}
+}


### PR DESCRIPTION
- Cache parsed topic results (`podIdentifier`, `modelName`) on the `zmqSubscriber` struct so repeated identical topics skip parsing entirely
- Extract inline topic parsing logic into a dedicated `parseTopic()` function for testability
- Add unit tests and benchmark for `parseTopic`

Test with following code

```go
package kvevents

import (
	"strings"
	"testing"
)

// BenchmarkParseTopicUncached benchmarks the old approach: strings.Split on every message.
func BenchmarkParseTopicUncached(b *testing.B) {
	topic := "kv@vllm-pod-abc123@meta-llama/Llama-3.1-8B-Instruct"
	b.ReportAllocs()
	for b.Loop() {
		topicParts := strings.Split(topic, "@")
		if len(topicParts) == 3 {
			_ = topicParts[1]
			_ = topicParts[2]
		}
	}
}

// BenchmarkParseTopicCached benchmarks the new approach: cache hit with repeated identical topics.
func BenchmarkParseTopicCached(b *testing.B) {
	topic := "kv@vllm-pod-abc123@meta-llama/Llama-3.1-8B-Instruct"
	sub := &zmqSubscriber{}
	pod, model, _ := parseTopic(topic)
	sub.lastTopic = topic
	sub.lastPodIdentifier = pod
	sub.lastModelName = model

	b.ReportAllocs()
	b.ResetTimer()
	for b.Loop() {
		if topic == sub.lastTopic {
			_ = sub.lastPodIdentifier
			_ = sub.lastModelName
		}
	}
}
```
```console
% go test ./pkg/kvevents/ -bench "ParseTopic" -benchmem
goos: darwin
goarch: arm64
pkg: github.com/llm-d/llm-d-kv-cache/pkg/kvevents
cpu: Apple M4 Pro
BenchmarkParseTopicUncached-14    	40701091	        29.44 ns/op	      48 B/op	       1 allocs/op
BenchmarkParseTopicCached-14      	748502797	         1.605 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/llm-d/llm-d-kv-cache/pkg/kvevents	3.300s

```
