### PR TITLE
perf: Use strings.Builder in podsPerKeyPrintHelper to avoid O(n²) string concatenation

### DIFF
--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -19,6 +19,7 @@ package kvblock
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -271,12 +272,11 @@ func (m *InMemoryIndex) GetRequestKey(ctx context.Context, engineKey BlockHash) 
 
 // podsPerKeyPrintHelper formats a map of keys to pod names for printing.
 func podsPerKeyPrintHelper(ks map[BlockHash][]PodEntry) string {
-	flattened := ""
+	var b strings.Builder
 	for k, v := range ks {
-		flattened += fmt.Sprintf("%s: %v\n", k.String(), utils.SliceMap(v, func(pod PodEntry) string {
+		fmt.Fprintf(&b, "%s: %v\n", k.String(), utils.SliceMap(v, func(pod PodEntry) string {
 			return pod.String()
 		}))
 	}
-
-	return flattened
+	return b.String()
 }


### PR DESCRIPTION
- Replace `string +=` concatenation with `strings.Builder` in `podsPerKeyPrintHelper` to eliminate O(n²) copying and repeated heap allocations.
- Go strings are immutable, so each `+=` allocates a new string and copies all previous content. `strings.Builder` appends to an internal `[]byte` buffer with amortized O(1) writes, reducing total copy cost from O(n²) to O(n) and allocation count from O(n) to O(log n).