### PR TITLE
fix: Add early stop on key miss in InMemoryIndex and CostAwareMemorIndex Lookup

### DIFF
--- a/pkg/kvcache/kvblock/cost_aware_memory.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory.go
@@ -242,7 +242,8 @@ func (m *CostAwareMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHa
 				})
 			}
 		} else {
-			traceLogger.Info("key not found in index", "key", key)
+			traceLogger.Info("key not found in index, cutting search", "key", key)
+			return podsPerKey, nil // early stop since prefix-chain breaks here
 		}
 	}
 

--- a/pkg/kvcache/kvblock/cost_aware_memory_test.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory_test.go
@@ -75,14 +75,20 @@ func TestCostAwareIndexSize(t *testing.T) {
 	err = index.Add(ctx, []BlockHash{engineKey3}, []BlockHash{requestKey3}, []PodEntry{{PodIdentifier: "pod3", DeviceTier: "cpu"}})
 	require.NoError(t, err)
 
-	// Lookup should only return the last two keys
-	podsPerKey, err := index.Lookup(ctx, []BlockHash{requestKey1, requestKey2, requestKey3}, nil)
+	// Verify evicted keys are gone (lookup individually to avoid prefix-chain early stop)
+	podsKey1, err := index.Lookup(ctx, []BlockHash{requestKey1}, nil)
 	require.NoError(t, err)
+	assert.Empty(t, podsKey1, "key1 should have been evicted")
 
-	assert.Len(t, podsPerKey, 1) // Only requestKey3 should be present
-	assert.Len(t, podsPerKey[requestKey3], 1)
+	podsKey2, err := index.Lookup(ctx, []BlockHash{requestKey2}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, podsKey2, "key2 should have been evicted")
 
-	assert.Contains(t, podsPerKey[requestKey3], PodEntry{PodIdentifier: "pod3", DeviceTier: "cpu"})
+	// Only requestKey3 should be present
+	podsKey3, err := index.Lookup(ctx, []BlockHash{requestKey3}, nil)
+	require.NoError(t, err)
+	assert.Len(t, podsKey3[requestKey3], 1)
+	assert.Contains(t, podsKey3[requestKey3], PodEntry{PodIdentifier: "pod3", DeviceTier: "cpu"})
 }
 
 func TestSizeHumanize(t *testing.T) {

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -135,7 +135,8 @@ func (m *InMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 				}
 			}
 		} else {
-			traceLogger.Info("key not found in index", "key", requestKey)
+			traceLogger.Info("key not found in index, cutting search", "key", requestKey)
+			return podsPerKey, nil // early stop since prefix-chain breaks here
 		}
 	}
 

--- a/pkg/kvcache/kvblock/in_memory_test.go
+++ b/pkg/kvcache/kvblock/in_memory_test.go
@@ -72,15 +72,21 @@ func TestInMemoryIndexSize(t *testing.T) {
 	err = index.Add(ctx, []BlockHash{engineKey3}, []BlockHash{requestKey3}, []PodEntry{{PodIdentifier: "pod3", DeviceTier: "cpu"}})
 	require.NoError(t, err)
 
-	// Lookup should only return the last two keys
-	podsPerKey, err := index.Lookup(ctx, []BlockHash{requestKey1, requestKey2, requestKey3}, nil)
+	// Verify key1 was evicted by LRU (lookup individually to avoid prefix-chain early stop)
+	podsKey1, err := index.Lookup(ctx, []BlockHash{requestKey1}, nil)
 	require.NoError(t, err)
+	assert.Empty(t, podsKey1, "key1 should have been evicted by LRU")
 
-	assert.Len(t, podsPerKey, 2) // Only key2 and key3 should be present
-	assert.Len(t, podsPerKey[requestKey2], 1)
-	assert.Len(t, podsPerKey[requestKey3], 1)
-	assert.Contains(t, podsPerKey[requestKey2], PodEntry{PodIdentifier: "pod2", DeviceTier: "gpu"})
-	assert.Contains(t, podsPerKey[requestKey3], PodEntry{PodIdentifier: "pod3", DeviceTier: "cpu"})
+	// Verify key2 and key3 are still present
+	podsKey2, err := index.Lookup(ctx, []BlockHash{requestKey2}, nil)
+	require.NoError(t, err)
+	assert.Len(t, podsKey2[requestKey2], 1)
+	assert.Contains(t, podsKey2[requestKey2], PodEntry{PodIdentifier: "pod2", DeviceTier: "gpu"})
+
+	podsKey3, err := index.Lookup(ctx, []BlockHash{requestKey3}, nil)
+	require.NoError(t, err)
+	assert.Len(t, podsKey3[requestKey3], 1)
+	assert.Contains(t, podsKey3[requestKey3], PodEntry{PodIdentifier: "pod3", DeviceTier: "cpu"})
 }
 
 func TestInMemoryIndexPodCacheSize(t *testing.T) {


### PR DESCRIPTION
`InMemoryIndex.Lookup` and `CostAwareMemoryIndex.Lookup` were missing an early stop when a key was not found in the index. Per the `Index` interface contract, keys form a prefix-chain: if `key[i]` does not exist, `key[i+1], key[i+2], ...` cannot exist either. The code already handled early stop when a key was found but had no pods, but continued iterating when a key was entirely missing, causing unnecessary work on long key lists.

/cc @vMaroon 