### PR TITLE
fix: Close race window in InMemoryIndex.Evict double-check

### DIFF
--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -241,18 +241,15 @@ func (m *InMemoryIndex) Evict(ctx context.Context, engineKey BlockHash, entries 
 
 	// Remove key from main cache if empty
 	if isEmpty {
-		// Double-check after getting the cache again to MINIMIZE race window
-		// Worst case, we leave an empty cache behind which would be cleaned up by LRU if needed
+		// Re-fetch and hold the lock through removal to prevent racing with Add
 		if currentCache, stillExists := m.data.Get(requestKey); stillExists && currentCache != nil {
 			currentCache.mu.Lock()
-			stillEmpty := currentCache.cache.Len() == 0
-			currentCache.mu.Unlock()
-
-			if stillEmpty {
+			if currentCache.cache.Len() == 0 {
 				m.data.Remove(requestKey)
 				m.engineToRequestKeys.Remove(engineKey)
 				traceLogger.Info("removed requestKey from index as no pods remain", "requestKey", requestKey, "engineKey", engineKey)
 			}
+			currentCache.mu.Unlock()
 		}
 	}
 


### PR DESCRIPTION
Fixed a race condition in `InMemoryIndex.Evict` where `m.data.Remove(requestKey)` was executed after releasing `currentCache.mu`, creating a window where another goroutine could `Add` new entries that would then be silently dropped.

```go
	podCache.mu.Lock()
	for _, entry := range entries {
		podCache.cache.Remove(entry)
	}
	isEmpty := podCache.cache.Len() == 0
	podCache.mu.Unlock()                     // unlock

	if isEmpty {
		// ...
		if currentCache, stillExists := m.data.Get(requestKey); stillExists && currentCache != nil {
			currentCache.mu.Lock()
			stillEmpty := currentCache.cache.Len() == 0
			currentCache.mu.Unlock()           // unlock

			if stillEmpty {
				m.data.Remove(requestKey)      // Another goroutine could `Add` new entries that would then be silently dropped.
			}
		}
	}
```