### PR TITLE
perf: Use strconv.FormatUint in BlockHash.String() to reduce allocation overhead

### DIFF
--- a/pkg/kvcache/kvblock/index.go
+++ b/pkg/kvcache/kvblock/index.go
@@ -19,6 +19,7 @@ package kvblock
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/metrics"
@@ -143,7 +144,7 @@ const EmptyBlockHash BlockHash = 0
 
 // String returns a string representation of the Key.
 func (c BlockHash) String() string {
-	return fmt.Sprintf("%d", uint64(c))
+	return strconv.FormatUint(uint64(c), 10)
 }
 
 // PodEntry struct represents a pod entry in the KV-block index.


### PR DESCRIPTION
Replace `fmt.Sprintf("%d", uint64(c))` with `strconv.FormatUint(uint64(c), 10)` in `BlockHash.String()`.

`BlockHash.String()` is called on every key in every `Lookup`, `Add`, and `Evict` operation across all index backends (InMemory, CostAwareMemory, Redis/Valkey). For a single request with 256 block keys, this method is invoked hundreds of times.

`fmt.Sprintf` parses the format string, goes through the reflection-based formatting pipeline, and allocates an internal `pp` struct from a pool on each call — all unnecessary overhead for a simple uint64-to-string conversion. `strconv.FormatUint` is a specialized function that performs the conversion directly, producing 3-5x fewer allocations and significantly less CPU overhead per call.

/cc @vMaroon 