### PR TITLE
Lower the tokenizer gRPC server's min ping enforcement

### DIFF
--- a/pkg/tokenization/uds_tokenizer.go
+++ b/pkg/tokenization/uds_tokenizer.go
@@ -105,8 +105,8 @@ func NewUdsTokenizer(ctx context.Context, config *UdsTokenizerConfig, modelName 
 		address,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                5 * time.Minute,
-			Timeout:             time.Second,
+			Time:                10 * time.Minute,
+			Timeout:             10 * time.Second,
 			PermitWithoutStream: true,
 		}),
 		grpc.WithDefaultCallOptions(

--- a/services/uds_tokenizer/tokenizer_grpc_service.py
+++ b/services/uds_tokenizer/tokenizer_grpc_service.py
@@ -148,8 +148,8 @@ def create_grpc_server(
             ("grpc.keepalive_timeout_ms", 20000),  # 20 seconds
             ("grpc.keepalive_permit_without_calls", 1),
             ("grpc.http2.max_pings_without_data", 0),
-            ("grpc.http2.min_time_between_pings_ms", 300000),
-            ("grpc.http2.min_ping_interval_without_data_ms", 300000),
+            ("grpc.http2.min_time_between_pings_ms", 10000),  # 10s - tolerate frequent pings from Envoy/Istio sidecars
+            ("grpc.http2.min_ping_interval_without_data_ms", 10000),
             ("grpc.http2.max_frame_size", 8192),
             (
                 "grpc.max_concurrent_streams",


### PR DESCRIPTION
This works for me with: `quay.io/grpereir/uds-tokenizer:fix-keepalive`
cc @pierDipi @zdtsw @vMaroon @elevran 

The core issue was a mismatch between how fast pings were arriving at the tokenizer gRPC server vs. how fast the server was willing to accept them. Now the server tolerates pings as frequent as every 10 seconds, which accommodates whatever Envoy sends. This is why fixing the Go client's keepalive parameters alone wouldn't have solved it — the pings weren't coming from the Go client, they were coming from the Envoy sidecar.