### PR TITLE
fix: Close data race in tokenization Pool.SetTokenizer

### DIFF
--- a/pkg/tokenization/pool.go
+++ b/pkg/tokenization/pool.go
@@ -51,10 +51,14 @@ type Pool struct {
 	queue     workqueue.TypedRateLimitingInterface[Task]
 	wg        sync.WaitGroup
 
+	// mu protects tokenizer and modelName from concurrent read/write via
+	// SetTokenizer and processTask.
+	mu sync.RWMutex
+
 	// Tokenizer is configured for the specific model this pool handles.
 	// It's shared between all pool workers.
-	// Since the tokenizer is immutable,
-	// tokenizer functions are safe for concurrent use without locks.
+	// Tokenizer functions are safe for concurrent use without locks,
+	// but the tokenizer reference itself is guarded by mu.
 	tokenizer Tokenizer
 }
 
@@ -130,17 +134,21 @@ func (pool *Pool) workerLoop(_ int) {
 // processTask tokenizes the prompt and returns the tokens via ResultCh.
 // It sends exactly one response (success or error) if ResultCh is provided.
 func (pool *Pool) processTask(task Task) error {
+	pool.mu.RLock()
+	tokenizer := pool.tokenizer
+	pool.mu.RUnlock()
+
 	var tokens []uint32
 	var features *MultiModalFeatures
 	var err error
 	if task.RenderReq == nil {
-		tokens, _, err = pool.tokenizer.Render(task.Prompt)
+		tokens, _, err = tokenizer.Render(task.Prompt)
 		if err != nil {
 			log.Log.Error(err, "failed to render tokens", "prompt", task.Prompt)
 			return err
 		}
 	} else {
-		tokens, features, err = pool.tokenizer.RenderChat(task.RenderReq)
+		tokens, features, err = tokenizer.RenderChat(task.RenderReq)
 		if err != nil {
 			log.Log.Error(err, "failed to render tokens", "task", task.RenderReq)
 			return err
@@ -161,6 +169,8 @@ func (pool *Pool) processTask(task Task) error {
 }
 
 func (pool *Pool) SetTokenizer(tokenizer Tokenizer, modelName string) {
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
 	pool.tokenizer = tokenizer
 	pool.modelName = modelName
 }

--- a/pkg/tokenization/pool_test.go
+++ b/pkg/tokenization/pool_test.go
@@ -102,6 +102,76 @@ func TestPool_ProcessTask(t *testing.T) {
 	mockTokenizer.AssertExpectations(t)
 }
 
+// TestPool_SetTokenizerConcurrent verifies that SetTokenizer can be called
+// concurrently with worker goroutines processing tasks without triggering a
+// data race. Run with: go test -race -run TestPool_SetTokenizerConcurrent.
+func TestPool_SetTokenizerConcurrent(t *testing.T) {
+	tokenizerA := &MockTokenizer{}
+	tokenizerB := &MockTokenizer{}
+
+	expectedTokens := []uint32{1, 2, 3}
+	expectedOffsets := []types.Offset{{0, 4}}
+
+	// Both tokenizers may receive calls depending on timing.
+	tokenizerA.On("Render", mock.Anything).
+		Return(expectedTokens, expectedOffsets, nil).Maybe()
+	tokenizerB.On("Render", mock.Anything).
+		Return(expectedTokens, expectedOffsets, nil).Maybe()
+
+	pool := &Pool{
+		modelName: "test-model",
+		workers:   2,
+		queue:     workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[Task]()),
+		tokenizer: tokenizerA,
+	}
+
+	// Start workers.
+	for i := range pool.workers {
+		pool.wg.Add(1)
+		go pool.workerLoop(i)
+	}
+
+	// Concurrently enqueue tasks and swap the tokenizer.
+	const taskCount = 50
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := range taskCount {
+			if i%2 == 0 {
+				pool.SetTokenizer(tokenizerB, "model-b")
+			} else {
+				pool.SetTokenizer(tokenizerA, "model-a")
+			}
+		}
+	}()
+
+	resultChs := make([]chan tokenizationResponse, taskCount)
+	for i := range taskCount {
+		ch := make(chan tokenizationResponse, 1)
+		resultChs[i] = ch
+		pool.queue.Add(Task{
+			Prompt:   "prompt",
+			ResultCh: ch,
+		})
+	}
+
+	// Wait for all results.
+	for i, ch := range resultChs {
+		select {
+		case res, ok := <-ch:
+			if ok {
+				assert.Equal(t, expectedTokens, res.Tokens, "task %d", i)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for task %d", i)
+		}
+	}
+
+	<-done
+	pool.queue.ShutDown()
+	pool.wg.Wait()
+}
+
 func TestPool_WorkerLoop(t *testing.T) {
 	specs := map[string]struct {
 		setupMocks func(*MockTokenizer)


### PR DESCRIPTION
- `SetTokenizer` writes `pool.tokenizer` and `pool.modelName` with no synchronization while `processTask` concurrently reads `pool.tokenizer` from worker goroutines, a data race detectable by `go test -race`
- Add `sync.RWMutex` to guard the tokenizer reference: write-lock in `SetTokenizer`, read-lock (snapshot) in `processTask`
- Add `TestPool_SetTokenizerConcurrent` to exercise concurrent `SetTokenizer` calls alongside active workers