### PR TITLE
Add consecutive match count tracking to KV-cache scorer API

### DIFF
--- a/examples/kv_cache_aware_scorer/kvcache_aware_scorer.go
+++ b/examples/kv_cache_aware_scorer/kvcache_aware_scorer.go
@@ -220,12 +220,12 @@ func (s *PrecisePrefixCacheScorer) Score(ctx context.Context, cycleState *types.
 		return nil
 	}
 
-	scores, err := s.getScores(ctx, request)
+	scoreResult, err := s.getScores(ctx, request)
 	if err != nil {
 		logger.Error(err, "Failed to get pod scores")
 		return nil
 	}
-	debugLogger.Info("Got pod scores", "scores", scores)
+	debugLogger.Info("Got pod scores", "scores", scoreResult.Scores)
 
 	podToKey := func(pod types.Pod) (string, bool) {
 		metricsPod := pod.GetPod()
@@ -245,18 +245,18 @@ func (s *PrecisePrefixCacheScorer) Score(ctx context.Context, cycleState *types.
 		if !ok {
 			continue
 		}
-		state.PrefixCacheServers[prefix.ServerID(pod.GetPod().NamespacedName)] = int(scores[key])
+		state.PrefixCacheServers[prefix.ServerID(pod.GetPod().NamespacedName)] = int(scoreResult.Scores[key])
 	}
 	cycleState.Write(plugins.StateKey(s.typedName.String()), state)
 
-	return indexedScoresToNormalizedScoredPods(pods, podToKey, scores)
+	return indexedScoresToNormalizedScoredPods(pods, podToKey, scoreResult.Scores)
 }
 
 // getScores retrieves the pod scores from the KV-cache indexer
 // based on the provided LLM request.
 // If the request contains chat completions, it processes them accordingly.
 // If the request contains regular completions, it uses the prompt directly.
-func (s *PrecisePrefixCacheScorer) getScores(ctx context.Context, request *types.LLMRequest) (map[string]float64, error) {
+func (s *PrecisePrefixCacheScorer) getScores(ctx context.Context, request *types.LLMRequest) (*kvcache.PodScoreResult, error) {
 	logger := log.FromContext(ctx).WithName(s.typedName.String())
 	traceLogger := logger.V(logutil.TRACE)
 
@@ -295,11 +295,11 @@ func (s *PrecisePrefixCacheScorer) getScores(ctx context.Context, request *types
 			"toolsCount", len(renderReq.Tools),
 			"documentsCount", len(renderReq.Documents))
 
-		scores, err := s.kvCacheIndexer.GetPodScores(ctx, renderReq, "", request.TargetModel, nil)
+		result, err := s.kvCacheIndexer.GetPodScores(ctx, renderReq, "", request.TargetModel, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get pod scores for chat/completions: %w", err)
 		}
-		return scores, nil
+		return result, nil
 	}
 
 	// For regular completions, use the prompt directly
@@ -307,11 +307,11 @@ func (s *PrecisePrefixCacheScorer) getScores(ctx context.Context, request *types
 		prompt := request.Body.Completions.Prompt
 		traceLogger.Info("Using completion prompt directly", "promptLength", len(prompt))
 
-		scores, err := s.kvCacheIndexer.GetPodScores(ctx, nil, prompt, request.TargetModel, nil)
+		result, err := s.kvCacheIndexer.GetPodScores(ctx, nil, prompt, request.TargetModel, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get pod scores for completions: %w", err)
 		}
-		return scores, nil
+		return result, nil
 	}
 
 	return nil, errors.New("no valid input found in request")

--- a/examples/kv_cache_index/main.go
+++ b/examples/kv_cache_index/main.go
@@ -135,13 +135,13 @@ func runPrompts(ctx context.Context, kvCacheIndexer *kvcache.Indexer) error {
 	logger.Info("Started Indexer", "model", modelName)
 
 	// Get pods for the prompt
-	pods, err := kvCacheIndexer.GetPodScores(ctx, testdata.RenderReq, testdata.Prompt, modelName, nil)
+	result, err := kvCacheIndexer.GetPodScores(ctx, testdata.RenderReq, testdata.Prompt, modelName, nil)
 	if err != nil {
 		return err
 	}
 
-	// Print the pods - should be empty because no tokenization
-	logger.Info("Got pods", "pods", pods)
+	// Print the result - should be empty because no tokenization
+	logger.Info("Got pod scores", "pods", result.Scores)
 
 	// Add entries in kvblock.Index manually
 	engineKeys := utils.SliceMap(testdata.PromptHashes, func(h uint64) kvblock.BlockHash {
@@ -159,12 +159,12 @@ func runPrompts(ctx context.Context, kvCacheIndexer *kvcache.Indexer) error {
 	time.Sleep(3 * time.Second)
 
 	// Get pods for the prompt
-	pods, err = kvCacheIndexer.GetPodScores(ctx, testdata.RenderReq, testdata.Prompt, modelName, nil)
+	result, err = kvCacheIndexer.GetPodScores(ctx, testdata.RenderReq, testdata.Prompt, modelName, nil)
 	if err != nil {
 		return err
 	}
 
-	// Print the pods - should be empty because no tokenization
-	logger.Info("Got pods", "pods", pods)
+	// Print the result - should be empty because no tokenization
+	logger.Info("Got pod scores", "pods", result.Scores)
 	return nil
 }

--- a/examples/kv_cache_index_service/server/main.go
+++ b/examples/kv_cache_index_service/server/main.go
@@ -82,11 +82,11 @@ func main() {
 	}
 
 	// Initial query - should be empty since no events have been published
-	pods, err := indexerSvc.indexer.GetPodScores(ctx, testdata.RenderReq, testdata.Prompt, testdata.ModelName, nil)
+	result, err := indexerSvc.indexer.GetPodScores(ctx, testdata.RenderReq, testdata.Prompt, testdata.ModelName, nil)
 	if err != nil {
 		logger.Error(err, "failed to get pod scores")
 	}
-	logger.Info("@@@ Initial pod scores (should be empty)", "pods", pods)
+	logger.Info("@@@ Initial pod scores (should be empty)", "scores", result.Scores)
 
 	// Simulate vLLM engine publishing some kvcache to storage
 	err = helper.SimulateProduceEvent(ctx, publisher)

--- a/examples/kv_cache_index_service/server/server.go
+++ b/examples/kv_cache_index_service/server/server.go
@@ -74,15 +74,15 @@ func (s *IndexerService) GetPodScores(ctx context.Context,
 	}
 
 	// Call the underlying indexer
-	podScores, err := s.indexer.GetPodScores(ctx, nil, req.Prompt, req.ModelName,
+	result, err := s.indexer.GetPodScores(ctx, nil, req.Prompt, req.ModelName,
 		req.PodIdentifiers)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pod scores: %w", err)
 	}
 
-	// Convert map[string]int to []*indexerpb.PodScore
-	scores := make([]*indexerpb.PodScore, 0, len(podScores))
-	for pod, score := range podScores {
+	// Convert map[string]float64 to []*indexerpb.PodScore
+	scores := make([]*indexerpb.PodScore, 0, len(result.Scores))
+	for pod, score := range result.Scores {
 		scores = append(scores, &indexerpb.PodScore{
 			Pod:   pod,
 			Score: score,

--- a/examples/kv_events/offline/main.go
+++ b/examples/kv_events/offline/main.go
@@ -169,11 +169,11 @@ func RunEventsDemo(ctx context.Context, kvCacheIndexer *kvcache.Indexer, publish
 	logger.Info("@@@ Starting KV Events Demo", "model", testdata.ModelName)
 
 	// Initial query - should be empty since no events have been published
-	pods, err := kvCacheIndexer.GetPodScores(ctx, testdata.RenderReq, testdata.Prompt, testdata.ModelName, nil)
+	result, err := kvCacheIndexer.GetPodScores(ctx, testdata.RenderReq, testdata.Prompt, testdata.ModelName, nil)
 	if err != nil {
 		return err
 	}
-	logger.Info("@@@ Initial pod scores (should be empty)", "pods", pods)
+	logger.Info("@@@ Initial pod scores (should be empty)", "scores", result.Scores)
 
 	// Simulate vLLM engine publishing BlockStored events
 	err = helper.SimulateProduceEvent(ctx, publisher)
@@ -182,11 +182,11 @@ func RunEventsDemo(ctx context.Context, kvCacheIndexer *kvcache.Indexer, publish
 	}
 
 	// Query again to see the effect of the events
-	pods, err = kvCacheIndexer.GetPodScores(ctx, testdata.RenderReq, testdata.Prompt, testdata.ModelName, nil)
+	result, err = kvCacheIndexer.GetPodScores(ctx, testdata.RenderReq, testdata.Prompt, testdata.ModelName, nil)
 	if err != nil {
 		return err
 	}
-	logger.Info("@@@ Pod scores after BlockStored events", "pods", pods)
+	logger.Info("@@@ Pod scores after BlockStored events", "scores", result.Scores)
 
 	// Simulate removing some blocks
 	err = helper.SimulateRemoveEvent(ctx, publisher)
@@ -195,11 +195,11 @@ func RunEventsDemo(ctx context.Context, kvCacheIndexer *kvcache.Indexer, publish
 	}
 
 	// Final query
-	pods, err = kvCacheIndexer.GetPodScores(ctx, testdata.RenderReq, testdata.Prompt, testdata.ModelName, nil)
+	result, err = kvCacheIndexer.GetPodScores(ctx, testdata.RenderReq, testdata.Prompt, testdata.ModelName, nil)
 	if err != nil {
 		return err
 	}
-	logger.Info("@@@ Final pod scores after BlockRemoved events", "pods", pods)
+	logger.Info("@@@ Final pod scores after BlockRemoved events", "scores", result.Scores)
 
 	logger.Info("Events demo completed. Pool continues listening for more events...")
 	logger.Info("Press Ctrl+C to shutdown")

--- a/examples/kv_events/online/main.go
+++ b/examples/kv_events/online/main.go
@@ -308,14 +308,14 @@ func setupUnifiedHTTPEndpoints(
 			return
 		}
 
-		pods, err := kvCacheIndexer.GetPodScores(ctx, nil, req.Prompt, req.Model, nil)
+		result, err := kvCacheIndexer.GetPodScores(ctx, nil, req.Prompt, req.Model, nil)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("error: %v", err), http.StatusInternalServerError)
 			return
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(pods); err != nil {
+		if err := json.NewEncoder(w).Encode(result.Scores); err != nil {
 			logger.Error(err, "failed to encode response")
 		}
 	})
@@ -334,14 +334,14 @@ func setupUnifiedHTTPEndpoints(
 			return
 		}
 
-		pods, err := kvCacheIndexer.GetPodScores(ctx, req.RenderChatRequest, "", req.Model, nil)
+		result, err := kvCacheIndexer.GetPodScores(ctx, req.RenderChatRequest, "", req.Model, nil)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Failed to get score request: %v", err), http.StatusInternalServerError)
 			return
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(pods); err != nil {
+		if err := json.NewEncoder(w).Encode(result.Scores); err != nil {
 			logger.Error(err, "Failed to encode score response")
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return

--- a/examples/valkey_example/main.go
+++ b/examples/valkey_example/main.go
@@ -141,12 +141,12 @@ func demonstrateValkeyOperations(ctx context.Context, indexer *kvcache.Indexer) 
 	logger.Info("Processing testdata prompt", "model", modelName, "promptLength", len(prompt))
 
 	// First, let's demonstrate basic scoring without any cache entries
-	scores, err := indexer.GetPodScores(ctx, nil, prompt, modelName, []string{"demo-pod-1", "demo-pod-2"})
+	result, err := indexer.GetPodScores(ctx, nil, prompt, modelName, []string{"demo-pod-1", "demo-pod-2"})
 	if err != nil {
 		return fmt.Errorf("failed to get pod scores: %w", err)
 	}
 
-	logger.Info("Initial cache scores (should be empty)", "scores", scores)
+	logger.Info("Initial cache scores (should be empty)", "scores", result.Scores)
 
 	// Now let's manually add some cache entries using the pre-calculated hashes from testdata
 	logger.Info("Adding cache entries manually to demonstrate Valkey backend")
@@ -167,12 +167,12 @@ func demonstrateValkeyOperations(ctx context.Context, indexer *kvcache.Indexer) 
 	logger.Info("Added cache entries", "keys", len(promptKeys), "pods", len(podEntries))
 
 	// Query for cache scores again
-	scores, err = indexer.GetPodScores(ctx, nil, prompt, modelName, []string{"demo-pod-1", "demo-pod-2"})
+	result, err = indexer.GetPodScores(ctx, nil, prompt, modelName, []string{"demo-pod-1", "demo-pod-2"})
 	if err != nil {
 		return fmt.Errorf("failed to get pod scores after adding entries: %w", err)
 	}
 
-	logger.Info("Cache scores after adding entries", "scores", scores)
+	logger.Info("Cache scores after adding entries", "scores", result.Scores)
 
 	// Demonstrate lookup functionality
 	logger.Info("Demonstrating cache lookup via Valkey backend")
@@ -202,12 +202,12 @@ func demonstrateValkeyOperations(ctx context.Context, indexer *kvcache.Indexer) 
 	logger.Info("Cache lookup after eviction", "keysFound", len(lookupAfterEvict))
 
 	// Final score check to see the difference
-	finalScores, err := indexer.GetPodScores(ctx, nil, prompt, modelName, []string{"demo-pod-1", "demo-pod-2"})
+	finalResult, err := indexer.GetPodScores(ctx, nil, prompt, modelName, []string{"demo-pod-1", "demo-pod-2"})
 	if err != nil {
 		return fmt.Errorf("failed to get final pod scores: %w", err)
 	}
 
-	logger.Info("Final cache scores", "scores", finalScores)
+	logger.Info("Final cache scores", "scores", finalResult.Scores)
 
 	return nil
 }

--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -70,6 +70,18 @@ type Indexer struct {
 	tokenizersPool TokenizersPool
 }
 
+// PodScoreResult contains the scoring results from GetPodScores.
+type PodScoreResult struct {
+	// Scores maps pod identifiers to their weighted scores.
+	// The weighted score is the sum of weights for consecutive matched blocks.
+	Scores map[string]float64
+	// ConsecutiveMatches maps pod identifiers to the number of consecutive
+	// blocks matched from the start (unweighted count).
+	ConsecutiveMatches map[string]int
+	// TotalBlocks is the total number of blocks in the request prompt.
+	TotalBlocks int
+}
+
 // NewKVCacheIndexer creates a KVCacheIndex given a Config.
 func NewKVCacheIndexer(ctx context.Context, config *Config, tokenProcessor kvblock.TokenProcessor) (*Indexer, error) {
 	if config == nil {
@@ -159,10 +171,11 @@ func (k *Indexer) ComputeBlockKeys(ctx context.Context, renderReq *types.RenderC
 // If the set of pod identifiers is empty, the function assumes all pods are
 // relevant.
 //
-// The function returns a map of pod identifiers to scores.
+// The function returns a PodScoreResult containing weighted scores, consecutive
+// match counts, and total blocks.
 func (k *Indexer) GetPodScores(ctx context.Context, renderReq *types.RenderChatRequest, prompt, modelName string,
 	podIdentifiers []string,
-) (map[string]float64, error) {
+) (*PodScoreResult, error) {
 	// 1. tokenize prompt
 	tokens := k.tokenizersPool.Tokenize(renderReq, prompt)
 
@@ -188,7 +201,7 @@ func (k *Indexer) ScoreTokens(
 	tokens []uint32,
 	modelName string,
 	podIdentifiers []string,
-) (map[string]float64, error) {
+) (*PodScoreResult, error) {
 	tracer := otel.Tracer(telemetry.InstrumentationName)
 	ctx, span := tracer.Start(ctx, "llm_d.kv_cache.score_tokens",
 		trace.WithSpanKind(trace.SpanKindInternal),
@@ -237,13 +250,18 @@ func (k *Indexer) ScoreTokens(
 		attribute.Int("llm_d.kv_cache.blocks_found", blocksFound),
 	)
 
-	podScores, err := k.kvBlockScorer.Score(ctx, blockKeys, keyToPods)
+	scorerResult, err := k.kvBlockScorer.Score(ctx, blockKeys, keyToPods)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return nil, fmt.Errorf("failed to query kvblock scorer: %w", err)
 	}
+	traceLogger.Info("found pod scores", "pod-scores", scorerResult.WeightedScores)
 
-	return podScores, nil
+	return &PodScoreResult{
+		Scores:             scorerResult.WeightedScores,
+		ConsecutiveMatches: scorerResult.ConsecutiveMatches,
+		TotalBlocks:        len(blockKeys),
+	}, nil
 }
 
 // podsPerKeyPrintHelper formats a map of keys to pod entries for printing.

--- a/pkg/kvcache/indexer_test.go
+++ b/pkg/kvcache/indexer_test.go
@@ -228,15 +228,17 @@ var scoringTests = []scoringTestCase{
 }
 
 // assertScores verifies that the returned scores match expectations.
-func assertScores(t *testing.T, tt *scoringTestCase, scores map[string]float64, err error) {
+func assertScores(t *testing.T, tt *scoringTestCase, result *kvcache.PodScoreResult, err error) {
 	t.Helper()
 	require.NoError(t, err)
 
 	if tt.wantNil {
-		assert.Nil(t, scores, "expected nil scores")
+		assert.Nil(t, result, "expected nil scores")
 		return
 	}
 
+	require.NotNil(t, result)
+	scores := result.Scores
 	require.Len(t, scores, len(tt.wantScores), "unexpected number of scored pods")
 	for pod, want := range tt.wantScores {
 		require.Contains(t, scores, pod, "missing pod %q in scores", pod)
@@ -304,10 +306,10 @@ func TestGetPodScores_TruncatePromptTokens(t *testing.T) {
 		TruncatePromptTokens: &truncateLimit,
 	}
 
-	scores, err := indexer.GetPodScores(ctx, renderReq, "", testModel, nil)
+	result, err := indexer.GetPodScores(ctx, renderReq, "", testModel, nil)
 	require.NoError(t, err)
-	require.Contains(t, scores, testPodA)
-	assert.InDelta(t, 3.0, scores[testPodA], 0.0001)
+	require.Contains(t, result.Scores, testPodA)
+	assert.InDelta(t, 3.0, result.Scores[testPodA], 0.0001)
 	assert.Equal(t, []uint32{300, 400, 500}, tp.receivedTokens,
 		"token processor should receive only the last 3 tokens after truncation")
 }
@@ -331,10 +333,10 @@ func TestGetPodScores_TruncateNoOp(t *testing.T) {
 		TruncatePromptTokens: &truncateLimit,
 	}
 
-	scores, err := indexer.GetPodScores(ctx, renderReq, "", testModel, nil)
+	result, err := indexer.GetPodScores(ctx, renderReq, "", testModel, nil)
 	require.NoError(t, err)
-	require.Contains(t, scores, testPodA)
-	assert.InDelta(t, 2.0, scores[testPodA], 0.0001)
+	require.Contains(t, result.Scores, testPodA)
+	assert.InDelta(t, 2.0, result.Scores[testPodA], 0.0001)
 	assert.Equal(t, []uint32{1, 2}, tp.receivedTokens,
 		"token processor should receive all tokens when limit exceeds count")
 }
@@ -357,10 +359,10 @@ func TestGetPodScores_TruncateZero(t *testing.T) {
 		TruncatePromptTokens: &truncateLimit,
 	}
 
-	scores, err := indexer.GetPodScores(ctx, renderReq, "", testModel, nil)
+	result, err := indexer.GetPodScores(ctx, renderReq, "", testModel, nil)
 	require.NoError(t, err)
-	require.Contains(t, scores, testPodA)
-	assert.InDelta(t, 2.0, scores[testPodA], 0.0001, "zero limit should not truncate")
+	require.Contains(t, result.Scores, testPodA)
+	assert.InDelta(t, 2.0, result.Scores[testPodA], 0.0001, "zero limit should not truncate")
 	assert.Equal(t, []uint32{1, 2}, tp.receivedTokens,
 		"token processor should receive all tokens when limit is zero")
 }

--- a/pkg/kvcache/kvblock_scorer.go
+++ b/pkg/kvcache/kvblock_scorer.go
@@ -45,15 +45,25 @@ func DefaultKVBlockScorerConfig() *KVBlockScorerConfig {
 	}
 }
 
+// ScorerResult contains the scoring results including both weighted scores
+// and unweighted consecutive match counts.
+type ScorerResult struct {
+	// WeightedScores maps pod identifiers to their weighted scores.
+	WeightedScores map[string]float64
+	// ConsecutiveMatches maps pod identifiers to the number of consecutive
+	// blocks matched from the start (unweighted count).
+	ConsecutiveMatches map[string]int
+}
+
 // KVBlockScorer defines the interface for implementing a KV block scoring
 // strategy.
 type KVBlockScorer interface {
 	// Strategy returns the scoring strategy type.
 	Strategy() KVScoringStrategy
 	// Score scores the blocks based on the scoring strategy.
-	// It returns a map of pod names to their scores.
+	// It returns both weighted scores and unweighted consecutive match counts.
 	Score(ctx context.Context, keys []kvblock.BlockHash,
-		keyToPods map[kvblock.BlockHash][]kvblock.PodEntry) (map[string]float64, error)
+		keyToPods map[kvblock.BlockHash][]kvblock.PodEntry) (*ScorerResult, error)
 }
 
 // NewKVBlockScorer creates a new KVBlockScorer based on the provided strategy.
@@ -107,12 +117,16 @@ func (s *LongestPrefixScorer) Score(
 	_ context.Context,
 	keys []kvblock.BlockHash,
 	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
-) (map[string]float64, error) {
-	if len(keys) == 0 {
-		return make(map[string]float64), nil
-	}
+) (*ScorerResult, error) {
+	weightedScores := make(map[string]float64)
+	consecutiveMatches := make(map[string]int)
 
-	podScores := make(map[string]float64)
+	if len(keys) == 0 {
+		return &ScorerResult{
+			WeightedScores:     make(map[string]float64),
+			ConsecutiveMatches: make(map[string]int),
+		}, nil
+	}
 
 	// Scratch map reused across iterations to avoid per-key allocation.
 	curWeights := make(map[string]float64)
@@ -126,7 +140,8 @@ func (s *LongestPrefixScorer) Score(
 	activePods := make(map[string]struct{}, len(curWeights))
 	for pod, w := range curWeights {
 		activePods[pod] = struct{}{}
-		podScores[pod] = w
+		weightedScores[pod] = w
+		consecutiveMatches[pod] = 1
 	}
 
 	for i := 1; i < len(keys); i++ {
@@ -142,13 +157,17 @@ func (s *LongestPrefixScorer) Score(
 		// in the current key, and accumulate scores for those that remain.
 		for pod := range activePods {
 			if w, exists := curWeights[pod]; exists {
-				podScores[pod] += w
+				weightedScores[pod] += w
+				consecutiveMatches[pod]++
 			} else {
 				delete(activePods, pod)
 			}
 		}
 	}
 
-	// Return the map containing the final score for each pod encountered.
-	return podScores, nil
+	// Return the result containing both weighted scores and consecutive match counts.
+	return &ScorerResult{
+		WeightedScores:     weightedScores,
+		ConsecutiveMatches: consecutiveMatches,
+	}, nil
 }

--- a/pkg/kvcache/kvblock_scorer_test.go
+++ b/pkg/kvcache/kvblock_scorer_test.go
@@ -60,9 +60,9 @@ func TestLongestPrefixScorer(t *testing.T) {
 		podB: 0.0,
 	}
 
-	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
+	result, err := scorer.Score(context.Background(), blockKeys, hitmap)
 	assert.NoError(t, err)
-	for pod, score := range scored {
+	for pod, score := range result.WeightedScores {
 		assert.InDelta(t, expected[pod], score, 0.0001)
 	}
 }
@@ -92,9 +92,9 @@ func TestLongestPrefixScorerDifferentTiers(t *testing.T) {
 		podB: 0.0,
 	}
 
-	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
+	result, err := scorer.Score(context.Background(), blockKeys, hitmap)
 	assert.NoError(t, err)
-	for pod, score := range scored {
+	for pod, score := range result.WeightedScores {
 		assert.InDelta(t, expected[pod], score, 0.0001)
 	}
 }

--- a/pkg/kvcache/traced_scorer.go
+++ b/pkg/kvcache/traced_scorer.go
@@ -46,7 +46,7 @@ func (t *tracedScorer) Score(
 	ctx context.Context,
 	keys []kvblock.BlockHash,
 	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
-) (map[string]float64, error) {
+) (*ScorerResult, error) {
 	tracer := otel.Tracer(telemetry.InstrumentationName)
 	_, span := tracer.Start(ctx, "llm_d.kv_cache.scorer.compute",
 		trace.WithSpanKind(trace.SpanKindInternal),
@@ -58,30 +58,30 @@ func (t *tracedScorer) Score(
 		attribute.Int("llm_d.kv_cache.scorer.key_count", len(keys)),
 	)
 
-	scores, err := t.next.Score(ctx, keys, keyToPods)
+	result, err := t.next.Score(ctx, keys, keyToPods)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 
 	// Calculate score distribution
-	if len(scores) > 0 {
+	if len(result.WeightedScores) > 0 {
 		maxScore := 0.0
 		totalScore := 0.0
-		for _, score := range scores {
+		for _, score := range result.WeightedScores {
 			if score > maxScore {
 				maxScore = score
 			}
 			totalScore += score
 		}
-		avgScore := totalScore / float64(len(scores))
+		avgScore := totalScore / float64(len(result.WeightedScores))
 
 		span.SetAttributes(
 			attribute.Float64("llm_d.kv_cache.score.max", maxScore),
 			attribute.Float64("llm_d.kv_cache.score.avg", avgScore),
-			attribute.Int("llm_d.kv_cache.scorer.pods_scored", len(scores)),
+			attribute.Int("llm_d.kv_cache.scorer.pods_scored", len(result.WeightedScores)),
 		)
 	}
 
-	return scores, nil
+	return result, nil
 }

--- a/pkg/kvcache/traced_scorer_test.go
+++ b/pkg/kvcache/traced_scorer_test.go
@@ -69,12 +69,12 @@ func TestTracedScorerBehavior(t *testing.T) {
 		},
 	}
 
-	scores, err := tracedScorer.Score(context.Background(), keys, keyToPods)
+	result, err := tracedScorer.Score(context.Background(), keys, keyToPods)
 	require.NoError(t, err)
-	require.NotNil(t, scores)
+	require.NotNil(t, result)
 
 	// pod1 should have highest score (appears in all 3 keys)
-	require.Greater(t, scores["pod1"], scores["pod2"])
+	require.Greater(t, result.WeightedScores["pod1"], result.WeightedScores["pod2"])
 }
 
 func TestTracedScorerWithEmptyData(t *testing.T) {
@@ -85,9 +85,9 @@ func TestTracedScorerWithEmptyData(t *testing.T) {
 	tracedScorer := kvcache.NewTracedScorer(baseScorer)
 
 	// Test with empty keys
-	scores, err := tracedScorer.Score(context.Background(), []kvblock.BlockHash{}, map[kvblock.BlockHash][]kvblock.PodEntry{})
+	result, err := tracedScorer.Score(context.Background(), []kvblock.BlockHash{}, map[kvblock.BlockHash][]kvblock.PodEntry{})
 	require.NoError(t, err)
-	require.Empty(t, scores)
+	require.Empty(t, result.WeightedScores)
 }
 
 func TestTracedScorerScoreDistribution(t *testing.T) {
@@ -114,11 +114,11 @@ func TestTracedScorerScoreDistribution(t *testing.T) {
 		},
 	}
 
-	scores, err := tracedScorer.Score(context.Background(), keys, keyToPods)
+	result, err := tracedScorer.Score(context.Background(), keys, keyToPods)
 	require.NoError(t, err)
-	require.Len(t, scores, 3)
+	require.Len(t, result.WeightedScores, 3)
 
 	// Verify pod1 has highest score
-	require.Greater(t, scores["pod1"], scores["pod2"])
-	require.Greater(t, scores["pod1"], scores["pod3"])
+	require.Greater(t, result.WeightedScores["pod1"], result.WeightedScores["pod2"])
+	require.Greater(t, result.WeightedScores["pod1"], result.WeightedScores["pod3"])
 }

--- a/tests/e2e/redis_mock/e2e_test.go
+++ b/tests/e2e/redis_mock/e2e_test.go
@@ -126,21 +126,21 @@ func (s *KVCacheSuite) TestCacheHit() {
 	engineKeys, requestKeys := s.promptToEngineAndRequestKeys(tokens, defaultModelName)
 	s.addEntriesToIndex(engineKeys, requestKeys, fakePodList)
 
-	pods, err := s.indexer.GetPodScores(s.ctx, nil, prompt, defaultModelName, fakePodList)
+	result, err := s.indexer.GetPodScores(s.ctx, nil, prompt, defaultModelName, fakePodList)
 	s.Require().NoError(err)
-	s.T().Logf("Received pod scores: %+v", pods)
-	s.Len(pods, len(fakePodList), "expected pod scores length to match candidate pods")
-	s.Greater(pods[s.Pod1IP], 1.0, "expected pod score to equal 1.0")
+	s.T().Logf("Received pod scores: %+v", result.Scores)
+	s.Len(result.Scores, len(fakePodList), "expected pod scores length to match candidate pods")
+	s.Greater(result.Scores[s.Pod1IP], 1.0, "expected pod score to equal 1.0")
 }
 
 func (s *KVCacheSuite) TestCacheMiss() {
 	prompt := "What is the capital of France?"
 	fakePodList := []string{s.Pod1IP}
 
-	pods, err := s.indexer.GetPodScores(s.ctx, nil, prompt, defaultModelName, fakePodList)
+	result, err := s.indexer.GetPodScores(s.ctx, nil, prompt, defaultModelName, fakePodList)
 	s.Require().NoError(err)
-	s.T().Logf("Received pod scores: %+v", pods)
-	s.Empty(pods, "expected no pod scores since no keys were added to the index")
+	s.T().Logf("Received pod scores: %+v", result.Scores)
+	s.Empty(result.Scores, "expected no pod scores since no keys were added to the index")
 }
 
 // TestPrefixReduction tests scoring behavior when querying progressively shorter prefixes of a fully cached prompt.
@@ -158,32 +158,32 @@ func (s *KVCacheSuite) TestPrefixReduction() {
 	fakePodList := []string{s.Pod1IP}
 
 	// Test 1: Full prompt (no match expected)
-	pods, err := s.indexer.GetPodScores(s.ctx, nil, fullPrompt, defaultModelName, []string{s.Pod1IP})
+	result, err := s.indexer.GetPodScores(s.ctx, nil, fullPrompt, defaultModelName, []string{s.Pod1IP})
 	s.Require().NoError(err)
-	s.T().Logf("Received pod scores: %+v", pods)
-	s.Empty(pods, "expected no pod scores")
+	s.T().Logf("Received pod scores: %+v", result.Scores)
+	s.Empty(result.Scores, "expected no pod scores")
 
 	s.addEntriesToIndex(fullPromptEngineKeys, fullPromptRequestKeys, fakePodList)
 
 	// Test 2: mid-length prompt(should return a match)
-	pods, err = s.indexer.GetPodScores(s.ctx, nil, midPrompt, defaultModelName, []string{s.Pod1IP})
+	result, err = s.indexer.GetPodScores(s.ctx, nil, midPrompt, defaultModelName, []string{s.Pod1IP})
 	s.Require().NoError(err)
 
-	s.T().Logf("Received pod scores: %+v", pods)
-	s.Greater(int(pods[s.Pod1IP]), 0, "mid-prompt block keys should have been indexed")
+	s.T().Logf("Received pod scores: %+v", result.Scores)
+	s.Greater(int(result.Scores[s.Pod1IP]), 0, "mid-prompt block keys should have been indexed")
 
 	// Test 3: short prompt(should return a match)
-	pods, err = s.indexer.GetPodScores(s.ctx, nil, shortPrompt, defaultModelName, []string{s.Pod1IP})
+	result, err = s.indexer.GetPodScores(s.ctx, nil, shortPrompt, defaultModelName, []string{s.Pod1IP})
 	s.Require().NoError(err)
 
-	s.Len(pods, len(fakePodList), "expected pod scores length to match candidate pods")
-	s.T().Logf("Received pod scores: %+v", pods)
+	s.Len(result.Scores, len(fakePodList), "expected pod scores length to match candidate pods")
+	s.T().Logf("Received pod scores: %+v", result.Scores)
 
 	tokens, _, err = s.tokenizer.Render(shortPrompt)
 	s.Require().NoError(err)
 
 	_, shortPromptRequestKeys := s.promptToEngineAndRequestKeys(tokens, defaultModelName)
-	s.Equal(int(pods[s.Pod1IP]), len(shortPromptRequestKeys), "all short-prompt block keys should have been indexed")
+	s.Equal(int(result.Scores[s.Pod1IP]), len(shortPromptRequestKeys), "all short-prompt block keys should have been indexed")
 }
 
 // TestPrefixExpansion tests that prompts longer than the cached prefix still return partial match scores.
@@ -197,10 +197,10 @@ func (s *KVCacheSuite) TestPrefixExpansion() {
 	fakePodList := []string{s.Pod1IP}
 
 	// Test 1: short prompt
-	pods, err := s.indexer.GetPodScores(s.ctx, nil, shortPrompt, modelName, []string{s.Pod1IP})
+	result, err := s.indexer.GetPodScores(s.ctx, nil, shortPrompt, modelName, []string{s.Pod1IP})
 	s.Require().NoError(err)
-	s.T().Logf("Received pod scores: %+v", pods)
-	s.Empty(pods, "expected no pod scores")
+	s.T().Logf("Received pod scores: %+v", result.Scores)
+	s.Empty(result.Scores, "expected no pod scores")
 
 	shortTokens, _, err := s.tokenizer.Render(shortPrompt)
 	s.Require().NoError(err)
@@ -209,11 +209,11 @@ func (s *KVCacheSuite) TestPrefixExpansion() {
 	s.addEntriesToIndex(shortPromptEngineKeys, shortPromptRequestKeys, fakePodList)
 
 	// Test 2: mid prompt
-	pods, err = s.indexer.GetPodScores(s.ctx, nil, midPrompt, modelName, []string{s.Pod1IP})
+	result, err = s.indexer.GetPodScores(s.ctx, nil, midPrompt, modelName, []string{s.Pod1IP})
 	s.Require().NoError(err)
 
-	s.T().Logf("Received pod scores: %+v", pods)
-	s.Equal(int(pods[s.Pod1IP]), len(shortPromptRequestKeys), "expected pod score to equal number of short prompt block keys")
+	s.T().Logf("Received pod scores: %+v", result.Scores)
+	s.Equal(int(result.Scores[s.Pod1IP]), len(shortPromptRequestKeys), "expected pod score to equal number of short prompt block keys")
 
 	midTokens, _, err := s.tokenizer.Render(midPrompt)
 	s.Require().NoError(err)
@@ -222,11 +222,11 @@ func (s *KVCacheSuite) TestPrefixExpansion() {
 	s.addEntriesToIndex(midPromptEngineKeys, midPromptRequestKeys, fakePodList)
 
 	// Test 3: full prompt
-	pods, err = s.indexer.GetPodScores(s.ctx, nil, fullPrompt, modelName, []string{s.Pod1IP})
+	result, err = s.indexer.GetPodScores(s.ctx, nil, fullPrompt, modelName, []string{s.Pod1IP})
 	s.Require().NoError(err)
 
-	s.T().Logf("Received pod scores: %+v", pods)
-	s.Equal(int(pods[s.Pod1IP]), len(midPromptRequestKeys), "expected pod score to equal number of mid prompt block keys")
+	s.T().Logf("Received pod scores: %+v", result.Scores)
+	s.Equal(int(result.Scores[s.Pod1IP]), len(midPromptRequestKeys), "expected pod score to equal number of mid prompt block keys")
 }
 
 func (s *KVCacheSuite) TestLongPrefixExpansion() {
@@ -241,10 +241,10 @@ func (s *KVCacheSuite) TestLongPrefixExpansion() {
 	fakePodList := []string{s.Pod1IP}
 
 	// Test 1: short prompt (should return no pod scores yet)
-	pods, err := s.indexer.GetPodScores(s.ctx, nil, shortPrompt, modelName, []string{s.Pod1IP})
+	result, err := s.indexer.GetPodScores(s.ctx, nil, shortPrompt, modelName, []string{s.Pod1IP})
 	s.Require().NoError(err)
 	s.T().Logf("Short prompt scores: %+v", pods)
-	s.Empty(pods, "expected no pod scores")
+	s.Empty(result.Scores, "expected no pod scores")
 
 	shortTokens, _, err := s.tokenizer.Render(shortPrompt)
 	s.Require().NoError(err)
@@ -254,7 +254,7 @@ func (s *KVCacheSuite) TestLongPrefixExpansion() {
 	s.addEntriesToIndex(shortPromptEngineKeys, shortPromptRequestKeys, fakePodList)
 
 	// Test 2: mid prompt (should return partial match if indexer picks it up)
-	pods, err = s.indexer.GetPodScores(s.ctx, nil, midPrompt, modelName, []string{s.Pod1IP})
+	result, err = s.indexer.GetPodScores(s.ctx, nil, midPrompt, modelName, []string{s.Pod1IP})
 	s.Require().NoError(err)
 	s.T().Logf("Mid prompt scores: %+v", pods)
 	s.True(len(pods) > 0, "expected at least one pod score for mid prompt")
@@ -267,7 +267,7 @@ func (s *KVCacheSuite) TestLongPrefixExpansion() {
 	s.addEntriesToIndex(midPromptEngineKeys, midPromptRequestKeys, fakePodList)
 
 	// Test 3: long prompt (should return higher score)
-	pods, err = s.indexer.GetPodScores(s.ctx, nil, longPrompt, modelName, []string{s.Pod1IP})
+	result, err = s.indexer.GetPodScores(s.ctx, nil, longPrompt, modelName, []string{s.Pod1IP})
 	s.Require().NoError(err)
 	s.T().Logf("Long prompt scores: %+v", pods)
 	s.True(len(pods) > 0, "expected at least one pod score for long prompt")
@@ -318,20 +318,20 @@ func (s *KVCacheSuite) TestChatCompletionsE2E() {
 	fakePodList := []string{s.Pod1IP}
 
 	// First lookup - should return no scores initially.
-	pods, err := s.indexer.GetPodScores(s.ctx, nil, flattenedPrompt, "ibm-granite/granite-3.3-8b-instruct", []string{s.Pod1IP})
+	result, err := s.indexer.GetPodScores(s.ctx, nil, flattenedPrompt, "ibm-granite/granite-3.3-8b-instruct", []string{s.Pod1IP})
 	s.Require().NoError(err)
 	s.T().Logf("First lookup - Received pod scores: %+v", pods)
-	s.Empty(pods, "expected no pod scores on first lookup")
+	s.Empty(result.Scores, "expected no pod scores on first lookup")
 
 	// Add entries to the index.
 	s.addEntriesToIndex(engineKeys, requestKeys, fakePodList)
 
 	// Second lookup - should return scores.
-	pods, err = s.indexer.GetPodScores(s.ctx, nil, flattenedPrompt, "ibm-granite/granite-3.3-8b-instruct", []string{s.Pod1IP})
+	result, err = s.indexer.GetPodScores(s.ctx, nil, flattenedPrompt, "ibm-granite/granite-3.3-8b-instruct", []string{s.Pod1IP})
 	s.Require().NoError(err)
 	s.T().Logf("Second lookup - Received pod scores: %+v", pods)
-	s.Len(pods, 1, "expected one pod score")
-	s.True(pods[s.Pod1IP] > 0, "expected positive pod score")
+	s.Len(result.Scores, 1, "expected one pod score")
+	s.True(result.Scores[s.Pod1IP] > 0, "expected positive pod score")
 
 	s.T().Logf("Chat completions E2E test completed successfully")
 }
@@ -395,20 +395,20 @@ func (s *KVCacheSuite) TestLongChatCompletionsE2E() {
 	fakePodList := []string{s.Pod1IP}
 
 	// First lookup.
-	pods, err := s.indexer.GetPodScores(s.ctx, nil, flattenedPrompt, "ibm-granite/granite-3.3-8b-instruct", []string{s.Pod1IP})
+	result, err := s.indexer.GetPodScores(s.ctx, nil, flattenedPrompt, "ibm-granite/granite-3.3-8b-instruct", []string{s.Pod1IP})
 	s.Require().NoError(err)
 	s.T().Logf("First lookup - Received pod scores: %+v", pods)
-	s.Empty(pods, "expected no pod scores on first lookup")
+	s.Empty(result.Scores, "expected no pod scores on first lookup")
 
 	// Add entries to the index.
 	s.addEntriesToIndex(engineKeys, requestKeys, fakePodList)
 
 	// Second lookup.
-	pods, err = s.indexer.GetPodScores(s.ctx, nil, flattenedPrompt, "ibm-granite/granite-3.3-8b-instruct", []string{s.Pod1IP})
+	result, err = s.indexer.GetPodScores(s.ctx, nil, flattenedPrompt, "ibm-granite/granite-3.3-8b-instruct", []string{s.Pod1IP})
 	s.Require().NoError(err)
 	s.T().Logf("Second lookup - Received pod scores: %+v", pods)
-	s.Len(pods, 1, "expected one pod score")
-	s.True(pods[s.Pod1IP] > 0, "expected positive pod score")
+	s.Len(result.Scores, 1, "expected one pod score")
+	s.True(result.Scores[s.Pod1IP] > 0, "expected positive pod score")
 
 	s.T().Logf("Long chat completions E2E test completed successfully")
 }
@@ -447,11 +447,11 @@ func (s *KVCacheSuite) TestCacheHitWithLocalTokenizer() {
 	s.addEntriesToIndex(engineKeys, requestKeys, fakePodList)
 
 	// Verify that we can retrieve the entries we just added using GetPodScores
-	pods, err := s.indexer.GetPodScores(s.ctx, nil, prompt, modelName, fakePodList)
+	result, err := s.indexer.GetPodScores(s.ctx, nil, prompt, modelName, fakePodList)
 	s.Require().NoError(err)
 	s.Require().NotEmpty(pods, "should find pod scores after adding entries")
-	s.Require().Greater(pods[s.Pod1IP], float64(0), "expected positive pod score")
-	s.T().Logf("GetPodScores returned score: %v", pods[s.Pod1IP])
+	s.Require().Greater(result.Scores[s.Pod1IP], float64(0), "expected positive pod score")
+	s.T().Logf("GetPodScores returned score: %v", result.Scores[s.Pod1IP])
 
 	// Also verify that tokenizing the same prompt again produces same block keys
 	tokens2, _, err := localTokenizer.Render(prompt)
@@ -578,11 +578,11 @@ func (s *KVCacheSuite) TestLocalTokenizerChatTemplateE2E() {
 			fakePodList := []string{s.Pod1IP}
 			s.addEntriesToIndex(engineKeys, requestKeys, fakePodList)
 			// Verify retrieval using GetPodScores with the rendered prompt
-			pods, err := s.indexer.GetPodScores(s.ctx, renderReq, "", tc.modelName, fakePodList)
+			result, err := s.indexer.GetPodScores(s.ctx, renderReq, "", tc.modelName, fakePodList)
 			s.Require().NoError(err)
 			s.Require().NotEmpty(pods, "should find pod scores after adding entries")
-			s.Require().Greater(pods[s.Pod1IP], float64(0), "expected positive pod score")
-			s.T().Logf("GetPodScores returned score: %v for rendered chat template", pods[s.Pod1IP])
+			s.Require().Greater(result.Scores[s.Pod1IP], float64(0), "expected positive pod score")
+			s.T().Logf("GetPodScores returned score: %v for rendered chat template", result.Scores[s.Pod1IP])
 
 			// Also verify by rendering and tokenizing the same conversation again
 			renderReq2 := &types.RenderChatRequest{
@@ -700,10 +700,10 @@ func (s *KVCacheSuite) TestLocalTokenizerChatTemplateMultiTurnE2E() {
 			s.addEntriesToIndex(extendedEngineKeys, extendedRequestKeys, fakePodList)
 
 			// Verify that querying with the short conversation still works (prefix sharing in KV-cache)
-			pods, err := s.indexer.GetPodScores(s.ctx, shortReq, "", tc.modelName, fakePodList)
+			result, err := s.indexer.GetPodScores(s.ctx, shortReq, "", tc.modelName, fakePodList)
 			s.Require().NoError(err)
 			s.Require().NotEmpty(pods, "Short conversation should still match after adding extended conversation")
-			s.T().Logf("Short conversation match score: %v", pods[s.Pod1IP])
+			s.T().Logf("Short conversation match score: %v", result.Scores[s.Pod1IP])
 
 			s.T().Logf("Multi-turn conversation E2E test completed successfully")
 		})
@@ -773,11 +773,11 @@ func (s *KVCacheSuite) TestLocalVsHFChatTemplateConsistency() {
 			fakePodList := []string{s.Pod1IP}
 			s.addEntriesToIndex(engineKeys, requestKeys, fakePodList)
 
-			pods, err := s.indexer.GetPodScores(s.ctx, req1, "", tc.modelName, fakePodList)
+			result, err := s.indexer.GetPodScores(s.ctx, req1, "", tc.modelName, fakePodList)
 			s.Require().NoError(err)
 			s.Require().NotEmpty(pods, "should find pod scores after adding entries")
-			s.Require().Greater(pods[s.Pod1IP], float64(0), "expected positive pod score")
-			s.T().Logf("GetPodScores returned score: %v", pods[s.Pod1IP])
+			s.Require().Greater(result.Scores[s.Pod1IP], float64(0), "expected positive pod score")
+			s.T().Logf("GetPodScores returned score: %v", result.Scores[s.Pod1IP])
 
 			// Render the same conversation again to test caching and consistency
 			req2 := &types.RenderChatRequest{
@@ -903,11 +903,11 @@ func (s *KVCacheSuite) TestLocalTokenizerChatTemplateLongConversation() {
 			s.addEntriesToIndex(engineKeys, requestKeys, fakePodList)
 			// Verify retrieval using GetPodScores
 			// Note: This works now because the test suite uses a composite tokenizer that includes the local models
-			pods, err := s.indexer.GetPodScores(s.ctx, reqLong, "", tc.modelName, fakePodList)
+			result, err := s.indexer.GetPodScores(s.ctx, reqLong, "", tc.modelName, fakePodList)
 			s.Require().NoError(err)
 			s.Require().NotEmpty(pods, "should find pod scores after adding entries")
-			s.Require().Greater(pods[s.Pod1IP], float64(0), "expected positive pod score")
-			s.T().Logf("GetPodScores returned score: %v for long conversation", pods[s.Pod1IP])
+			s.Require().Greater(result.Scores[s.Pod1IP], float64(0), "expected positive pod score")
+			s.T().Logf("GetPodScores returned score: %v for long conversation", result.Scores[s.Pod1IP])
 
 			s.T().Logf("Long conversation E2E test completed successfully")
 		})

--- a/tests/e2e/uds_tokenizer/uds_e2e_test.go
+++ b/tests/e2e/uds_tokenizer/uds_e2e_test.go
@@ -134,11 +134,11 @@ func (s *UDSTokenizerSuite) TestCacheHit() {
 	engineKeys, requestKeys := s.promptToEngineAndRequestKeys(tokens)
 	s.addEntriesToIndex(engineKeys, requestKeys, fakePodList)
 
-	pods, err := s.indexer.GetPodScores(s.T().Context(), nil, prompt, defaultModelName, fakePodList)
+	result, err := s.indexer.GetPodScores(s.T().Context(), nil, prompt, defaultModelName, fakePodList)
 	s.Require().NoError(err)
-	s.T().Logf("Received pod scores: %+v", pods)
-	s.Len(pods, len(fakePodList), "expected pod scores length to match candidate pods")
-	s.Greater(pods[s.Pod1IP], 1.0, "expected positive pod score")
+	s.T().Logf("Received pod scores: %+v", result.Scores)
+	s.Len(result.Scores, len(fakePodList), "expected pod scores length to match candidate pods")
+	s.Greater(result.Scores[s.Pod1IP], 1.0, "expected positive pod score")
 }
 
 // TestCacheMiss queries scores for a prompt that has no index entries
@@ -147,10 +147,10 @@ func (s *UDSTokenizerSuite) TestCacheMiss() {
 	prompt := "What is the capital of France?"
 	fakePodList := []string{s.Pod1IP}
 
-	pods, err := s.indexer.GetPodScores(s.T().Context(), nil, prompt, defaultModelName, fakePodList)
+	result, err := s.indexer.GetPodScores(s.T().Context(), nil, prompt, defaultModelName, fakePodList)
 	s.Require().NoError(err)
-	s.T().Logf("Received pod scores: %+v", pods)
-	s.Empty(pods, "expected no pod scores since no keys were added to the index")
+	s.T().Logf("Received pod scores: %+v", result.Scores)
+	s.Empty(result.Scores, "expected no pod scores since no keys were added to the index")
 }
 
 // TestPrefixReduction caches a full prompt, then queries progressively shorter
@@ -169,29 +169,29 @@ func (s *UDSTokenizerSuite) TestPrefixReduction() {
 	fakePodList := []string{s.Pod1IP}
 
 	// Before indexing — no match expected.
-	pods, err := s.indexer.GetPodScores(s.T().Context(), nil, fullPrompt, defaultModelName, fakePodList)
+	result, err := s.indexer.GetPodScores(s.T().Context(), nil, fullPrompt, defaultModelName, fakePodList)
 	s.Require().NoError(err)
-	s.Empty(pods, "expected no pod scores before indexing")
+	s.Empty(result.Scores, "expected no pod scores before indexing")
 
 	s.addEntriesToIndex(fullEngineKeys, fullRequestKeys, fakePodList)
 
 	// Mid-length prompt should match.
-	pods, err = s.indexer.GetPodScores(s.T().Context(), nil, midPrompt, defaultModelName, fakePodList)
+	result, err = s.indexer.GetPodScores(s.T().Context(), nil, midPrompt, defaultModelName, fakePodList)
 	s.Require().NoError(err)
-	s.Greater(int(pods[s.Pod1IP]), 0, "mid-prompt should have scored > 0")
-	s.T().Logf("Mid prompt scores: %+v", pods)
+	s.Greater(int(result.Scores[s.Pod1IP]), 0, "mid-prompt should have scored > 0")
+	s.T().Logf("Mid prompt scores: %+v", result.Scores)
 
 	// Short prompt should match.
-	pods, err = s.indexer.GetPodScores(s.T().Context(), nil, shortPrompt, defaultModelName, fakePodList)
+	result, err = s.indexer.GetPodScores(s.T().Context(), nil, shortPrompt, defaultModelName, fakePodList)
 	s.Require().NoError(err)
-	s.Len(pods, len(fakePodList), "expected pod scores for short prompt")
-	s.T().Logf("Short prompt scores: %+v", pods)
+	s.Len(result.Scores, len(fakePodList), "expected pod scores for short prompt")
+	s.T().Logf("Short prompt scores: %+v", result.Scores)
 
 	// Verify the short prompt score equals the number of its block keys.
 	shortTokens, _, err := s.tokenizer.Render(shortPrompt)
 	s.Require().NoError(err)
 	_, shortRequestKeys := s.promptToEngineAndRequestKeys(shortTokens)
-	s.Equal(int(pods[s.Pod1IP]), len(shortRequestKeys),
+	s.Equal(int(result.Scores[s.Pod1IP]), len(shortRequestKeys),
 		"all short-prompt block keys should have been indexed")
 }
 
@@ -218,18 +218,18 @@ func (s *UDSTokenizerSuite) TestChatCompletionsFlow() {
 	fakePodList := []string{s.Pod1IP}
 
 	// First lookup — no match.
-	pods, err := s.indexer.GetPodScores(s.T().Context(), renderReq, "", defaultModelName, fakePodList)
+	result, err := s.indexer.GetPodScores(s.T().Context(), renderReq, "", defaultModelName, fakePodList)
 	s.Require().NoError(err)
-	s.Empty(pods, "expected no pod scores on first lookup")
+	s.Empty(result.Scores, "expected no pod scores on first lookup")
 
 	// Index and lookup again.
 	s.addEntriesToIndex(engineKeys, requestKeys, fakePodList)
 
-	pods, err = s.indexer.GetPodScores(s.T().Context(), renderReq, "", defaultModelName, fakePodList)
+	result, err = s.indexer.GetPodScores(s.T().Context(), renderReq, "", defaultModelName, fakePodList)
 	s.Require().NoError(err)
-	s.Len(pods, 1, "expected one pod score after indexing")
-	s.Greater(pods[s.Pod1IP], float64(0), "expected positive pod score")
-	s.T().Logf("Chat completions flow score: %v", pods[s.Pod1IP])
+	s.Len(result.Scores, 1, "expected one pod score after indexing")
+	s.Greater(result.Scores[s.Pod1IP], float64(0), "expected positive pod score")
+	s.T().Logf("Chat completions flow score: %v", result.Scores[s.Pod1IP])
 }
 
 // ---------------------------------------------------------------------------
@@ -254,8 +254,8 @@ func (s *UDSTokenizerSuite) TestScoreTokensCacheHit() {
 	pods, err := s.indexer.ScoreTokens(s.T().Context(), tokens, defaultModelName, fakePodList)
 	s.Require().NoError(err)
 	s.T().Logf("ScoreTokens scores: %+v", pods)
-	s.Len(pods, len(fakePodList), "expected pod scores length to match candidate pods")
-	s.Greater(pods[s.Pod1IP], 1.0, "expected positive pod score")
+	s.Len(pods.Scores, len(fakePodList), "expected pod scores length to match candidate pods")
+	s.Greater(pods.Scores[s.Pod1IP], 1.0, "expected positive pod score")
 }
 
 // TestScoreTokensCacheMiss calls ScoreTokens for tokens
@@ -271,7 +271,7 @@ func (s *UDSTokenizerSuite) TestScoreTokensCacheMiss() {
 	pods, err := s.indexer.ScoreTokens(s.T().Context(), tokens, defaultModelName, fakePodList)
 	s.Require().NoError(err)
 	s.T().Logf("ScoreTokens scores: %+v", pods)
-	s.Empty(pods, "expected no pod scores since no keys were added to the index")
+	s.Empty(pods.Scores, "expected no pod scores since no keys were added to the index")
 }
 
 // TestScoreTokensConsistentWithGetPodScores tokenizes a prompt,
@@ -321,10 +321,10 @@ func (s *UDSTokenizerSuite) TestScoreTokensPrefixReduction() {
 
 	pods, err := s.indexer.ScoreTokens(s.T().Context(), shortTokens, defaultModelName, fakePodList)
 	s.Require().NoError(err)
-	s.Len(pods, len(fakePodList), "expected pod scores for short token prefix")
+	s.Len(pods.Scores, len(fakePodList), "expected pod scores for short token prefix")
 	s.T().Logf("Short prefix scores: %+v", pods)
 
 	_, shortRequestKeys := s.promptToEngineAndRequestKeys(shortTokens)
-	s.Equal(int(pods[s.Pod1IP]), len(shortRequestKeys),
+	s.Equal(int(pods.Scores[s.Pod1IP]), len(shortRequestKeys),
 		"all short-prefix block keys should have been indexed")
 }


### PR DESCRIPTION
 Modified `GetPodScores()` to return `PodScoreResult` containing weighted scores, consecutive match counts, and total blocks. Updated LongestPrefixScorer to track both device-tier-weighted scores and unweighted consecutive matches.

Blocks:
 - https://github.com/llm-d/llm-d-inference-scheduler/pull/681

The changes support two use cases:
  - https://github.com/llm-d/llm-d-inference-scheduler/pull/667
  - https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2481

Helps converge with the [ApproximatePrefixCache API](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types.go
)