### PR TITLE
build: add workflow_dispatch trigger to ci-wheels workflow

### DIFF
--- a/.github/workflows/ci-wheels.yaml
+++ b/.github/workflows/ci-wheels.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -61,6 +62,7 @@ jobs:
 
   attach-assets:
     needs: build-wheels
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to allow manual runs of the CI wheels workflow
- Skip the `attach-assets` job on manual dispatch (only runs on tag push) — wheels are still available as workflow artifacts in the run