### PR TITLE
Fix get_finished to return TransferResult, aligning with vLLM

### DIFF
--- a/kv_connectors/llmd_fs_backend/csrc/storage/storage_offload.cpp
+++ b/kv_connectors/llmd_fs_backend/csrc/storage/storage_offload.cpp
@@ -85,10 +85,10 @@ size_t StorageOffloadEngine::calc_staging_bytes(
 // Status and job management
 // -------------------------------
 // Return finished jobs and their success status
-std::vector<std::pair<int, bool>> StorageOffloadEngine::get_finished() {
+std::vector<TransferResult> StorageOffloadEngine::get_finished() {
   std::lock_guard<std::mutex> lock(m_jobs_mutex);
 
-  std::vector<std::pair<int, bool>> results;
+  std::vector<TransferResult> results;
   std::vector<int> to_erase;
 
   // Iterate over all active jobs.
@@ -99,7 +99,7 @@ std::vector<std::pair<int, bool>> StorageOffloadEngine::get_finished() {
     // Check if the job has completed all its tasks.
     if (job_state->completed_tasks.load() == job_state->total_tasks) {
       bool all_ok = job_state->all_success.load();
-      results.emplace_back(job_id, all_ok);
+      results.push_back(TransferResult{job_id, all_ok, std::nullopt, std::nullopt});
       to_erase.push_back(job_id);
     }
   }

--- a/kv_connectors/llmd_fs_backend/csrc/storage/storage_offload.hpp
+++ b/kv_connectors/llmd_fs_backend/csrc/storage/storage_offload.hpp
@@ -29,6 +29,7 @@
 
 #include "thread_pool.hpp"
 #include "tensor_copier.hpp"
+#include "storage_types.hpp"
 
 // Tracks progress and results for a multi-file async PUT/GET job
 struct JobState {
@@ -65,7 +66,7 @@ class StorageOffloadEngine {
                        int gpu_blocks_per_file,
                        std::vector<torch::Tensor>& tensors);
   // Return finished jobs and their success status
-  std::vector<std::pair<int, bool>> get_finished();
+  std::vector<TransferResult> get_finished();
   // Wait for all tasks in the specified job to complete
   void wait_job(int job_id);
   // Async GPU -> Storage transfer (PUT)

--- a/kv_connectors/llmd_fs_backend/csrc/storage/storage_offload_bindings.cpp
+++ b/kv_connectors/llmd_fs_backend/csrc/storage/storage_offload_bindings.cpp
@@ -18,11 +18,22 @@
 #include <pybind11/pybind11.h>
 
 #include "storage_offload.hpp"
+#include "storage_types.hpp"
 
 namespace py = pybind11;
 // Pybind11 bindings exposing the C++ StorageOffloadEngine for
 // asynchronous KV-cache transfers between GPU memory and shared storage.
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  py::class_<TransferResult>(m, "TransferResult")
+      .def_readonly("job_id", &TransferResult::job_id)
+      .def_readonly("success", &TransferResult::success)
+      .def_readonly("transfer_size", &TransferResult::transfer_size)
+      .def_readonly("transfer_time", &TransferResult::transfer_time)
+      .def("__repr__", [](const TransferResult& r) {
+        return "TransferResult(job_id=" + std::to_string(r.job_id) +
+               ", success=" + (r.success ? "True" : "False") + ")";
+      });
+
   py::class_<StorageOffloadEngine>(
       m,
       "StorageOffloadEngine",

--- a/kv_connectors/llmd_fs_backend/csrc/storage/storage_types.hpp
+++ b/kv_connectors/llmd_fs_backend/csrc/storage/storage_types.hpp
@@ -16,8 +16,16 @@
 // storage_types.hpp
 #pragma once
 #include <cstddef>
+#include <optional>
 
 struct StagingBufferInfo {
   void* ptr = nullptr;
   size_t size = 0;
+};
+
+struct TransferResult {
+  int job_id;
+  bool success;
+  std::optional<size_t> transfer_size;
+  std::optional<double> transfer_time;
 };


### PR DESCRIPTION
Changes to fix #389:

- Add `TransferResult` class (transfer_size, transfer_time added because vllm expects them)
- Update `get_finished` to return `std::vector<TransferResult>`
- Basic testing done with vllm bench