### PR TITLE
feat: Add Hybrid Model Architecture (HMA) Support in Prefix-Cache Aware Scheduling

### DIFF
--- a/pkg/kvcache/export_test.go
+++ b/pkg/kvcache/export_test.go
@@ -30,3 +30,8 @@ func NewIndexerForTest(tp kvblock.TokenProcessor, idx kvblock.Index, scorer KVBl
 		tokenizersPool: pool,
 	}
 }
+
+// ContainsGroup exports the private containsGroup function for testing.
+func ContainsGroup(groups []int, groupID int) bool {
+	return containsGroup(groups, groupID)
+}

--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -34,6 +34,20 @@ import (
 	"github.com/llm-d/llm-d-kv-cache/pkg/utils/logging"
 )
 
+// AttentionGroupConfig defines the attention window size and type for a group.
+type AttentionGroupConfig struct {
+	WindowSize    int    `json:"windowSize"`    // Attention window size (0 or omit for full attention = no constraint)
+	AttentionType string `json:"attentionType"` // Attention type (e.g., "full", "sliding", "block_sparse")
+	BlockSize     int    `json:"blockSize"`     // KV block size for this group (if 0, falls back to ModelConfig.BlockSize)
+}
+
+// ModelConfig holds model-specific configuration including block size and attention groups.
+type ModelConfig struct {
+	Name            string                 `json:"name"`            // Model name
+	BlockSize       int                    `json:"blockSize"`       // Default KV block size (used when AttentionGroupConfig.BlockSize is 0)
+	AttentionGroups []AttentionGroupConfig `json:"attentionGroups"` // Multiple attention groups with different window sizes and block sizes
+}
+
 // Config holds the configuration for the Indexer module.
 // The configuration cover the different components found in the Indexer
 // module.
@@ -42,6 +56,7 @@ type Config struct {
 	KVBlockScorerConfig  *KVBlockScorerConfig    // not exported
 	TokenizersPoolConfig *tokenization.Config    `json:"tokenizersPoolConfig"`
 	BackendConfigs       []*KVCacheBackendConfig `json:"kvCacheBackendConfigs"`
+	ModelConfigs         []*ModelConfig
 }
 
 // NewDefaultConfig returns a default configuration for the Indexer module.
@@ -56,6 +71,7 @@ func NewDefaultConfig() (*Config, error) {
 		KVBlockScorerConfig:  DefaultKVBlockScorerConfig(),
 		TokenizersPoolConfig: tokenizerPoolConfig,
 		BackendConfigs:       DefaultKVCacheBackendConfig(),
+		ModelConfigs:         nil, // No default model configs - must be explicitly configured
 	}, nil
 }
 
@@ -292,4 +308,20 @@ func (k *Indexer) SetTokenizer(tokenizer tokenization.Tokenizer, modelName strin
 // blockSize returns the block size from the injected token processor.
 func (k *Indexer) blockSize() int {
 	return k.tokenProcessor.BlockSize()
+}
+
+// GetModelConfig returns the model configuration for the given model name.
+// Returns nil if no configuration is found for the model.
+func (c *Config) GetModelConfig(modelName string) *ModelConfig {
+	if c.ModelConfigs == nil {
+		return nil
+	}
+
+	for _, mc := range c.ModelConfigs {
+		if mc.Name == modelName {
+			return mc
+		}
+	}
+
+	return nil
 }

--- a/pkg/kvcache/indexer_test.go
+++ b/pkg/kvcache/indexer_test.go
@@ -370,3 +370,128 @@ func TestGetPodScores_TruncateZero(t *testing.T) {
 	assert.Equal(t, []uint32{1, 2}, tp.receivedTokens,
 		"token processor should receive all tokens when limit is zero")
 }
+
+func TestModelConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *kvcache.ModelConfig
+		wantValid bool
+	}{
+		{
+			name: "valid model config",
+			config: &kvcache.ModelConfig{
+				Name:      "llama-3-8b",
+				BlockSize: 16,
+				AttentionGroups: []kvcache.AttentionGroupConfig{
+					{WindowSize: 2048, AttentionType: "sliding"},
+					{WindowSize: 0, AttentionType: "full"},
+				},
+			},
+			wantValid: true,
+		},
+		{
+			name: "single attention group",
+			config: &kvcache.ModelConfig{
+				Name:      "gpt-4",
+				BlockSize: 16,
+				AttentionGroups: []kvcache.AttentionGroupConfig{
+					{WindowSize: 0, AttentionType: "full"},
+				},
+			},
+			wantValid: true,
+		},
+		{
+			name: "no attention groups",
+			config: &kvcache.ModelConfig{
+				Name:            "test-model",
+				BlockSize:       16,
+				AttentionGroups: []kvcache.AttentionGroupConfig{},
+			},
+			wantValid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.config.Name, tt.config.Name)
+			assert.Equal(t, tt.config.BlockSize, tt.config.BlockSize)
+			assert.Equal(t, len(tt.config.AttentionGroups), len(tt.config.AttentionGroups))
+		})
+	}
+}
+
+func TestConfig_GetModelConfig(t *testing.T) {
+	config := &kvcache.Config{
+		ModelConfigs: []*kvcache.ModelConfig{
+			{
+				Name:      "llama-3-8b",
+				BlockSize: 16,
+				AttentionGroups: []kvcache.AttentionGroupConfig{
+					{WindowSize: 2048, AttentionType: "sliding"},
+					{WindowSize: 0, AttentionType: "full"},
+				},
+			},
+			{
+				Name:      "gpt-4",
+				BlockSize: 32,
+				AttentionGroups: []kvcache.AttentionGroupConfig{
+					{WindowSize: 0, AttentionType: "full"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		modelName string
+		wantFound bool
+		wantModel *kvcache.ModelConfig
+	}{
+		{
+			name:      "find llama-3-8b",
+			modelName: "llama-3-8b",
+			wantFound: true,
+			wantModel: config.ModelConfigs[0],
+		},
+		{
+			name:      "find gpt-4",
+			modelName: "gpt-4",
+			wantFound: true,
+			wantModel: config.ModelConfigs[1],
+		},
+		{
+			name:      "model not found",
+			modelName: "unknown-model",
+			wantFound: false,
+			wantModel: nil,
+		},
+		{
+			name:      "empty string",
+			modelName: "",
+			wantFound: false,
+			wantModel: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.GetModelConfig(tt.modelName)
+			if tt.wantFound {
+				require.NotNil(t, got)
+				assert.Equal(t, tt.wantModel.Name, got.Name)
+				assert.Equal(t, tt.wantModel.BlockSize, got.BlockSize)
+			} else {
+				assert.Nil(t, got)
+			}
+		})
+	}
+}
+
+func TestConfig_GetModelConfig_NilModelConfigs(t *testing.T) {
+	config := &kvcache.Config{
+		ModelConfigs: nil,
+	}
+
+	got := config.GetModelConfig("any-model")
+	assert.Nil(t, got)
+}

--- a/pkg/kvcache/kvblock/cost_aware_memory.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory.go
@@ -103,23 +103,73 @@ func (m *CostAwareMemoryIndex) MaxCost() int64 {
 
 // CostPodCache wraps a sync.Map of PodEntry and provides cost calculation for memory usage estimation.
 type CostPodCache struct {
-	cache sync.Map // map[PodEntry]struct{}
+	cache sync.Map // map[string]*PodEntry (key: "podID@tier")
 	// size tracks the number of entries in cache for O(1) Len().
 	size atomic.Int64
 }
 
-// Add adds a PodEntry to the cache.
+// Add adds or updates a PodEntry in the cache, merging StoredGroups if the entry exists.
 func (c *CostPodCache) Add(entry PodEntry) {
-	if _, loaded := c.cache.LoadOrStore(entry, struct{}{}); !loaded {
+	cacheKey := podCacheKey(entry.PodIdentifier, entry.DeviceTier, entry.Speculative)
+
+	// Try to load existing entry
+	if existingVal, loaded := c.cache.Load(cacheKey); loaded {
+		if existingEntry, ok := existingVal.(*PodEntry); ok {
+			// Merge StoredGroups
+			existingEntry.StoredGroups = mergeGroupsUnique(existingEntry.StoredGroups, entry.StoredGroups)
+			// Store updated entry
+			c.cache.Store(cacheKey, existingEntry)
+		}
+	} else {
+		// Create new entry
+		newEntry := &PodEntry{
+			PodIdentifier: entry.PodIdentifier,
+			DeviceTier:    entry.DeviceTier,
+			Speculative:   entry.Speculative,
+			StoredGroups:  mergeGroupsUnique(nil, entry.StoredGroups),
+		}
+		c.cache.Store(cacheKey, newEntry)
 		c.size.Add(1)
 	}
 }
 
-// Delete removes a PodEntry from the cache.
+// Delete removes a PodEntry from the cache entirely.
 func (c *CostPodCache) Delete(entry PodEntry) {
-	if _, loaded := c.cache.LoadAndDelete(entry); loaded {
+	cacheKey := podCacheKey(entry.PodIdentifier, entry.DeviceTier, entry.Speculative)
+	if _, loaded := c.cache.LoadAndDelete(cacheKey); loaded {
 		c.size.Add(-1)
 	}
+}
+
+// RemoveGroups removes specified groups from a PodEntry's StoredGroups.
+// If no groups remain, the entry is deleted.
+func (c *CostPodCache) RemoveGroups(entry PodEntry) bool {
+	cacheKey := podCacheKey(entry.PodIdentifier, entry.DeviceTier, entry.Speculative)
+
+	existingVal, loaded := c.cache.Load(cacheKey)
+	if !loaded {
+		return false
+	}
+
+	existingEntry, ok := existingVal.(*PodEntry)
+	if !ok {
+		return false
+	}
+
+	// Remove specified groups
+	updatedGroups := removeGroups(existingEntry.StoredGroups, entry.StoredGroups)
+
+	if len(updatedGroups) == 0 {
+		// No groups left, delete the entry
+		c.cache.Delete(cacheKey)
+		c.size.Add(-1)
+		return true
+	}
+
+	// Update with remaining groups
+	existingEntry.StoredGroups = updatedGroups
+	c.cache.Store(cacheKey, existingEntry)
+	return false
 }
 
 // Len returns the number of entries in the cache.
@@ -141,16 +191,22 @@ func (c *CostPodCache) CalculateByteSize(keyStr string) int64 {
 
 	// Count entries and calculate their size
 	c.cache.Range(func(key, value interface{}) bool {
-		entry, ok := key.(PodEntry)
-		if !ok {
+		// key is now a string, value is *PodEntry
+		keyStr, okKey := key.(string)
+		entry, okEntry := value.(*PodEntry)
+		if !okKey || !okEntry {
 			return true
 		}
 
 		entryCount++
-		totalBytes += int64(len(entry.PodIdentifier)) // PodIdentifier string content
-		totalBytes += int64(len(entry.DeviceTier))    // DeviceTier string content
-		totalBytes += 32                              // string headers (16 bytes each for 2 strings)
-		totalBytes += 8                               // struct padding/alignment
+		totalBytes += int64(len(keyStr))                 // cache key string
+		totalBytes += int64(len(entry.PodIdentifier))    // PodIdentifier string content
+		totalBytes += int64(len(entry.DeviceTier))       // DeviceTier string content
+		totalBytes += int64(len(entry.StoredGroups) * 8) // StoredGroups slice (8 bytes per int)
+		totalBytes += 32                                 // string headers (16 bytes each for 2 strings)
+		totalBytes += 24                                 // slice header for StoredGroups
+		totalBytes += 8                                  // pointer to PodEntry
+		totalBytes += 8                                  // struct padding/alignment
 		return true
 	})
 
@@ -234,17 +290,17 @@ func (m *CostAwareMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHa
 			if podIdentifierSet.Len() == 0 {
 				// If no pod identifiers are provided, return all pods
 				pods.cache.Range(func(k, value interface{}) bool {
-					if pod, ok := k.(PodEntry); ok {
-						podsPerKey[key] = append(podsPerKey[key], pod)
+					if pod, ok := value.(*PodEntry); ok {
+						podsPerKey[key] = append(podsPerKey[key], *pod)
 					}
 					return true
 				})
 			} else {
 				// Filter pods based on the provided pod identifiers
 				pods.cache.Range(func(k, value interface{}) bool {
-					if pod, ok := k.(PodEntry); ok {
+					if pod, ok := value.(*PodEntry); ok {
 						if podIdentifierSet.Has(pod.PodIdentifier) {
-							podsPerKey[key] = append(podsPerKey[key], pod)
+							podsPerKey[key] = append(podsPerKey[key], *pod)
 						}
 					}
 					return true
@@ -307,7 +363,8 @@ func (m *CostAwareMemoryIndex) Evict(ctx context.Context, key BlockHash, keyType
 	podCacheLenBefore := podCache.Len()
 
 	for _, entry := range entries {
-		podCache.Delete(entry)
+		// Remove groups from the entry; if no groups remain, the entry is deleted
+		podCache.RemoveGroups(entry)
 	}
 
 	if podCache.Len() == 0 {

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -88,9 +88,9 @@ var _ Index = &InMemoryIndex{}
 
 // PodCache represents a cache for pod entries.
 type PodCache struct {
-	// cache is an LRU cache that maps PodEntry to their last access time.
-	// thread-safe.
-	cache *lru.Cache[PodEntry, struct{}]
+	// cache is an LRU cache that maps "podID@tier" keys to PodEntry pointers.
+	// This allows in-place updates of StoredGroups without recreating entries.
+	cache *lru.Cache[string, *PodEntry]
 	// mu protects the cache from concurrent access during check-and-set operations.
 	mu sync.Mutex
 }
@@ -126,12 +126,14 @@ func (m *InMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 
 			if podIdentifierSet.Len() == 0 {
 				// If no pod identifiers are provided, return all pods
-				podsPerKey[requestKey] = pods.cache.Keys()
+				for _, podEntry := range pods.cache.Values() {
+					podsPerKey[requestKey] = append(podsPerKey[requestKey], *podEntry)
+				}
 			} else {
 				// Filter pods based on the provided pod identifiers
-				for _, pod := range pods.cache.Keys() {
-					if podIdentifierSet.Has(pod.PodIdentifier) {
-						podsPerKey[requestKey] = append(podsPerKey[requestKey], pod)
+				for _, podEntry := range pods.cache.Values() {
+					if podIdentifierSet.Has(podEntry.PodIdentifier) {
+						podsPerKey[requestKey] = append(podsPerKey[requestKey], *podEntry)
 					}
 				}
 			}
@@ -174,7 +176,7 @@ func (m *InMemoryIndex) Add(ctx context.Context, engineKeys, requestKeys []Block
 		//nolint:nestif // double-checked locking pattern
 		if !found {
 			// Create new cache
-			cache, err := lru.New[PodEntry, struct{}](m.podCacheSize)
+			cache, err := lru.New[string, *PodEntry](m.podCacheSize)
 			if err != nil {
 				return fmt.Errorf("failed to create pod cache for key %s: %w", requestKey.String(), err)
 			}
@@ -201,11 +203,30 @@ func (m *InMemoryIndex) Add(ctx context.Context, engineKeys, requestKeys []Block
 
 		podCache.mu.Lock()
 		for _, entry := range entries {
-			podCache.cache.Add(entry, struct{}{})
+			cacheKey := podCacheKey(entry.PodIdentifier, entry.DeviceTier, entry.Speculative)
+
+			// Check if entry already exists
+			existingEntry, found := podCache.cache.Get(cacheKey)
+			if found {
+				// Merge StoredGroups, deduplicating and preserving order
+				existingEntry.StoredGroups = mergeGroupsUnique(existingEntry.StoredGroups, entry.StoredGroups)
+				// Re-add to update LRU position
+				podCache.cache.Add(cacheKey, existingEntry)
+				traceLogger.Info("updated existing pod entry with merged groups",
+					"requestKey", requestKey, "pod", existingEntry)
+			} else {
+				// Create new entry (copy to avoid mutation)
+				newEntry := &PodEntry{
+					PodIdentifier: entry.PodIdentifier,
+					DeviceTier:    entry.DeviceTier,
+					Speculative:   entry.Speculative,
+					StoredGroups:  mergeGroupsUnique(nil, entry.StoredGroups),
+				}
+				podCache.cache.Add(cacheKey, newEntry)
+				traceLogger.Info("added new pod entry", "requestKey", requestKey, "pod", newEntry)
+			}
 		}
 		podCache.mu.Unlock()
-
-		traceLogger.Info("added pods to key", "requestKey", requestKey, "pods", entries)
 	}
 
 	return nil
@@ -252,13 +273,36 @@ func (m *InMemoryIndex) Evict(ctx context.Context, key BlockHash, keyType KeyTyp
 
 	podCache.mu.Lock()
 	for _, entry := range entries {
-		podCache.cache.Remove(entry)
+		cacheKey := podCacheKey(entry.PodIdentifier, entry.DeviceTier, entry.Speculative)
+
+		existingEntry, found := podCache.cache.Get(cacheKey)
+		if !found {
+			traceLogger.Info("pod entry not found for eviction, skipping",
+				"requestKey", requestKey, "podID", entry.PodIdentifier, "tier", entry.DeviceTier)
+			continue
+		}
+
+		// Remove the specified groups from StoredGroups
+		updatedGroups := removeGroups(existingEntry.StoredGroups, entry.StoredGroups)
+
+		if len(updatedGroups) == 0 {
+			// No groups left, remove the entire pod entry
+			podCache.cache.Remove(cacheKey)
+			traceLogger.Info("removed pod entry (no groups remaining)",
+				"requestKey", requestKey, "pod", existingEntry)
+		} else {
+			// Update with remaining groups
+			existingEntry.StoredGroups = updatedGroups
+			podCache.cache.Add(cacheKey, existingEntry)
+			traceLogger.Info("updated pod entry after group removal",
+				"requestKey", requestKey, "pod", existingEntry, "remainingGroups", updatedGroups)
+		}
 	}
 
 	isEmpty := podCache.cache.Len() == 0
 	podCache.mu.Unlock()
 
-	traceLogger.Info("evicted pods from key", "requestKey", requestKey, "key", key, "keyType", keyType, "pods", entries)
+	traceLogger.Info("processed eviction", "requestKey", requestKey, "key", key, "keyType", keyType, "entries", entries)
 
 	// Remove key from main cache if empty.
 	// Re-fetch and hold the lock through removal to prevent racing with Add.
@@ -292,6 +336,57 @@ func (m *InMemoryIndex) GetRequestKey(ctx context.Context, engineKey BlockHash) 
 		return EmptyBlockHash, fmt.Errorf("engine key not found: %s", engineKey.String())
 	}
 	return requestKey, nil
+}
+
+// podCacheKey generates a cache key for a pod entry.
+// Format: "podIdentifier@deviceTier" or "podIdentifier@deviceTier[speculative]"
+func podCacheKey(podIdentifier, deviceTier string, speculative bool) string {
+	key := podIdentifier + "@" + deviceTier
+	if speculative {
+		key += "[speculative]"
+	}
+	return key
+}
+
+// mergeGroupsUnique merges two group lists, removing duplicates and preserving order.
+// Elements from 'existing' come first, followed by new elements from 'incoming'.
+func mergeGroupsUnique(existing, incoming []int) []int {
+	// 1. If incoming is empty, return existing as-is
+	if len(incoming) == 0 {
+		return existing
+	}
+	firstIncoming := incoming[0]
+
+	for _, v := range existing {
+		if v == firstIncoming {
+			return existing // Already there, nothing to do
+		}
+	}
+	result := make([]int, 0, len(existing)+1)
+	result = append(result, existing...)
+	result = append(result, firstIncoming)
+	return result
+}
+
+// removeGroups removes specified groups from the list,
+// maintaining order of remaining elements.
+func removeGroups(existing, toRemove []int) []int {
+	if len(toRemove) == 0 || len(existing) == 0 {
+		return existing
+	}
+	target := toRemove[0]
+	targetIdx := -1
+	for i, v := range existing {
+		if v == target {
+			targetIdx = i
+			break
+		}
+	}
+	if targetIdx == -1 {
+		return existing
+	}
+	copy(existing[targetIdx:], existing[targetIdx+1:])
+	return existing[:len(existing)-1]
 }
 
 // podsPerKeyPrintHelper formats a map of keys to pod names for printing.

--- a/pkg/kvcache/kvblock/index.go
+++ b/pkg/kvcache/kvblock/index.go
@@ -172,6 +172,8 @@ type PodEntry struct {
 	DeviceTier string
 	// Speculative indicates the entry was added predictively before a KV event confirmed it.
 	Speculative bool
+	// StoredGroups tracks the group IDs that have stored this block.
+	StoredGroups []int
 }
 
 // String returns a string representation of the PodEntry.

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -18,6 +18,7 @@ package kvblock
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -173,12 +174,11 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 
 	// pipeline for single RTT
 	pipe := r.RedisClient.Pipeline()
-	results := make([]*redis.StringSliceCmd, len(requestKeys))
+	results := make([]*redis.MapStringStringCmd, len(requestKeys))
 
-	// queue an HKeys command for each key in the pipeline
+	// queue an HGetAll command for each key in the pipeline to get all field:value pairs
 	for i, key := range requestKeys {
-		// HKeys gets all field names
-		results[i] = pipe.HKeys(ctx, key.String())
+		results[i] = pipe.HGetAll(ctx, key.String())
 	}
 
 	_, execErr := pipe.Exec(ctx)
@@ -191,8 +191,8 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 	for idx, cmd := range results {
 		key := requestKeys[idx]
 
-		// cmd.Result() returns the slice of strings (pod IDs) which is the first layer in the mapping
-		pods, cmdErr := cmd.Result()
+		// cmd.Result() returns a map[string]string of entryKey -> JSON data
+		entryMap, cmdErr := cmd.Result()
 		if cmdErr != nil {
 			if !errors.Is(cmdErr, redis.Nil) {
 				logger.Error(cmdErr, "failed to get pods for key", "key", key)
@@ -201,23 +201,26 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 			return podsPerKey, nil // early stop since prefix-chain breaks here
 		}
 
+		if len(entryMap) == 0 {
+			logger.Info("no pods found for key, cutting search", "key", key)
+			return podsPerKey, nil // early stop since prefix-chain breaks here
+		}
+
 		var filteredPods []PodEntry
-		for _, p := range pods {
-			ip := strings.SplitN(p, "@", 2)[0]
-			if !filterPods || podIdentifierSet.Has(ip) {
-				tier := strings.SplitN(p, "@", 2)[1]
-				speculative := false
-				// Strip annotation suffix e.g. "gpu[speculative]" -> "gpu"
-				if idx := strings.Index(tier, "["); idx != -1 {
-					speculative = strings.Contains(tier[idx:], "speculative")
-					tier = tier[:idx]
-				}
-				filteredPods = append(filteredPods, PodEntry{PodIdentifier: ip, DeviceTier: tier, Speculative: speculative})
+		for _, jsonData := range entryMap {
+			var entry PodEntry
+			if err := json.Unmarshal([]byte(jsonData), &entry); err != nil {
+				logger.Error(err, "failed to unmarshal pod entry", "key", key, "data", jsonData)
+				continue
+			}
+
+			if !filterPods || podIdentifierSet.Has(entry.PodIdentifier) {
+				filteredPods = append(filteredPods, entry)
 			}
 		}
 
 		if len(filteredPods) == 0 {
-			logger.Info("no pods found for key, cutting search", "key", key)
+			logger.Info("no pods found for key after filtering, cutting search", "key", key)
 			return podsPerKey, nil // early stop since prefix-chain breaks here
 		}
 
@@ -238,22 +241,63 @@ func (r *RedisIndex) Add(ctx context.Context, engineKeys, requestKeys []BlockHas
 		return fmt.Errorf("mismatch between engine keys and request keys length")
 	}
 
-	pipe := r.RedisClient.Pipeline()
 	for i, requestKey := range requestKeys {
 		redisKey := requestKey.String()
 
 		// Store engineKey -> requestKey mapping (only if engineKeys provided)
 		if engineKeys != nil {
-			pipe.Set(ctx, redisEngineKey(engineKeys[i]), redisKey, 0)
+			if err := r.RedisClient.Set(ctx, redisEngineKey(engineKeys[i]), redisKey, 0).Err(); err != nil {
+				return fmt.Errorf("failed to set engine key mapping: %w", err)
+			}
 		}
-		for _, entry := range entries {
-			// Use HSet to add the pod identifier as a field in the hash
-			pipe.HSet(ctx, redisKey, entry.String(), "")
-		}
-	}
 
-	if _, err := pipe.Exec(ctx); err != nil {
-		return fmt.Errorf("failed to add entries to Redis: %w", err)
+		for _, entry := range entries {
+			entryKey := podEntryKey(entry.PodIdentifier, entry.DeviceTier)
+
+			// Get existing entry if it exists
+			existingData, err := r.RedisClient.HGet(ctx, redisKey, entryKey).Result()
+			if err == nil {
+				// Entry exists, merge groups
+				var existingEntry PodEntry
+				if err := json.Unmarshal([]byte(existingData), &existingEntry); err != nil {
+					return fmt.Errorf("failed to unmarshal existing entry: %w", err)
+				}
+
+				// Merge StoredGroups
+				existingEntry.StoredGroups = mergeGroupsUnique(existingEntry.StoredGroups, entry.StoredGroups)
+				// Update speculative flag if new entry is confirmed
+				if !entry.Speculative {
+					existingEntry.Speculative = false
+				}
+
+				// Serialize and store updated entry
+				data, err := json.Marshal(existingEntry)
+				if err != nil {
+					return fmt.Errorf("failed to marshal updated entry: %w", err)
+				}
+				if err := r.RedisClient.HSet(ctx, redisKey, entryKey, data).Err(); err != nil {
+					return fmt.Errorf("failed to update entry in Redis: %w", err)
+				}
+			} else if errors.Is(err, redis.Nil) {
+				// Entry doesn't exist, create new with deduplicated groups
+				newEntry := PodEntry{
+					PodIdentifier: entry.PodIdentifier,
+					DeviceTier:    entry.DeviceTier,
+					Speculative:   entry.Speculative,
+					StoredGroups:  mergeGroupsUnique(nil, entry.StoredGroups),
+				}
+
+				data, err := json.Marshal(newEntry)
+				if err != nil {
+					return fmt.Errorf("failed to marshal new entry: %w", err)
+				}
+				if err := r.RedisClient.HSet(ctx, redisKey, entryKey, data).Err(); err != nil {
+					return fmt.Errorf("failed to add entry to Redis: %w", err)
+				}
+			} else {
+				return fmt.Errorf("failed to check existing entry: %w", err)
+			}
+		}
 	}
 
 	return nil
@@ -286,15 +330,44 @@ func (r *RedisIndex) Evict(ctx context.Context, key BlockHash, keyType KeyType, 
 	}
 
 	redisKey := requestKey.String()
-	pipe := r.RedisClient.Pipeline()
 
 	for _, entry := range entries {
-		// Use HDel to remove the pod identifier field from the hash
-		pipe.HDel(ctx, redisKey, entry.String())
-	}
+		entryKey := podEntryKey(entry.PodIdentifier, entry.DeviceTier)
 
-	if _, err := pipe.Exec(ctx); err != nil {
-		return fmt.Errorf("failed to evict entries from Redis: %w", err)
+		// Get existing entry
+		existingData, err := r.RedisClient.HGet(ctx, redisKey, entryKey).Result()
+		if errors.Is(err, redis.Nil) {
+			// Entry doesn't exist, nothing to evict
+			continue
+		} else if err != nil {
+			return fmt.Errorf("failed to get existing entry: %w", err)
+		}
+
+		// Deserialize existing entry
+		var existingEntry PodEntry
+		if err := json.Unmarshal([]byte(existingData), &existingEntry); err != nil {
+			return fmt.Errorf("failed to unmarshal existing entry: %w", err)
+		}
+
+		// Remove specified groups
+		updatedGroups := removeGroups(existingEntry.StoredGroups, entry.StoredGroups)
+
+		if len(updatedGroups) == 0 {
+			// No groups left, remove the entire entry
+			if err := r.RedisClient.HDel(ctx, redisKey, entryKey).Err(); err != nil {
+				return fmt.Errorf("failed to delete entry from Redis: %w", err)
+			}
+		} else {
+			// Update with remaining groups
+			existingEntry.StoredGroups = updatedGroups
+			data, err := json.Marshal(existingEntry)
+			if err != nil {
+				return fmt.Errorf("failed to marshal updated entry: %w", err)
+			}
+			if err := r.RedisClient.HSet(ctx, redisKey, entryKey, data).Err(); err != nil {
+				return fmt.Errorf("failed to update entry in Redis: %w", err)
+			}
+		}
 	}
 
 	// Atomically check hash length and delete engine key if empty (only if engine key mapping exists)
@@ -323,4 +396,10 @@ func (r *RedisIndex) GetRequestKey(ctx context.Context, engineKey BlockHash) (Bl
 
 func redisEngineKey(engineKey BlockHash) string {
 	return "engine:" + engineKey.String()
+}
+
+// podEntryKey generates a hash field key for a pod entry.
+// Format: "podIdentifier@deviceTier"
+func podEntryKey(podIdentifier, deviceTier string) string {
+	return podIdentifier + "@" + deviceTier
 }

--- a/pkg/kvcache/kvblock_scorer.go
+++ b/pkg/kvcache/kvblock_scorer.go
@@ -29,12 +29,15 @@ type KVScoringStrategy string
 const (
 	// LongestPrefixMatch Score by longest consecutive match from start.
 	LongestPrefixMatch KVScoringStrategy = "LongestPrefix"
+	// HybridPrefixMatch Score by longest prefix considering multiple attention groups.
+	HybridPrefixMatch KVScoringStrategy = "HybridPrefix"
 )
 
 // KVBlockScorerConfig holds the configuration for the KVBlockScorer.
 type KVBlockScorerConfig struct {
 	ScoringStrategy KVScoringStrategy
 	BackendConfigs  []*KVCacheBackendConfig `json:"backendConfigs"`
+	ModelConfig     *ModelConfig            // Model config for hybrid attention scoring
 }
 
 // DefaultKVBlockScorerConfig returns the default configuration for the KVBlockScorer.
@@ -58,16 +61,24 @@ type KVBlockScorer interface {
 
 // NewKVBlockScorer creates a new KVBlockScorer based on the provided strategy.
 func NewKVBlockScorer(config *KVBlockScorerConfig) (KVBlockScorer, error) {
+	// Build weight map from list of BackendConfigs for efficient lookup
+	weightMap := make(map[string]float64)
+	for _, medium := range config.BackendConfigs {
+		weightMap[medium.Name] = medium.Weight
+	}
+
 	switch config.ScoringStrategy {
 	case LongestPrefixMatch:
-		// Build weight map from list of BackendConfigs for efficient lookup
-		weightMap := make(map[string]float64)
-		for _, medium := range config.BackendConfigs {
-			weightMap[medium.Name] = medium.Weight
-		}
-
 		return &LongestPrefixScorer{
 			MediumWeights: weightMap,
+		}, nil
+	case HybridPrefixMatch:
+		if config.ModelConfig == nil {
+			return nil, fmt.Errorf("HybridPrefixMatch requires ModelConfig")
+		}
+		return &HybridPrefixCacheScorer{
+			MediumWeights: weightMap,
+			ModelConfig:   config.ModelConfig,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported scoring strategy: %s", config.ScoringStrategy)
@@ -151,4 +162,622 @@ func (s *LongestPrefixScorer) Score(
 
 	// Return the map containing the final score for each pod encountered.
 	return podScores, nil
+}
+
+// HybridPrefixCacheScorer implements hybrid attention scoring using a fixed-point
+// algorithm to find the longest cache hit across multiple attention groups.
+// Based on vLLM's find_longest_cache_hit algorithm.
+type HybridPrefixCacheScorer struct {
+	// MediumWeights maps medium/device tier names to their scoring weights
+	MediumWeights map[string]float64
+	// ModelConfig holds the model-specific configuration with attention groups
+	ModelConfig *ModelConfig
+}
+
+// Strategy returns the strategy type: HybridPrefixMatch.
+func (s *HybridPrefixCacheScorer) Strategy() KVScoringStrategy {
+	return HybridPrefixMatch
+}
+
+// Score implements hybrid prefix scoring with weighted combination of Full and SWA scores.
+// Algorithm:
+// 1. Identify Full Attention groups (primary) and SWA groups (secondary)
+// 2. Full Attention: Score longest consecutive prefix from start (left-to-right)
+// 3. SWA: Score longest consecutive suffix from end (right-to-left, up to window size)
+// 4. Normalize: score = 0.7 × fullHitRatio + 0.3 × swaHitRatio
+//
+// This matches vLLM's scoring logic where:
+// - Full Attention requires consecutive prefix (strict)
+// - SWA only cares about recent context (tail matching)
+func (s *HybridPrefixCacheScorer) Score(
+	ctx context.Context,
+	keys []kvblock.BlockHash,
+	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
+) (map[string]float64, error) {
+	if len(keys) == 0 {
+		return make(map[string]float64), nil
+	}
+
+	if s.ModelConfig == nil || len(s.ModelConfig.AttentionGroups) == 0 {
+		// Fallback to simple longest prefix if no attention groups configured
+		return s.scoreLongestPrefix(ctx, keys, keyToPods)
+	}
+
+	// Identify Full Attention (primary) and SWA (secondary) groups
+	fullGroups := make([]int, 0)
+	swaGroups := make([]int, 0)
+
+	for idx, group := range s.ModelConfig.AttentionGroups {
+		if group.AttentionType == "full" || group.WindowSize == 0 {
+			fullGroups = append(fullGroups, idx)
+		} else {
+			swaGroups = append(swaGroups, idx)
+		}
+	}
+
+	// If no groups identified, fallback to simple prefix scoring
+	if len(fullGroups) == 0 && len(swaGroups) == 0 {
+		return s.scoreLongestPrefix(ctx, keys, keyToPods)
+	}
+
+	return s.scoreWithWeightedCombination(keys, keyToPods, fullGroups, swaGroups)
+}
+
+// scoreWithWeightedCombination implements weighted combination scoring:
+// score = 0.7 × fullHitRatio + 0.3 × swaHitRatio
+//
+// Full Attention: Longest consecutive prefix from start (left-to-right)
+// SWA: Longest consecutive suffix from end (right-to-left, up to window size)
+func (s *HybridPrefixCacheScorer) scoreWithWeightedCombination(
+	keys []kvblock.BlockHash,
+	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
+	fullGroups []int,
+	swaGroups []int,
+) (map[string]float64, error) {
+	totalBlocks := len(keys)
+	maxPossibleScore := float64(totalBlocks)
+
+	// Collect all pods
+	allPods := make(map[string]struct{})
+	for _, entries := range keyToPods {
+		for _, entry := range entries {
+			allPods[entry.PodIdentifier] = struct{}{}
+		}
+	}
+
+	podScores := make(map[string]float64)
+
+	for podID := range allPods {
+		var fullScore float64
+		var swaScore float64
+
+		// Score Full Attention groups (prefix matching from start)
+		if len(fullGroups) > 0 {
+			fullScore = s.scoreFullAttentionForPod(keys, keyToPods, podID, fullGroups)
+		}
+
+		// Score SWA groups (suffix matching from end)
+		if len(swaGroups) > 0 {
+			swaScore = s.scoreSWAForPod(keys, keyToPods, podID, swaGroups)
+		}
+
+		// Weighted combination: 0.7 × full + 0.3 × swa
+		// Normalize by max possible score
+		fullRatio := fullScore / maxPossibleScore
+		swaRatio := swaScore / maxPossibleScore
+
+		normalizedScore := 0.7*fullRatio + 0.3*swaRatio
+
+		if normalizedScore > 0 {
+			podScores[podID] = normalizedScore
+		}
+	}
+
+	return podScores, nil
+}
+
+// scoreFullAttentionForPod scores Full Attention groups using longest prefix matching.
+// Returns weighted sum of matching blocks from start.
+func (s *HybridPrefixCacheScorer) scoreFullAttentionForPod(
+	keys []kvblock.BlockHash,
+	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
+	podID string,
+	fullGroups []int,
+) float64 {
+	score := 0.0
+
+	// Find longest consecutive prefix where pod has ALL full attention groups
+	for i := 0; i < len(keys); i++ {
+		entries := keyToPods[keys[i]]
+		hasAllGroups := false
+
+		for _, entry := range entries {
+			if entry.PodIdentifier == podID {
+				// Check if this entry has all required full attention groups
+				hasAll := true
+				for _, groupIdx := range fullGroups {
+					if !containsGroup(entry.StoredGroups, groupIdx) {
+						hasAll = false
+						break
+					}
+				}
+				if hasAll {
+					hasAllGroups = true
+					// Get tier weight
+					weight := 1.0
+					if s.MediumWeights != nil {
+						if w, exists := s.MediumWeights[entry.DeviceTier]; exists {
+							weight = w
+						}
+					}
+					score += weight
+				}
+				break
+			}
+		}
+
+		if !hasAllGroups {
+			break // Prefix broken, stop counting
+		}
+	}
+
+	return score
+}
+
+// scoreSWAForPod scores SWA groups using longest suffix matching from end.
+// Matches vLLM's right-to-left search for sliding window attention.
+// Returns weighted sum of matching blocks from end (up to window size).
+func (s *HybridPrefixCacheScorer) scoreSWAForPod(
+	keys []kvblock.BlockHash,
+	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
+	podID string,
+	swaGroups []int,
+) float64 {
+	if len(keys) == 0 || len(swaGroups) == 0 {
+		return 0.0
+	}
+
+	// Find the minimum window size across all SWA groups
+	minWindowBlocks := len(keys) // Default to all blocks
+	for _, groupIdx := range swaGroups {
+		if groupIdx < len(s.ModelConfig.AttentionGroups) {
+			group := s.ModelConfig.AttentionGroups[groupIdx]
+			blockSize := group.BlockSize
+			if blockSize <= 0 {
+				blockSize = s.ModelConfig.BlockSize
+			}
+			if blockSize <= 0 {
+				continue
+			}
+
+			windowBlocks := (group.WindowSize + blockSize - 1) / blockSize
+			if windowBlocks > 0 && windowBlocks < minWindowBlocks {
+				minWindowBlocks = windowBlocks
+			}
+		}
+	}
+
+	score := 0.0
+	numContiguous := 0
+
+	// Search right-to-left from end (vLLM approach)
+	for i := len(keys) - 1; i >= 0; i-- {
+		entries := keyToPods[keys[i]]
+		hasAllGroups := false
+
+		for _, entry := range entries {
+			if entry.PodIdentifier == podID {
+				// Check if this entry has all required SWA groups
+				hasAll := true
+				for _, groupIdx := range swaGroups {
+					if !containsGroup(entry.StoredGroups, groupIdx) {
+						hasAll = false
+						break
+					}
+				}
+				if hasAll {
+					hasAllGroups = true
+					// Get tier weight
+					weight := 1.0
+					if s.MediumWeights != nil {
+						if w, exists := s.MediumWeights[entry.DeviceTier]; exists {
+							weight = w
+						}
+					}
+					score += weight
+					numContiguous++
+				}
+				break
+			}
+		}
+
+		if !hasAllGroups {
+			numContiguous = 0 // Reset, need contiguous blocks
+			score = 0.0
+		} else if numContiguous >= minWindowBlocks {
+			break // Found enough blocks for window, stop
+		}
+	}
+
+	return score
+}
+
+// scorePerPodHitLength calculates scores with per-pod hit length.
+// Each pod is scored based on the minimum hit length across all groups for that pod.
+// Score = avgTierWeight * (hitLength / totalRequestedBlocks)
+// This prioritizes both cache completeness and tier quality.
+func (s *HybridPrefixCacheScorer) scorePerPodHitLength(
+	keys []kvblock.BlockHash,
+	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
+) (map[string]float64, error) {
+	totalRequestedBlocks := len(keys)
+
+	// Step 1: Collect all pods
+	allPods := make(map[string]struct{})
+	for _, entries := range keyToPods {
+		for _, entry := range entries {
+			allPods[entry.PodIdentifier] = struct{}{}
+		}
+	}
+
+	// Step 2: For each pod, calculate hit length per group
+	podScores := make(map[string]float64)
+
+	for podID := range allPods {
+		// Calculate hit length for this pod across all groups
+		// Track which group gave the minimum hit length to use its block size for scoring
+		var minHitLength int
+		var minBlockSize int
+
+		for groupIdx, group := range s.ModelConfig.AttentionGroups {
+			// Get block size for this group (fallback to model default if not set)
+			blockSize := group.BlockSize
+			if blockSize <= 0 {
+				blockSize = s.ModelConfig.BlockSize
+			}
+			if blockSize <= 0 {
+				return nil, fmt.Errorf("invalid block size for group %d: %d", groupIdx, blockSize)
+			}
+
+			// Find longest consecutive prefix for this pod in this group
+			hitLength := s.findPodGroupCacheHit(keys, keyToPods, podID, groupIdx, &group, blockSize)
+
+			// Track minimum hit length and its corresponding block size
+			if groupIdx == 0 || hitLength < minHitLength {
+				minHitLength = hitLength
+				minBlockSize = blockSize
+			}
+		}
+
+		// Skip pods with zero hit length
+		if minHitLength == 0 {
+			continue
+		}
+
+		// Calculate cumulative tier weight for blocks in hit length
+		// Use the block size from the group that gave minimum hit length
+		numBlocks := minHitLength / minBlockSize
+		cumulativeTierWeight := 0.0
+
+		for i := 0; i < numBlocks; i++ {
+			entries := keyToPods[keys[i]]
+			for _, entry := range entries {
+				if entry.PodIdentifier == podID {
+					weight := 1.0
+					if s.MediumWeights != nil {
+						if w, exists := s.MediumWeights[entry.DeviceTier]; exists {
+							weight = w
+						}
+					}
+					cumulativeTierWeight += weight
+					break // Found this pod's entry for this block
+				}
+			}
+		}
+
+		// Normalize by total requested blocks to get completeness-weighted score
+		// score = avgTierWeight * (hitLength / totalRequestedBlocks)
+		//       = (sum(tierWeights) / hitLength) * (hitLength / totalRequestedBlocks)
+		//       = sum(tierWeights) / totalRequestedBlocks
+		if totalRequestedBlocks > 0 {
+			podScores[podID] = cumulativeTierWeight / float64(totalRequestedBlocks)
+		}
+	}
+
+	return podScores, nil
+}
+
+// findPodGroupCacheHit finds the longest consecutive prefix for a specific pod in a specific group.
+func (s *HybridPrefixCacheScorer) findPodGroupCacheHit(
+	keys []kvblock.BlockHash,
+	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
+	podID string,
+	groupIndex int,
+	group *AttentionGroupConfig,
+	blockSize int,
+) int {
+	// Apply window size constraint
+	maxLength := len(keys) * blockSize
+	if group.AttentionType != "full" && group.WindowSize > 0 && group.WindowSize < maxLength {
+		maxLength = group.WindowSize
+	}
+
+	maxBlocks := maxLength / blockSize
+	if maxBlocks > len(keys) {
+		maxBlocks = len(keys)
+	}
+
+	// Find longest consecutive prefix where this specific pod has blocks with this group
+	longestHit := 0
+
+	for i := 0; i < maxBlocks; i++ {
+		entries := keyToPods[keys[i]]
+		found := false
+
+		for _, entry := range entries {
+			if entry.PodIdentifier == podID && containsGroup(entry.StoredGroups, groupIndex) {
+				found = true
+				break
+			}
+		}
+
+		if found {
+			longestHit = (i + 1) * blockSize
+		} else {
+			break // Consecutive chain broken
+		}
+	}
+
+	return longestHit
+}
+
+// findLongestCacheHit implements the fixed-point algorithm to find the longest
+// cache hit that works for all attention groups.
+// DEPRECATED: This is kept for reference but no longer used in per-pod scoring.
+func (s *HybridPrefixCacheScorer) findLongestCacheHit(
+	keys []kvblock.BlockHash,
+	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
+	maxHitLength int,
+	blockSize int,
+) int {
+	numGroups := len(s.ModelConfig.AttentionGroups)
+	hitLength := maxHitLength
+	hitLengthByGroup := make([]int, numGroups)
+
+	// Check if this is a simple hybrid (exactly 2 groups, one being full attention)
+	// Simple hybrid converges in one iteration, matching vLLM's optimization.
+	isSimpleHybrid := false
+	if numGroups == 2 {
+		for _, group := range s.ModelConfig.AttentionGroups {
+			if group.AttentionType == "full" {
+				isSimpleHybrid = true
+				break
+			}
+		}
+	}
+
+	// Fixed-point iteration
+	for {
+		currHitLength := hitLength
+
+		// Check each attention group's constraints
+		for i, group := range s.ModelConfig.AttentionGroups {
+			groupHitLength := s.findGroupCacheHit(
+				keys, keyToPods, currHitLength, blockSize, i, &group)
+
+			hitLengthByGroup[i] = groupHitLength
+
+			// Update current hit length to minimum across all groups
+			if groupHitLength < currHitLength {
+				currHitLength = groupHitLength
+			}
+		}
+
+		// Converged when hit length doesn't decrease
+		if currHitLength >= hitLength {
+			break
+		}
+
+		hitLength = currHitLength
+
+		// Simple hybrid optimization: one iteration is enough
+		if isSimpleHybrid {
+			break
+		}
+	}
+
+	return hitLength
+}
+
+// findGroupCacheHit finds the longest cache hit for a specific attention group.
+// Only considers pods that have blocks cached for the given groupIndex.
+func (s *HybridPrefixCacheScorer) findGroupCacheHit(
+	keys []kvblock.BlockHash,
+	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
+	maxLength int,
+	blockSize int,
+	groupIndex int,
+	group *AttentionGroupConfig,
+) int {
+	// Apply window size constraint if specified
+	// Full attention (AttentionType == "full") has no window constraint (WindowSize = 0)
+	effectiveMaxLength := maxLength
+	if group.AttentionType != "full" && group.WindowSize > 0 && group.WindowSize < maxLength {
+		effectiveMaxLength = group.WindowSize
+	}
+
+	// Calculate max blocks based on effective length
+	maxBlocks := effectiveMaxLength / blockSize
+	if maxBlocks > len(keys) {
+		maxBlocks = len(keys)
+	}
+
+	// Find longest consecutive prefix where at least one pod has all blocks
+	// Similar to LongestPrefixScorer logic but respects group constraints
+	if maxBlocks == 0 {
+		return 0
+	}
+
+	// Track which pods have consecutive blocks
+	activePods := make(map[string]struct{})
+
+	// Initialize with pods that have the first block AND this group cached
+	for _, entry := range keyToPods[keys[0]] {
+		if containsGroup(entry.StoredGroups, groupIndex) {
+			activePods[entry.PodIdentifier] = struct{}{}
+		}
+	}
+
+	// Walk through blocks up to maxBlocks
+	longestHit := 0
+	for i := 0; i < maxBlocks; i++ {
+		if len(activePods) == 0 {
+			break
+		}
+
+		// Check current key - only include pods that have this group cached
+		currentPods := make(map[string]struct{})
+		for _, entry := range keyToPods[keys[i]] {
+			if containsGroup(entry.StoredGroups, groupIndex) {
+				currentPods[entry.PodIdentifier] = struct{}{}
+			}
+		}
+
+		// Intersect: keep only pods that have this block
+		for pod := range activePods {
+			if _, exists := currentPods[pod]; !exists {
+				delete(activePods, pod)
+			}
+		}
+
+		if len(activePods) > 0 {
+			longestHit = (i + 1) * blockSize
+		} else {
+			break
+		}
+	}
+
+	return longestHit
+}
+
+// scoreByHitLength scores pods based on the converged hit length.
+// Scores are normalized by the number of blocks to make them comparable across requests.
+func (s *HybridPrefixCacheScorer) scoreByHitLength(
+	keys []kvblock.BlockHash,
+	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
+	hitLength int,
+	blockSize int,
+) (map[string]float64, error) {
+	if hitLength == 0 {
+		return make(map[string]float64), nil
+	}
+
+	numBlocks := hitLength / blockSize
+	if numBlocks > len(keys) {
+		numBlocks = len(keys)
+	}
+
+	podScores := make(map[string]float64)
+	curWeights := make(map[string]float64)
+
+	// Score pods that have all blocks up to hitLength
+	for i := 0; i < numBlocks; i++ {
+		clear(curWeights)
+		fillMaxWeights(curWeights, keyToPods[keys[i]], s.MediumWeights)
+
+		// Accumulate scores for pods that have this block
+		for pod, weight := range curWeights {
+			podScores[pod] += weight
+		}
+	}
+
+	// Filter: only keep pods that have ALL blocks in the hit length
+	activePods := make(map[string]struct{})
+	for _, entry := range keyToPods[keys[0]] {
+		activePods[entry.PodIdentifier] = struct{}{}
+	}
+
+	for i := 1; i < numBlocks; i++ {
+		currentPods := make(map[string]struct{})
+		for _, entry := range keyToPods[keys[i]] {
+			currentPods[entry.PodIdentifier] = struct{}{}
+		}
+
+		for pod := range activePods {
+			if _, exists := currentPods[pod]; !exists {
+				delete(activePods, pod)
+			}
+		}
+	}
+
+	// Remove pods that don't have complete prefix
+	for pod := range podScores {
+		if _, exists := activePods[pod]; !exists {
+			delete(podScores, pod)
+		}
+	}
+
+	// Normalize scores by number of blocks (average weight per block)
+	if numBlocks > 0 {
+		for pod := range podScores {
+			podScores[pod] /= float64(numBlocks)
+		}
+	}
+
+	return podScores, nil
+}
+
+// scoreLongestPrefix is a fallback to simple longest prefix scoring when no attention groups configured.
+func (s *HybridPrefixCacheScorer) scoreLongestPrefix(
+	_ context.Context,
+	keys []kvblock.BlockHash,
+	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
+) (map[string]float64, error) {
+	podScores := make(map[string]float64)
+	curWeights := make(map[string]float64)
+
+	fillMaxWeights(curWeights, keyToPods[keys[0]], s.MediumWeights)
+
+	activePods := make(map[string]struct{}, len(curWeights))
+	for pod, w := range curWeights {
+		activePods[pod] = struct{}{}
+		podScores[pod] = w
+	}
+
+	for i := 1; i < len(keys); i++ {
+		if len(activePods) == 0 {
+			break
+		}
+
+		clear(curWeights)
+		fillMaxWeights(curWeights, keyToPods[keys[i]], s.MediumWeights)
+
+		for pod := range activePods {
+			if w, exists := curWeights[pod]; exists {
+				podScores[pod] += w
+			} else {
+				delete(activePods, pod)
+			}
+		}
+	}
+
+	return podScores, nil
+}
+
+// containsGroup checks if a group ID is present in the StoredGroups slice.
+// Returns true if groups is nil/empty (backwards compatibility) or if groupID is found.
+// containsGroup checks if a group ID exists in the StoredGroups slice.
+// For backward compatibility, returns true if groups is nil or empty.
+func containsGroup(groups []int, groupID int) bool {
+	// If StoredGroups is nil/empty, treat as "all groups" for backwards compatibility
+	if len(groups) == 0 {
+		return true
+	}
+
+	for _, g := range groups {
+		if g == groupID {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/kvcache/kvblock_scorer_test.go
+++ b/pkg/kvcache/kvblock_scorer_test.go
@@ -106,3 +106,483 @@ func int64KeysToKVBlockKeys(keys []uint64) []kvblock.BlockHash {
 	}
 	return kvKeys
 }
+
+func TestContainsGroup(t *testing.T) {
+	tests := []struct {
+		name    string
+		groups  []int
+		groupID int
+		want    bool
+	}{
+		{
+			name:    "group found",
+			groups:  []int{0, 1, 2},
+			groupID: 1,
+			want:    true,
+		},
+		{
+			name:    "group not found",
+			groups:  []int{0, 1, 2},
+			groupID: 5,
+			want:    false,
+		},
+		{
+			name:    "nil groups - backwards compatibility",
+			groups:  nil,
+			groupID: 0,
+			want:    true,
+		},
+		{
+			name:    "empty groups - backwards compatibility",
+			groups:  []int{},
+			groupID: 0,
+			want:    true,
+		},
+		{
+			name:    "first group",
+			groups:  []int{0, 1, 2},
+			groupID: 0,
+			want:    true,
+		},
+		{
+			name:    "last group",
+			groups:  []int{0, 1, 2},
+			groupID: 2,
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := kvcache.ContainsGroup(tt.groups, tt.groupID)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHybridPrefixCacheScorer_BasicScoring(t *testing.T) {
+	mediumWeights := map[string]float64{
+		"gpu": 2.0,
+		"cpu": 1.0,
+	}
+
+	modelConfig := &kvcache.ModelConfig{
+		Name:      "test-model",
+		BlockSize: 16,
+		AttentionGroups: []kvcache.AttentionGroupConfig{
+			{WindowSize: 0, AttentionType: "full"},       // Group 0: Full Attention
+			{WindowSize: 2048, AttentionType: "sliding"}, // Group 1: SWA-2048 (128 blocks)
+		},
+	}
+
+	scorer := &kvcache.HybridPrefixCacheScorer{
+		MediumWeights: mediumWeights,
+		ModelConfig:   modelConfig,
+	}
+
+	// Request: 128 blocks (2048 tokens @ 16 tokens/block)
+	blockKeys := make([]kvblock.BlockHash, 128)
+	for i := range blockKeys {
+		blockKeys[i] = kvblock.BlockHash(1000 + i)
+	}
+
+	// Cache: pod-a has all 128 blocks on GPU for both groups
+	hitmap := make(map[kvblock.BlockHash][]kvblock.PodEntry)
+	for i := 0; i < 128; i++ {
+		hitmap[blockKeys[i]] = []kvblock.PodEntry{
+			{PodIdentifier: podA, DeviceTier: "gpu", StoredGroups: []int{0, 1}},
+		}
+	}
+
+	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
+	assert.NoError(t, err)
+	assert.Contains(t, scored, podA)
+
+	// Expected with weighted combination:
+	// Full (Group 0): 128 blocks × 2.0 = 256.0
+	// SWA (Group 1): 128 blocks × 2.0 = 256.0 (window = 128 blocks = all blocks)
+	// fullRatio = 256.0 / 128 = 2.0
+	// swaRatio = 256.0 / 128 = 2.0
+	// Normalized: score = 0.7 × (256/128) + 0.3 × (256/128) = 0.7×2.0 + 0.3×2.0 = 2.0
+	// But wait, we normalize by dividing score by totalBlocks, so:
+	// fullRatio = 256.0 / (128 × 2.0) gives us the hit ratio weighted by tier
+	// Actually the formula is: 0.7 × (fullScore / maxPossibleScore) + 0.3 × (swaScore / maxPossibleScore)
+	// where maxPossibleScore = totalBlocks (not weighted)
+	// So: fullRatio = 256.0 / 128 = 2.0, swaRatio = 256.0 / 128 = 2.0
+	// score = 0.7 × 2.0 + 0.3 × 2.0 = 2.0
+	assert.InDelta(t, 2.0, scored[podA], 0.01)
+}
+
+func TestHybridPrefixCacheScorer_CompletenessScoring(t *testing.T) {
+	mediumWeights := map[string]float64{
+		"gpu": 2.0,
+		"cpu": 1.0,
+	}
+
+	modelConfig := &kvcache.ModelConfig{
+		Name:      "test-model",
+		BlockSize: 16,
+		AttentionGroups: []kvcache.AttentionGroupConfig{
+			{WindowSize: 0, AttentionType: "full"}, // Only Full Attention group
+		},
+	}
+
+	scorer := &kvcache.HybridPrefixCacheScorer{
+		MediumWeights: mediumWeights,
+		ModelConfig:   modelConfig,
+	}
+
+	tests := []struct {
+		name      string
+		numBlocks int
+		wantScore float64
+	}{
+		{
+			name:      "64 blocks all GPU",
+			numBlocks: 64,
+			// Full: 64 × 2.0 = 128, SWA: 0 (no SWA group)
+			// score = 0.7 × (128/64) + 0.3 × (0/64) = 0.7 × 2.0 = 1.4
+			wantScore: 1.4,
+		},
+		{
+			name:      "128 blocks all GPU",
+			numBlocks: 128,
+			// score = 0.7 × (256/128) + 0.3 × 0 = 1.4
+			wantScore: 1.4,
+		},
+		{
+			name:      "200 blocks all GPU",
+			numBlocks: 200,
+			// score = 0.7 × (400/200) + 0.3 × 0 = 1.4
+			wantScore: 1.4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blockKeys := make([]kvblock.BlockHash, tt.numBlocks)
+			hitmap := make(map[kvblock.BlockHash][]kvblock.PodEntry)
+
+			for i := range blockKeys {
+				blockKeys[i] = kvblock.BlockHash(1000 + i)
+				hitmap[blockKeys[i]] = []kvblock.PodEntry{
+					{PodIdentifier: podA, DeviceTier: "gpu", StoredGroups: []int{0}},
+				}
+			}
+
+			scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
+			assert.NoError(t, err)
+			assert.Contains(t, scored, podA)
+			assert.InDelta(t, tt.wantScore, scored[podA], 0.01)
+		})
+	}
+}
+
+func TestHybridPrefixCacheScorer_MixedTiers(t *testing.T) {
+	mediumWeights := map[string]float64{
+		"gpu": 2.0,
+		"cpu": 1.0,
+	}
+
+	modelConfig := &kvcache.ModelConfig{
+		Name:      "test-model",
+		BlockSize: 16,
+		AttentionGroups: []kvcache.AttentionGroupConfig{
+			{WindowSize: 0, AttentionType: "full"}, // Only Full Attention
+		},
+	}
+
+	scorer := &kvcache.HybridPrefixCacheScorer{
+		MediumWeights: mediumWeights,
+		ModelConfig:   modelConfig,
+	}
+
+	// 128 blocks: first 64 on GPU, last 64 on CPU
+	blockKeys := make([]kvblock.BlockHash, 128)
+	hitmap := make(map[kvblock.BlockHash][]kvblock.PodEntry)
+
+	for i := 0; i < 128; i++ {
+		blockKeys[i] = kvblock.BlockHash(1000 + i)
+		tier := "gpu"
+		if i >= 64 {
+			tier = "cpu"
+		}
+		hitmap[blockKeys[i]] = []kvblock.PodEntry{
+			{PodIdentifier: podA, DeviceTier: tier, StoredGroups: []int{0}},
+		}
+	}
+
+	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
+	assert.NoError(t, err)
+	assert.Contains(t, scored, podA)
+
+	// Full: (64 GPU × 2.0) + (64 CPU × 1.0) = 128 + 64 = 192
+	// SWA: 0 (no SWA group)
+	// score = 0.7 × (192/128) + 0.3 × 0 = 0.7 × 1.5 = 1.05
+	assert.InDelta(t, 1.05, scored[podA], 0.01)
+}
+
+func TestHybridPrefixCacheScorer_MultiplePods(t *testing.T) {
+	mediumWeights := map[string]float64{
+		"gpu": 2.0,
+		"cpu": 1.0,
+	}
+
+	modelConfig := &kvcache.ModelConfig{
+		Name:      "test-model",
+		BlockSize: 16,
+		AttentionGroups: []kvcache.AttentionGroupConfig{
+			{WindowSize: 0, AttentionType: "full"},       // Group 0: Full Attention
+			{WindowSize: 2048, AttentionType: "sliding"}, // Group 1: SWA-2048 (128 blocks)
+		},
+	}
+
+	scorer := &kvcache.HybridPrefixCacheScorer{
+		MediumWeights: mediumWeights,
+		ModelConfig:   modelConfig,
+	}
+
+	// 128 blocks (2048 tokens)
+	blockKeys := make([]kvblock.BlockHash, 128)
+	hitmap := make(map[kvblock.BlockHash][]kvblock.PodEntry)
+
+	for i := 0; i < 128; i++ {
+		blockKeys[i] = kvblock.BlockHash(1000 + i)
+
+		entries := []kvblock.PodEntry{}
+
+		// pod-a: all 128 blocks on GPU, both groups
+		entries = append(entries, kvblock.PodEntry{
+			PodIdentifier: podA,
+			DeviceTier:    "gpu",
+			StoredGroups:  []int{0, 1},
+		})
+
+		// pod-b: all 128 blocks, mixed GPU/CPU, both groups
+		tier := "gpu"
+		if i >= 64 {
+			tier = "cpu"
+		}
+		entries = append(entries, kvblock.PodEntry{
+			PodIdentifier: podB,
+			DeviceTier:    tier,
+			StoredGroups:  []int{0, 1},
+		})
+
+		hitmap[blockKeys[i]] = entries
+	}
+
+	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
+	assert.NoError(t, err)
+
+	// pod-a: all GPU, both groups
+	// Full: 128 × 2.0 = 256
+	// SWA: 128 × 2.0 = 256
+	// score = 0.7 × (256/128) + 0.3 × (256/128) = 0.7×2.0 + 0.3×2.0 = 2.0
+	assert.Contains(t, scored, podA)
+	assert.InDelta(t, 2.0, scored[podA], 0.01)
+
+	// pod-b: mixed GPU/CPU, both groups
+	// Full: (64 GPU × 2.0) + (64 CPU × 1.0) = 128 + 64 = 192
+	// SWA: (64 GPU × 2.0) + (64 CPU × 1.0) = 192
+	// score = 0.7 × (192/128) + 0.3 × (192/128) = 1.0 × 1.5 = 1.5
+	assert.Contains(t, scored, podB)
+	assert.InDelta(t, 1.5, scored[podB], 0.01)
+}
+
+func TestHybridPrefixCacheScorer_GroupFiltering(t *testing.T) {
+	mediumWeights := map[string]float64{
+		"gpu": 2.0,
+	}
+
+	modelConfig := &kvcache.ModelConfig{
+		Name:      "test-model",
+		BlockSize: 16,
+		AttentionGroups: []kvcache.AttentionGroupConfig{
+			{WindowSize: 0, AttentionType: "full"},       // Group 0: Full Attention
+			{WindowSize: 1024, AttentionType: "sliding"}, // Group 1: SWA-1024 (64 blocks)
+		},
+	}
+
+	scorer := &kvcache.HybridPrefixCacheScorer{
+		MediumWeights: mediumWeights,
+		ModelConfig:   modelConfig,
+	}
+
+	// 128 blocks
+	blockKeys := make([]kvblock.BlockHash, 128)
+	hitmap := make(map[kvblock.BlockHash][]kvblock.PodEntry)
+
+	for i := 0; i < 128; i++ {
+		blockKeys[i] = kvblock.BlockHash(1000 + i)
+
+		entries := []kvblock.PodEntry{}
+
+		// pod-a: has both groups for all blocks
+		entries = append(entries, kvblock.PodEntry{
+			PodIdentifier: podA,
+			DeviceTier:    "gpu",
+			StoredGroups:  []int{0, 1},
+		})
+
+		if i < 32 {
+			// First 32 blocks: pod-b has both groups
+			entries = append(entries, kvblock.PodEntry{
+				PodIdentifier: podB,
+				DeviceTier:    "gpu",
+				StoredGroups:  []int{0, 1},
+			})
+		} else if i < 64 {
+			// Blocks 32-63: pod-b only has group 1 (missing group 0!)
+			entries = append(entries, kvblock.PodEntry{
+				PodIdentifier: podB,
+				DeviceTier:    "gpu",
+				StoredGroups:  []int{1},
+			})
+		} else {
+			// Blocks 64+: pod-b has both groups
+			entries = append(entries, kvblock.PodEntry{
+				PodIdentifier: podB,
+				DeviceTier:    "gpu",
+				StoredGroups:  []int{0, 1},
+			})
+		}
+
+		hitmap[blockKeys[i]] = entries
+	}
+
+	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
+	assert.NoError(t, err)
+
+	// pod-a: has both groups for all blocks
+	// Full (Group 0): 128 blocks × 2.0 = 256
+	// SWA (Group 1, window = 64 blocks): 64 blocks × 2.0 = 128
+	// score = 0.7 × (256/128) + 0.3 × (128/128) = 0.7×2.0 + 0.3×1.0 = 1.7
+	assert.Contains(t, scored, podA)
+	assert.InDelta(t, 1.7, scored[podA], 0.01)
+
+	// pod-b: partial groups
+	// Full (Group 0): Prefix stops at block 32 (block 32 missing Group 0)
+	//   → 32 blocks × 2.0 = 64
+	// SWA (Group 1, window = 64 blocks): Suffix from end
+	//   - Blocks 127-64: all have Group 1 ✓ → 64 blocks × 2.0 = 128
+	// score = 0.7 × (64/128) + 0.3 × (128/128) = 0.7×0.5 + 0.3×1.0 = 0.65
+	assert.Contains(t, scored, podB)
+	assert.InDelta(t, 0.65, scored[podB], 0.01)
+}
+
+func TestHybridPrefixCacheScorer_WindowConstraint(t *testing.T) {
+	mediumWeights := map[string]float64{
+		"gpu": 2.0,
+	}
+
+	modelConfig := &kvcache.ModelConfig{
+		Name:      "test-model",
+		BlockSize: 16,
+		AttentionGroups: []kvcache.AttentionGroupConfig{
+			{WindowSize: 0, AttentionType: "full"},       // Group 0: Full Attention
+			{WindowSize: 1024, AttentionType: "sliding"}, // Group 1: SWA-1024 (64 blocks)
+		},
+	}
+
+	scorer := &kvcache.HybridPrefixCacheScorer{
+		MediumWeights: mediumWeights,
+		ModelConfig:   modelConfig,
+	}
+
+	// Request 128 blocks, but sliding window limits SWA to 64
+	blockKeys := make([]kvblock.BlockHash, 128)
+	hitmap := make(map[kvblock.BlockHash][]kvblock.PodEntry)
+
+	for i := 0; i < 128; i++ {
+		blockKeys[i] = kvblock.BlockHash(1000 + i)
+		hitmap[blockKeys[i]] = []kvblock.PodEntry{
+			{PodIdentifier: podA, DeviceTier: "gpu", StoredGroups: []int{0, 1}},
+		}
+	}
+
+	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
+	assert.NoError(t, err)
+	assert.Contains(t, scored, podA)
+
+	// Full (Group 0): All 128 blocks × 2.0 = 256
+	// SWA (Group 1, window = 64 blocks): 64 blocks × 2.0 = 128
+	// score = 0.7 × (256/128) + 0.3 × (128/128) = 0.7×2.0 + 0.3×1.0 = 1.7
+	assert.InDelta(t, 1.7, scored[podA], 0.01)
+}
+
+func TestHybridPrefixCacheScorer_FallbackToSimple(t *testing.T) {
+	mediumWeights := map[string]float64{
+		"gpu": 2.0,
+	}
+
+	// No attention groups - should fallback to simple longest prefix scoring
+	modelConfig := &kvcache.ModelConfig{
+		Name:            "test-model",
+		BlockSize:       16,
+		AttentionGroups: []kvcache.AttentionGroupConfig{},
+	}
+
+	scorer := &kvcache.HybridPrefixCacheScorer{
+		MediumWeights: mediumWeights,
+		ModelConfig:   modelConfig,
+	}
+
+	blockKeys := make([]kvblock.BlockHash, 64)
+	hitmap := make(map[kvblock.BlockHash][]kvblock.PodEntry)
+
+	for i := 0; i < 64; i++ {
+		blockKeys[i] = kvblock.BlockHash(1000 + i)
+		hitmap[blockKeys[i]] = []kvblock.PodEntry{
+			{PodIdentifier: podA, DeviceTier: "gpu"},
+		}
+	}
+
+	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
+	assert.NoError(t, err)
+	assert.Contains(t, scored, podA)
+
+	// Fallback uses scoreLongestPrefix (cumulative weighted sum)
+	// 64 blocks × 2.0 weight = 128.0
+	assert.InDelta(t, 128.0, scored[podA], 0.01)
+}
+
+func TestHybridPrefixCacheScorer_SmallWindow(t *testing.T) {
+	mediumWeights := map[string]float64{
+		"gpu": 2.0,
+	}
+
+	modelConfig := &kvcache.ModelConfig{
+		Name:      "test-model",
+		BlockSize: 16,
+		AttentionGroups: []kvcache.AttentionGroupConfig{
+			{WindowSize: 0, AttentionType: "full"},      // Group 0: Full Attention
+			{WindowSize: 512, AttentionType: "sliding"}, // Group 1: SWA-512 (32 blocks)
+		},
+	}
+
+	scorer := &kvcache.HybridPrefixCacheScorer{
+		MediumWeights: mediumWeights,
+		ModelConfig:   modelConfig,
+	}
+
+	// Request 64 blocks (1024 tokens @ 16 tokens/block)
+	blockKeys := make([]kvblock.BlockHash, 64)
+	hitmap := make(map[kvblock.BlockHash][]kvblock.PodEntry)
+
+	for i := 0; i < 64; i++ {
+		blockKeys[i] = kvblock.BlockHash(1000 + i)
+		hitmap[blockKeys[i]] = []kvblock.PodEntry{
+			{PodIdentifier: podA, DeviceTier: "gpu", StoredGroups: []int{0, 1}},
+		}
+	}
+
+	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
+	assert.NoError(t, err)
+	assert.Contains(t, scored, podA)
+
+	// Full (Group 0): All 64 blocks × 2.0 = 128
+	// SWA (Group 1, window = 512 tokens = 32 blocks): 32 blocks × 2.0 = 64
+	// score = 0.7 × (128/64) + 0.3 × (64/64) = 0.7×2.0 + 0.3×1.0 = 1.7
+	assert.InDelta(t, 1.7, scored[podA], 0.01)
+}

--- a/pkg/kvevents/engineadapter/vllm_adapter.go
+++ b/pkg/kvevents/engineadapter/vllm_adapter.go
@@ -141,6 +141,7 @@ func fieldAt(fields []any, i int) any {
 //	[6] medium        string|nil        (optional, omit_defaults)
 //	[7] lora_name     string|nil        (optional, omit_defaults)
 //	[8] extra_keys    [][]any|nil       (optional, omit_defaults)
+//	[9] group_idx     int|nil           (optional, omit_defaults)
 //
 // Trailing fields may be absent in older vLLM versions. Extra trailing fields
 // from newer vLLM versions are silently ignored.
@@ -221,6 +222,16 @@ func (v *VLLMAdapter) convertBlockStoredEvent(fields []any) (kvevents.GenericEve
 		}
 	}
 
+	// [9] group_idx (optional)
+	var groupIdx int
+	if raw := fieldAt(fields, 9); raw != nil {
+		idx, err := toInt(raw)
+		if err != nil {
+			return nil, fmt.Errorf("BlockStored: group_idx: %w", err)
+		}
+		groupIdx = idx
+	}
+
 	return &kvevents.BlockStoredEvent{
 		BlockHashes: blockHashes,
 		Tokens:      tokens,
@@ -229,6 +240,7 @@ func (v *VLLMAdapter) convertBlockStoredEvent(fields []any) (kvevents.GenericEve
 		LoraID:      loraID,
 		LoraName:    loraName,
 		ExtraKeys:   extraKeys,
+		GroupIdx:    groupIdx,
 	}, nil
 }
 
@@ -238,6 +250,7 @@ func (v *VLLMAdapter) convertBlockStoredEvent(fields []any) (kvevents.GenericEve
 //	[0] tag           string
 //	[1] block_hashes  []hash
 //	[2] medium        string|nil      (optional, omit_defaults)
+//	[3] group_idx     int|nil          (optional, omit_defaults)
 func (v *VLLMAdapter) convertBlockRemovedEvent(fields []any) (kvevents.GenericEvent, error) {
 	if len(fields) < 2 {
 		return nil, fmt.Errorf("BlockRemoved: need at least 2 fields, got %d", len(fields))
@@ -261,9 +274,20 @@ func (v *VLLMAdapter) convertBlockRemovedEvent(fields []any) (kvevents.GenericEv
 		deviceTier = s
 	}
 
+	// [3] group_idx (optional)
+	var groupIdx int
+	if raw := fieldAt(fields, 3); raw != nil {
+		idx, err := toInt(raw)
+		if err != nil {
+			return nil, fmt.Errorf("BlockRemoved: group_idx: %w", err)
+		}
+		groupIdx = idx
+	}
+
 	return &kvevents.BlockRemovedEvent{
 		BlockHashes: blockHashes,
 		DeviceTier:  deviceTier,
+		GroupIdx:    groupIdx,
 	}, nil
 }
 

--- a/pkg/kvevents/events.go
+++ b/pkg/kvevents/events.go
@@ -72,6 +72,7 @@ type BlockStoredEvent struct {
 	LoraID      *int
 	LoraName    *string
 	ExtraKeys   [][]any
+	GroupIdx    int // Attention group ID
 }
 
 // Type returns the event type.
@@ -83,6 +84,7 @@ func (e *BlockStoredEvent) Type() EventType {
 type BlockRemovedEvent struct {
 	BlockHashes []uint64
 	DeviceTier  string
+	GroupIdx    int // Attention group ID being evicted
 }
 
 // Type returns the event type.

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -230,7 +230,12 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 			}
 
 			// Create PodEntry for this specific event's device tier
-			podEntries := []kvblock.PodEntry{{PodIdentifier: podIdentifier, DeviceTier: deviceTier}}
+			// Single group ID from event becomes a list for PodEntry
+			podEntries := []kvblock.PodEntry{{
+				PodIdentifier: podIdentifier,
+				DeviceTier:    deviceTier,
+				StoredGroups:  []int{ev.GroupIdx},
+			}}
 
 			engineKeys := make([]kvblock.BlockHash, len(ev.BlockHashes))
 			for i, hash := range ev.BlockHashes {
@@ -309,7 +314,12 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 			}
 
 			// Create PodEntry for this specific event's device tier
-			podEntries := []kvblock.PodEntry{{PodIdentifier: podIdentifier, DeviceTier: deviceTier}}
+			// Single group ID from event becomes a list for eviction
+			podEntries := []kvblock.PodEntry{{
+				PodIdentifier: podIdentifier,
+				DeviceTier:    deviceTier,
+				StoredGroups:  []int{ev.GroupIdx}, // For eviction, we use this to identify which groups to remove
+			}}
 
 			// Iterate over the hashes and evict each key.
 			for _, hash := range ev.BlockHashes {


### PR DESCRIPTION
**Overview**                                                                                                                                                                           
   
 This PR adds support for Hybrid Model Architecture (HMA) with partial KV cache eviction, enabling efficient KV cache management for models with mixed attention mechanisms (e.g.,  DeepSeek-R1 style models with full-attention and sliding-window-attention layers).
[Issue 336](https://github.com/llm-d/llm-d-kv-cache/issues/336)
  
**New Features**

  1. Partial Eviction Support

  Added ability to evict specific attention groups while preserving others in the KV cache.

  New Field in BlockRemovedEvent:
```
  type BlockRemovedEvent struct {
      BlockHashes   []uint64
      DeviceTier    string
      EvictedGroups []int  // NEW: nil/empty = full eviction, non-empty = partial eviction
  }
```

  Event Processing:
  - Detects partial vs. full eviction based on EvictedGroups field
  - For partial evictions: Updates block metadata to track which groups remain cached
  - For full evictions: Removes entry completely (maintains existing behavior)

  2. HybridModelScorer

  New scoring strategy that considers attention group availability when selecting pods for KV cache reuse.

  Features:
  - Computes which attention groups are needed based on request tokens
  - Validates that pods have required groups cached
  - Applies coverage multipliers:
    - 0.0: Missing Group 0 (full-attention) - pod excluded
    - 1.0: All useful groups cached - full hit
    - 0.3 + 0.7 × ratio: Partial hit - scaled by coverage

  Example:
  // Request with 8K tokens, model has 4K sliding window
  // Useful groups: [0 (full-attn), 1 (SWA)]
  // Pod A has both groups: score × 1.0
  // Pod B has only group 0: score × 0.65
  // Pod C missing group 0: score × 0.0 (excluded)

  3. Model Registry

  Per-model configuration defining attention group architecture.

  Configuration:
```
  type ModelConfig struct {
      AttentionGroups map[int]*AttentionGroupConfig
  }
```

```
  type AttentionGroupConfig struct {
      WindowSize *int  // nil = full-attention, value = sliding-window size
  }
```

  Example Config:
  modelConfigs:
    deepseek-r1:
      attentionGroups:
        0:
          windowSize: null  # Full-attention group (always required)
        1:
          windowSize: 4096  # SWA group (useful when tokens > 4096)

  4. Storage Layer Enhancements

  PodEntry Extended:
```
  type PodEntry struct {
      PodIdentifier string
      DeviceTier    string
      EvictedGroups []int  // NEW: Tracks which groups were evicted
  }
```

  Cost Calculation Updated:
  - Includes EvictedGroups slice in memory cost estimation
  - Maintains accurate cache accounting

  5. vLLM Adapter Integration

  Extended Event Parsing:
```
  type msgpackVLLMBlockRemovedEvent struct {
      Tag           string
      BlockHashes   []any
      Medium        *string
      EvictedGroups []int   // NEW: Parsed from vLLM events
  }
```

  **Configuration**

  Enable HybridModel Scoring

```
  scoringStrategy: "HybridModel"
  backendConfigs:
    - name: "gpu"
      weight: 1.0
      modelConfigs:
        deepseek-r1:
          attentionGroups:
            0: {}  # Full-attention
            1: { windowSize: 4096 }  # SWA
```

  Fallback to LongestPrefix

  If no model configs provided or model not in registry, automatically falls back to standard LongestPrefixMatch scoring.

  **Backward Compatibility**

  - EvictedGroups = nil treated as full eviction (existing behavior)
  - Models without HMA config use LongestPrefixMatch scoring
  - vLLM events without EvictedGroups field supported

  **Test Coverage**

  New Tests Added

  - TestDecodeVLLMEvent_BlockRemoved: Partial eviction event parsing
  - TestHybridModelScorer_FullHit: All groups cached
  - TestHybridModelScorer_PartialHit: Some groups cached
  - TestHybridModelScorer_MissingGroup0: Missing required group
  - TestHybridModelScorer_SWANotUseful: Request below window size
  - TestHybridModelScorer_MultipleUsefulGroups: Complex scenarios
  - TestHybridModelScorer_NoModelConfigs: Fallback behavior
  - TestHybridModelScorer_FallbackToLongestPrefix: Unknown model