### PR TITLE
feat:add support to invalidate KV cache via AllBlocksCleared event

### DIFF
--- a/pkg/kvcache/kvblock/cost_aware_memory.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory.go
@@ -80,6 +80,7 @@ func NewCostAwareMemoryIndex(cfg *CostAwareMemoryIndexConfig) (*CostAwareMemoryI
 	return &CostAwareMemoryIndex{
 		data:        cache,
 		requestKeys: requestKeys,
+		sweepCh:     make(chan struct{}, 1),
 	}, nil
 }
 
@@ -442,9 +443,7 @@ func (m *CostAwareMemoryIndex) StartSweeper(ctx context.Context, debounce time.D
 	if debounce <= 0 {
 		debounce = 100 * time.Millisecond
 	}
-	if m.sweepCh == nil {
-		m.sweepCh = make(chan struct{}, 1)
-	}
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/kvcache/kvblock/cost_aware_memory.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory.go
@@ -365,9 +365,8 @@ func (m *CostAwareMemoryIndex) evictPodsFromRequestKey(
 	}
 }
 
-// Clear invalidates all entries for the given podEntry by bumping the pod's
-// generation counter. Stale entries are filtered at Lookup time and reclaimed
-// lazily by ristretto's cost-based eviction (or eagerly via Sweep). O(1).
+// Clear bumps the pod's generation counter, invalidating all prior entries for
+// that pod lazily. Reclaimed by Sweep or by ristretto's cost-based eviction. O(1).
 func (m *CostAwareMemoryIndex) Clear(ctx context.Context, podEntry PodEntry) error {
 	m.gen.bump(podEntry.PodIdentifier)
 	log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.CostAwareMemoryIndex.Clear").
@@ -381,9 +380,8 @@ func (m *CostAwareMemoryIndex) Clear(ctx context.Context, podEntry PodEntry) err
 	return nil
 }
 
-// Sweep performs an immediate scan over all live request-keys, removing entries
-// whose stamped generation is below their pod's current generation. Returns the
-// count of removed entries.
+// Sweep removes entries whose stamped generation is below their pod's current
+// generation. Returns the count removed. O(N) over the index; off the hot path.
 func (m *CostAwareMemoryIndex) Sweep(ctx context.Context) int {
 	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.CostAwareMemoryIndex.Sweep")
 	if m.gen.anyClears() == 0 {
@@ -438,8 +436,8 @@ func (m *CostAwareMemoryIndex) Sweep(ctx context.Context) int {
 	return removed
 }
 
-// StartSweeper runs Sweep on every Clear, debounced by `debounce`. Returns when
-// ctx is cancelled.
+// StartSweeper runs Sweep on every Clear, debounced and coalesced.
+// Returns when ctx is cancelled. NewIndex starts this by default.
 func (m *CostAwareMemoryIndex) StartSweeper(ctx context.Context, debounce time.Duration) {
 	if debounce <= 0 {
 		debounce = 100 * time.Millisecond

--- a/pkg/kvcache/kvblock/cost_aware_memory.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -94,10 +95,16 @@ type CostAwareMemoryIndex struct {
 	data *ristretto.Cache[string, *CostPodCache]
 	// requestKeys holds the mapping of engine keys to request keys.
 	requestKeys *lru.Cache[BlockHash, []BlockHash]
+	// keyIndex tracks the set of live request-key strings so Sweep can iterate.
+	// Ristretto does not expose iteration; we maintain this set on Add and
+	// prune it lazily during Sweep.
+	keyIndex sync.Map // map[string]struct{}
 	// mu protects concurrent access to the index operations
 	mu sync.RWMutex
 	// gen tracks per-pod generation counters for O(1) Clear via lazy invalidation.
 	gen podGenTracker
+	// sweepCh is signalled by Clear when a background sweeper is running.
+	sweepCh chan struct{}
 }
 
 func (m *CostAwareMemoryIndex) MaxCost() int64 {
@@ -218,6 +225,7 @@ func (m *CostAwareMemoryIndex) Add(ctx context.Context, engineKeys, requestKeys 
 		// Calculate the actual cost for this cache entry
 		cost := podCache.CalculateByteSize(keyStr)
 		m.data.Set(keyStr, podCache, cost)
+		m.keyIndex.Store(keyStr, struct{}{})
 		traceLogger.Info("added pods to key", "requestKey", requestKey, "pods", entries, "cost-bytes", cost)
 	}
 	m.data.Wait()
@@ -239,6 +247,14 @@ func (m *CostAwareMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHa
 	podsPerKey := make(map[BlockHash][]PodEntry)
 	highestHitIdx := 0
 
+	// Fast-path predicates evaluated once per call.
+	filterPodSet := podIdentifierSet.Len() != 0
+	needGenFilter := m.gen.anyClears() != 0
+	var gens *genCache
+	if needGenFilter {
+		gens = m.gen.snapshot()
+	}
+
 	for idx, key := range requestKeys {
 		keyStr := key.String()
 		if pods, found := m.data.Get(keyStr); found { //nolint:nestif // TODO: can this be optimized?
@@ -249,10 +265,6 @@ func (m *CostAwareMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHa
 
 			highestHitIdx = idx
 
-			// Filter pods based on the provided pod identifiers AND the per-pod generation
-			// counter. An entry whose stamped generation is below the current generation
-			// for its pod is considered cleared.
-			filterPodSet := podIdentifierSet.Len() != 0
 			pods.cache.Range(func(k, value interface{}) bool {
 				pod, ok := k.(PodEntry)
 				if !ok {
@@ -261,9 +273,11 @@ func (m *CostAwareMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHa
 				if filterPodSet && !podIdentifierSet.Has(pod.PodIdentifier) {
 					return true
 				}
-				stampedGen, _ := value.(uint64)
-				if stampedGen < m.gen.current(pod.PodIdentifier) {
-					return true
+				if needGenFilter {
+					stampedGen, _ := value.(uint64)
+					if stampedGen < gens.current(pod.PodIdentifier) {
+						return true
+					}
 				}
 				podsPerKey[key] = append(podsPerKey[key], pod)
 				return true
@@ -343,6 +357,7 @@ func (m *CostAwareMemoryIndex) evictPodsFromRequestKey(
 
 	if podCache.Len() == 0 {
 		m.data.Del(keyStr)
+		m.keyIndex.Delete(keyStr)
 		traceLogger.Info("removed requestKey from index as no pods remain", "requestKey", requestKey)
 	} else if podCacheLenBefore != podCache.Len() {
 		m.data.Set(keyStr, podCache, podCache.CalculateByteSize(keyStr))
@@ -352,12 +367,106 @@ func (m *CostAwareMemoryIndex) evictPodsFromRequestKey(
 
 // Clear invalidates all entries for the given podEntry by bumping the pod's
 // generation counter. Stale entries are filtered at Lookup time and reclaimed
-// lazily by ristretto's cost-based eviction. O(1).
+// lazily by ristretto's cost-based eviction (or eagerly via Sweep). O(1).
 func (m *CostAwareMemoryIndex) Clear(ctx context.Context, podEntry PodEntry) error {
 	m.gen.bump(podEntry.PodIdentifier)
 	log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.CostAwareMemoryIndex.Clear").
 		Info("bumped pod generation", "pod", podEntry.PodIdentifier)
+	if m.sweepCh != nil {
+		select {
+		case m.sweepCh <- struct{}{}:
+		default:
+		}
+	}
 	return nil
+}
+
+// Sweep performs an immediate scan over all live request-keys, removing entries
+// whose stamped generation is below their pod's current generation. Returns the
+// count of removed entries.
+func (m *CostAwareMemoryIndex) Sweep(ctx context.Context) int {
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.CostAwareMemoryIndex.Sweep")
+	if m.gen.anyClears() == 0 {
+		return 0
+	}
+	gens := m.gen.snapshot()
+
+	removed := 0
+	m.keyIndex.Range(func(k, _ any) bool {
+		keyStr, ok := k.(string)
+		if !ok {
+			return true
+		}
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		podCache, found := m.data.Get(keyStr)
+		if !found || podCache == nil {
+			m.keyIndex.Delete(keyStr)
+			return true
+		}
+
+		var toDelete []PodEntry
+		podCache.cache.Range(func(ek, ev any) bool {
+			entry, ok := ek.(PodEntry)
+			if !ok {
+				return true
+			}
+			stamped, _ := ev.(uint64)
+			if stamped < gens.current(entry.PodIdentifier) {
+				toDelete = append(toDelete, entry)
+			}
+			return true
+		})
+		for _, e := range toDelete {
+			podCache.Delete(e)
+		}
+		removed += len(toDelete)
+		if podCache.Len() == 0 {
+			m.data.Del(keyStr)
+			m.keyIndex.Delete(keyStr)
+		} else if len(toDelete) > 0 {
+			m.data.Set(keyStr, podCache, podCache.CalculateByteSize(keyStr))
+		}
+		return true
+	})
+
+	m.data.Wait()
+	if removed > 0 {
+		traceLogger.Info("sweep removed stale entries", "removed", removed)
+	}
+	return removed
+}
+
+// StartSweeper runs Sweep on every Clear, debounced by `debounce`. Returns when
+// ctx is cancelled.
+func (m *CostAwareMemoryIndex) StartSweeper(ctx context.Context, debounce time.Duration) {
+	if debounce <= 0 {
+		debounce = 100 * time.Millisecond
+	}
+	if m.sweepCh == nil {
+		m.sweepCh = make(chan struct{}, 1)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-m.sweepCh:
+			timer := time.NewTimer(debounce)
+			drained := false
+			for !drained {
+				select {
+				case <-m.sweepCh:
+				case <-timer.C:
+					drained = true
+				case <-ctx.Done():
+					timer.Stop()
+					return
+				}
+			}
+			m.Sweep(ctx)
+		}
+	}
 }
 
 // GetRequestKey returns the last request key (highest index in the chain) associated with the given engineKey.

--- a/pkg/kvcache/kvblock/cost_aware_memory.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory.go
@@ -96,6 +96,8 @@ type CostAwareMemoryIndex struct {
 	requestKeys *lru.Cache[BlockHash, []BlockHash]
 	// mu protects concurrent access to the index operations
 	mu sync.RWMutex
+	// gen tracks per-pod generation counters for O(1) Clear via lazy invalidation.
+	gen podGenTracker
 }
 
 func (m *CostAwareMemoryIndex) MaxCost() int64 {
@@ -103,15 +105,18 @@ func (m *CostAwareMemoryIndex) MaxCost() int64 {
 }
 
 // CostPodCache wraps a sync.Map of PodEntry and provides cost calculation for memory usage estimation.
+// The map value is the generation at which the entry was admitted (see podGenTracker).
 type CostPodCache struct {
-	cache sync.Map // map[PodEntry]struct{}
+	cache sync.Map // map[PodEntry]uint64
 	// size tracks the number of entries in cache for O(1) Len().
 	size atomic.Int64
 }
 
-// Add adds a PodEntry to the cache.
-func (c *CostPodCache) Add(entry PodEntry) {
-	if _, loaded := c.cache.LoadOrStore(entry, struct{}{}); !loaded {
+// Add adds (or refreshes) a PodEntry in the cache, stamped with the supplied generation.
+// On re-add of an existing entry, the stored generation is overwritten so post-Clear
+// re-admissions become visible at Lookup time.
+func (c *CostPodCache) Add(entry PodEntry, gen uint64) {
+	if _, loaded := c.cache.Swap(entry, gen); !loaded {
 		c.size.Add(1)
 	}
 }
@@ -207,7 +212,7 @@ func (m *CostAwareMemoryIndex) Add(ctx context.Context, engineKeys, requestKeys 
 		}
 
 		for _, entry := range entries {
-			podCache.Add(entry)
+			podCache.Add(entry, m.gen.current(entry.PodIdentifier))
 		}
 
 		// Calculate the actual cost for this cache entry
@@ -244,25 +249,25 @@ func (m *CostAwareMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHa
 
 			highestHitIdx = idx
 
-			if podIdentifierSet.Len() == 0 {
-				// If no pod identifiers are provided, return all pods
-				pods.cache.Range(func(k, value interface{}) bool {
-					if pod, ok := k.(PodEntry); ok {
-						podsPerKey[key] = append(podsPerKey[key], pod)
-					}
+			// Filter pods based on the provided pod identifiers AND the per-pod generation
+			// counter. An entry whose stamped generation is below the current generation
+			// for its pod is considered cleared.
+			filterPodSet := podIdentifierSet.Len() != 0
+			pods.cache.Range(func(k, value interface{}) bool {
+				pod, ok := k.(PodEntry)
+				if !ok {
 					return true
-				})
-			} else {
-				// Filter pods based on the provided pod identifiers
-				pods.cache.Range(func(k, value interface{}) bool {
-					if pod, ok := k.(PodEntry); ok {
-						if podIdentifierSet.Has(pod.PodIdentifier) {
-							podsPerKey[key] = append(podsPerKey[key], pod)
-						}
-					}
+				}
+				if filterPodSet && !podIdentifierSet.Has(pod.PodIdentifier) {
 					return true
-				})
-			}
+				}
+				stampedGen, _ := value.(uint64)
+				if stampedGen < m.gen.current(pod.PodIdentifier) {
+					return true
+				}
+				podsPerKey[key] = append(podsPerKey[key], pod)
+				return true
+			})
 		} else {
 			traceLogger.Info("key not found in index", "key", key)
 		}
@@ -343,6 +348,16 @@ func (m *CostAwareMemoryIndex) evictPodsFromRequestKey(
 		m.data.Set(keyStr, podCache, podCache.CalculateByteSize(keyStr))
 		traceLogger.Info("evicted pods from key", "requestKey", requestKey, "engineKey", engineKey, "pods", entries)
 	}
+}
+
+// Clear invalidates all entries for the given podEntry by bumping the pod's
+// generation counter. Stale entries are filtered at Lookup time and reclaimed
+// lazily by ristretto's cost-based eviction. O(1).
+func (m *CostAwareMemoryIndex) Clear(ctx context.Context, podEntry PodEntry) error {
+	m.gen.bump(podEntry.PodIdentifier)
+	log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.CostAwareMemoryIndex.Clear").
+		Info("bumped pod generation", "pod", podEntry.PodIdentifier)
+	return nil
 }
 
 // GetRequestKey returns the last request key (highest index in the chain) associated with the given engineKey.

--- a/pkg/kvcache/kvblock/cost_aware_memory_test.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory_test.go
@@ -50,7 +50,7 @@ func TestCostAwareIndexSize(t *testing.T) {
 	entry1 := PodEntry{PodIdentifier: "pod1", DeviceTier: "gpu"}
 
 	costPodCache := &CostPodCache{}
-	costPodCache.Add(entry1)
+	costPodCache.Add(entry1, 0)
 	cost := costPodCache.CalculateByteSize(requestKey1.String())
 
 	// Test with small size to verify eviction

--- a/pkg/kvcache/kvblock/gen_buildup_test.go
+++ b/pkg/kvcache/kvblock/gen_buildup_test.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package kvblock
+
+import (
+	"context"
+	"math/rand/v2"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// TestGenBuildup exercises repeated Clear+Add cycles with *fresh* request keys
+// each round. The naive expectation under the generation-counter scheme without
+// any cleanup is that stale entries pile up in the index until LRU/cost pressure
+// reclaims them. This test verifies:
+//
+//  1. Without Sweep: Lookup correctly returns zero hits for cleared rounds — i.e.,
+//     correctness is preserved despite stale entries lingering — and the live
+//     entry count grows linearly with rounds.
+//  2. With explicit Sweep: stale entries are physically removed; the live entry
+//     count stays bounded at one round's worth.
+//  3. With StartSweeper background goroutine: stale entries are reclaimed within
+//     a few debounce cycles without explicit Sweep calls.
+func TestGenBuildup(t *testing.T) {
+	const (
+		rounds       = 10
+		keysPerRound = 500
+		pod          = "podA"
+		tier         = "gpu"
+	)
+	podEntry := PodEntry{PodIdentifier: pod, DeviceTier: tier}
+
+	t.Run("InMemory_NoSweep_StaleAccumulates", func(t *testing.T) {
+		idx, err := NewInMemoryIndex(nil)
+		require.NoError(t, err)
+
+		for round := 0; round < rounds; round++ {
+			keys := keysForRound(round, keysPerRound)
+			require.NoError(t, idx.Add(t.Context(), keys, keys, []PodEntry{podEntry}))
+
+			// Sanity: the new round's entries are visible.
+			hits, _ := idx.Lookup(t.Context(), keys, sets.Set[string]{})
+			assert.Len(t, hits, keysPerRound, "round %d entries visible before clear", round)
+
+			require.NoError(t, idx.Clear(t.Context(), podEntry))
+
+			// Lookup after Clear must return zero — correctness invariant.
+			postClear, _ := idx.Lookup(t.Context(), keys, sets.Set[string]{})
+			assert.Empty(t, postClear, "round %d entries cleared by Clear", round)
+		}
+
+		// Without Sweep, the index physically still holds entries for every round.
+		// Count live entries by ranging over the lru cache.
+		live := countLiveInMemory(idx)
+		t.Logf("InMemory no-sweep: %d live entries after %d rounds (%d added per round)",
+			live, rounds, keysPerRound)
+		assert.GreaterOrEqual(t, live, rounds*keysPerRound,
+			"expected stale entries to accumulate without Sweep")
+	})
+
+	t.Run("InMemory_ExplicitSweep_BoundedGrowth", func(t *testing.T) {
+		idx, err := NewInMemoryIndex(nil)
+		require.NoError(t, err)
+
+		for round := 0; round < rounds; round++ {
+			keys := keysForRound(round, keysPerRound)
+			require.NoError(t, idx.Add(t.Context(), keys, keys, []PodEntry{podEntry}))
+			require.NoError(t, idx.Clear(t.Context(), podEntry))
+			removed := idx.Sweep(t.Context())
+			assert.Equal(t, keysPerRound, removed,
+				"round %d: Sweep should remove this round's stale entries", round)
+		}
+
+		// After a final round + sweep, the index should be empty.
+		live := countLiveInMemory(idx)
+		t.Logf("InMemory explicit-sweep: %d live entries after %d rounds", live, rounds)
+		assert.Equal(t, 0, live, "Sweep should keep growth bounded")
+	})
+
+	t.Run("InMemory_BackgroundSweeper_BoundedGrowth", func(t *testing.T) {
+		idx, err := NewInMemoryIndex(nil)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		go idx.StartSweeper(ctx, 20*time.Millisecond)
+
+		for round := 0; round < rounds; round++ {
+			keys := keysForRound(round, keysPerRound)
+			require.NoError(t, idx.Add(t.Context(), keys, keys, []PodEntry{podEntry}))
+			require.NoError(t, idx.Clear(t.Context(), podEntry))
+			// Give the sweeper a chance to run.
+			time.Sleep(40 * time.Millisecond)
+		}
+
+		// Wait one more debounce window to drain.
+		time.Sleep(60 * time.Millisecond)
+
+		live := countLiveInMemory(idx)
+		t.Logf("InMemory background-sweeper: %d live entries after %d rounds", live, rounds)
+		// Bound: allow up to a small constant of in-flight entries from the most recent round.
+		assert.LessOrEqual(t, live, keysPerRound,
+			"background sweeper should keep buildup bounded near a round's worth")
+	})
+
+	t.Run("CostAware_ExplicitSweep_BoundedGrowth", func(t *testing.T) {
+		idx, err := NewCostAwareMemoryIndex(nil)
+		require.NoError(t, err)
+
+		for round := 0; round < rounds; round++ {
+			keys := keysForRound(round, keysPerRound)
+			require.NoError(t, idx.Add(t.Context(), keys, keys, []PodEntry{podEntry}))
+			require.NoError(t, idx.Clear(t.Context(), podEntry))
+			removed := idx.Sweep(t.Context())
+			assert.Equal(t, keysPerRound, removed,
+				"round %d: Sweep should remove this round's stale entries", round)
+		}
+	})
+
+	t.Run("Redis_ExplicitSweep_BoundedGrowth", func(t *testing.T) {
+		idx, addr, cleanup := newMiniRedisIndex(t)
+		defer cleanup()
+		_ = addr
+
+		for round := 0; round < rounds; round++ {
+			keys := keysForRound(round, keysPerRound)
+			require.NoError(t, idx.Add(t.Context(), keys, keys, []PodEntry{podEntry}))
+			require.NoError(t, idx.Clear(t.Context(), podEntry))
+			removed, err := idx.Sweep(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, keysPerRound, removed,
+				"round %d: Redis Sweep should remove this round's stale entries", round)
+		}
+
+		// After a final sweep, the request-key namespace should be empty.
+		live := countLiveRedisRequestHashes(t.Context(), idx)
+		t.Logf("Redis explicit-sweep: %d live request-key hashes after %d rounds", live, rounds)
+		assert.Equal(t, 0, live, "Redis Sweep should keep growth bounded")
+	})
+}
+
+// keysForRound generates a deterministic, round-unique set of BlockHash keys.
+func keysForRound(round, n int) []BlockHash {
+	r := rand.New(rand.NewPCG(uint64(round)+1, 0xC0FFEE))
+	out := make([]BlockHash, n)
+	for i := range out {
+		out[i] = BlockHash(r.Uint64())
+	}
+	return out
+}
+
+// countLiveInMemory counts physically-present (PodEntry,requestKey) pairs in an
+// InMemoryIndex's underlying LRU. Used by the build-up test to distinguish
+// "Lookup reports zero" (correctness) from "the index has reclaimed memory".
+func countLiveInMemory(idx *InMemoryIndex) int {
+	n := 0
+	for _, k := range idx.data.Keys() {
+		pc, ok := idx.data.Peek(k)
+		if !ok || pc == nil {
+			continue
+		}
+		pc.mu.Lock()
+		n += pc.cache.Len()
+		pc.mu.Unlock()
+	}
+	return n
+}
+
+// newMiniRedisIndex spins up an in-process Redis (miniredis) and returns a
+// RedisIndex pointed at it, plus a cleanup func.
+func newMiniRedisIndex(t *testing.T) (*RedisIndex, string, func()) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	cfg := DefaultRedisIndexConfig()
+	cfg.Address = mr.Addr()
+	idx, err := NewRedisIndex(cfg)
+	require.NoError(t, err)
+	ri, ok := idx.(*RedisIndex)
+	require.True(t, ok)
+	return ri, mr.Addr(), func() {
+		_ = ri.RedisClient.Close()
+		mr.Close()
+	}
+}
+
+// countLiveRedisRequestHashes scans all keys and counts request-key hashes
+// (i.e. those without the "engine:" prefix) that still hold any fields.
+func countLiveRedisRequestHashes(ctx context.Context, idx *RedisIndex) int {
+	n := 0
+	var cursor uint64
+	for {
+		keys, next, err := idx.RedisClient.Scan(ctx, cursor, "*", 256).Result()
+		if err != nil {
+			return n
+		}
+		for _, k := range keys {
+			if hasPrefix(k, "engine:") {
+				continue
+			}
+			if length, err := idx.RedisClient.HLen(ctx, k).Result(); err == nil && length > 0 {
+				n++
+			}
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	return n
+}
+
+func hasPrefix(s, p string) bool {
+	return len(s) >= len(p) && s[:len(p)] == p
+}
+

--- a/pkg/kvcache/kvblock/gen_buildup_test.go
+++ b/pkg/kvcache/kvblock/gen_buildup_test.go
@@ -22,118 +22,64 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-// TestGenBuildup exercises repeated Clear+Add cycles with *fresh* request keys
-// each round. The naive expectation under the generation-counter scheme without
-// any cleanup is that stale entries pile up in the index until LRU/cost pressure
-// reclaims them. This test verifies:
+// TestGenBuildup runs N rounds of Add+Clear with fresh request keys per round
+// and verifies the three contracts of the generation-counter approach:
 //
-//  1. Without Sweep: Lookup correctly returns zero hits for cleared rounds — i.e.,
-//     correctness is preserved despite stale entries lingering — and the live
-//     entry count grows linearly with rounds.
-//  2. With explicit Sweep: stale entries are physically removed; the live entry
-//     count stays bounded at one round's worth.
-//  3. With StartSweeper background goroutine: stale entries are reclaimed within
-//     a few debounce cycles without explicit Sweep calls.
+//  1. Correctness without Sweep: Lookup returns zero hits post-Clear even though
+//     entries physically linger in the index.
+//  2. Default-on Sweeper via NewIndex: stale entries are reclaimed automatically.
+//  3. Redis Sweep: explicit reclamation works against the Redis backend.
 func TestGenBuildup(t *testing.T) {
 	const (
 		rounds       = 10
 		keysPerRound = 500
-		pod          = "podA"
-		tier         = "gpu"
 	)
-	podEntry := PodEntry{PodIdentifier: pod, DeviceTier: tier}
+	podEntry := PodEntry{PodIdentifier: "podA", DeviceTier: "gpu"}
 
-	t.Run("InMemory_NoSweep_StaleAccumulates", func(t *testing.T) {
+	t.Run("NoSweep_LookupCorrectButEntriesLinger", func(t *testing.T) {
 		idx, err := NewInMemoryIndex(nil)
 		require.NoError(t, err)
 
 		for round := 0; round < rounds; round++ {
 			keys := keysForRound(round, keysPerRound)
 			require.NoError(t, idx.Add(t.Context(), keys, keys, []PodEntry{podEntry}))
-
-			// Sanity: the new round's entries are visible.
 			hits, _ := idx.Lookup(t.Context(), keys, sets.Set[string]{})
-			assert.Len(t, hits, keysPerRound, "round %d entries visible before clear", round)
-
+			assert.Len(t, hits, keysPerRound)
 			require.NoError(t, idx.Clear(t.Context(), podEntry))
-
-			// Lookup after Clear must return zero — correctness invariant.
 			postClear, _ := idx.Lookup(t.Context(), keys, sets.Set[string]{})
-			assert.Empty(t, postClear, "round %d entries cleared by Clear", round)
+			assert.Empty(t, postClear, "Lookup must return zero post-Clear")
 		}
 
-		// Without Sweep, the index physically still holds entries for every round.
-		// Count live entries by ranging over the lru cache.
 		live := countLiveInMemory(idx)
-		t.Logf("InMemory no-sweep: %d live entries after %d rounds (%d added per round)",
-			live, rounds, keysPerRound)
-		assert.GreaterOrEqual(t, live, rounds*keysPerRound,
-			"expected stale entries to accumulate without Sweep")
+		t.Logf("no-sweep: %d live entries after %d rounds (%d/round)", live, rounds, keysPerRound)
+		assert.GreaterOrEqual(t, live, rounds*keysPerRound)
 	})
 
-	t.Run("InMemory_ExplicitSweep_BoundedGrowth", func(t *testing.T) {
-		idx, err := NewInMemoryIndex(nil)
-		require.NoError(t, err)
-
-		for round := 0; round < rounds; round++ {
-			keys := keysForRound(round, keysPerRound)
-			require.NoError(t, idx.Add(t.Context(), keys, keys, []PodEntry{podEntry}))
-			require.NoError(t, idx.Clear(t.Context(), podEntry))
-			removed := idx.Sweep(t.Context())
-			assert.Equal(t, keysPerRound, removed,
-				"round %d: Sweep should remove this round's stale entries", round)
-		}
-
-		// After a final round + sweep, the index should be empty.
-		live := countLiveInMemory(idx)
-		t.Logf("InMemory explicit-sweep: %d live entries after %d rounds", live, rounds)
-		assert.Equal(t, 0, live, "Sweep should keep growth bounded")
-	})
-
-	t.Run("InMemory_BackgroundSweeper_BoundedGrowth", func(t *testing.T) {
-		idx, err := NewInMemoryIndex(nil)
-		require.NoError(t, err)
-
+	t.Run("NewIndex_DefaultSweeper_BoundedGrowth", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
-		go idx.StartSweeper(ctx, 20*time.Millisecond)
 
-		for round := 0; round < rounds; round++ {
-			keys := keysForRound(round, keysPerRound)
-			require.NoError(t, idx.Add(t.Context(), keys, keys, []PodEntry{podEntry}))
-			require.NoError(t, idx.Clear(t.Context(), podEntry))
-			// Give the sweeper a chance to run.
-			time.Sleep(40 * time.Millisecond)
-		}
-
-		// Wait one more debounce window to drain.
-		time.Sleep(60 * time.Millisecond)
-
-		live := countLiveInMemory(idx)
-		t.Logf("InMemory background-sweeper: %d live entries after %d rounds", live, rounds)
-		// Bound: allow up to a small constant of in-flight entries from the most recent round.
-		assert.LessOrEqual(t, live, keysPerRound,
-			"background sweeper should keep buildup bounded near a round's worth")
-	})
-
-	t.Run("CostAware_ExplicitSweep_BoundedGrowth", func(t *testing.T) {
-		idx, err := NewCostAwareMemoryIndex(nil)
+		cfg := DefaultIndexConfig()
+		cfg.SweeperDebounce = 20 * time.Millisecond
+		idx, err := NewIndex(ctx, cfg)
 		require.NoError(t, err)
 
 		for round := 0; round < rounds; round++ {
 			keys := keysForRound(round, keysPerRound)
-			require.NoError(t, idx.Add(t.Context(), keys, keys, []PodEntry{podEntry}))
-			require.NoError(t, idx.Clear(t.Context(), podEntry))
-			removed := idx.Sweep(t.Context())
-			assert.Equal(t, keysPerRound, removed,
-				"round %d: Sweep should remove this round's stale entries", round)
+			require.NoError(t, idx.Add(ctx, keys, keys, []PodEntry{podEntry}))
+			require.NoError(t, idx.Clear(ctx, podEntry))
+			time.Sleep(40 * time.Millisecond)
 		}
+		time.Sleep(60 * time.Millisecond)
+
+		live := countLiveInMemory(idx.(*InMemoryIndex))
+		t.Logf("default sweeper: %d live entries after %d rounds", live, rounds)
+		assert.LessOrEqual(t, live, keysPerRound)
 	})
 
-	t.Run("Redis_ExplicitSweep_BoundedGrowth", func(t *testing.T) {
-		idx, addr, cleanup := newMiniRedisIndex(t)
+	t.Run("Redis_Sweep_BoundedGrowth", func(t *testing.T) {
+		idx, _, cleanup := newMiniRedisIndex(t)
 		defer cleanup()
-		_ = addr
 
 		for round := 0; round < rounds; round++ {
 			keys := keysForRound(round, keysPerRound)
@@ -141,14 +87,9 @@ func TestGenBuildup(t *testing.T) {
 			require.NoError(t, idx.Clear(t.Context(), podEntry))
 			removed, err := idx.Sweep(t.Context())
 			require.NoError(t, err)
-			assert.Equal(t, keysPerRound, removed,
-				"round %d: Redis Sweep should remove this round's stale entries", round)
+			assert.Equal(t, keysPerRound, removed)
 		}
-
-		// After a final sweep, the request-key namespace should be empty.
-		live := countLiveRedisRequestHashes(t.Context(), idx)
-		t.Logf("Redis explicit-sweep: %d live request-key hashes after %d rounds", live, rounds)
-		assert.Equal(t, 0, live, "Redis Sweep should keep growth bounded")
+		assert.Equal(t, 0, countLiveRedisRequestHashes(t.Context(), idx))
 	})
 }
 

--- a/pkg/kvcache/kvblock/gen_concurrent_test.go
+++ b/pkg/kvcache/kvblock/gen_concurrent_test.go
@@ -1,0 +1,324 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package kvblock
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// TestSweepDoesNotEvictFreshEntries verifies that an entry re-added after Clear
+// (stamped gen == current gen, so stamped < current is false) survives Sweep.
+// This is the "re-add after invalidation" contract.
+func TestSweepDoesNotEvictFreshEntries(t *testing.T) {
+	pod := PodEntry{PodIdentifier: "pod", DeviceTier: "gpu"}
+	key := BlockHash(0xDEADBEEF)
+	ctx := context.Background()
+
+	t.Run("InMemory", func(t *testing.T) {
+		idx, err := NewInMemoryIndex(nil)
+		require.NoError(t, err)
+
+		require.NoError(t, idx.Add(ctx, nil, []BlockHash{key}, []PodEntry{pod}))
+		require.NoError(t, idx.Clear(ctx, pod))
+		// Re-add stamps gen = current (post-Clear) so condition stamped < current is false.
+		require.NoError(t, idx.Add(ctx, nil, []BlockHash{key}, []PodEntry{pod}))
+
+		removed := idx.Sweep(ctx)
+		assert.Equal(t, 0, removed, "Sweep must not remove an entry added after Clear")
+
+		hits, err := idx.Lookup(ctx, []BlockHash{key}, sets.Set[string]{})
+		require.NoError(t, err)
+		assert.Len(t, hits[key], 1, "re-added pod must be visible after Sweep")
+	})
+
+	t.Run("CostAwareMemory", func(t *testing.T) {
+		idx, err := NewCostAwareMemoryIndex(nil)
+		require.NoError(t, err)
+
+		require.NoError(t, idx.Add(ctx, nil, []BlockHash{key}, []PodEntry{pod}))
+		require.NoError(t, idx.Clear(ctx, pod))
+		require.NoError(t, idx.Add(ctx, nil, []BlockHash{key}, []PodEntry{pod}))
+
+		removed := idx.Sweep(ctx)
+		assert.Equal(t, 0, removed, "Sweep must not remove an entry added after Clear")
+
+		hits, err := idx.Lookup(ctx, []BlockHash{key}, sets.Set[string]{})
+		require.NoError(t, err)
+		assert.Len(t, hits[key], 1)
+	})
+
+	t.Run("Redis", func(t *testing.T) {
+		idx, _, cleanup := newMiniRedisIndex(t)
+		defer cleanup()
+
+		require.NoError(t, idx.Add(ctx, nil, []BlockHash{key}, []PodEntry{pod}))
+		require.NoError(t, idx.Clear(ctx, pod))
+		require.NoError(t, idx.Add(ctx, nil, []BlockHash{key}, []PodEntry{pod}))
+
+		removed, err := idx.Sweep(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 0, removed, "Sweep must not remove an entry added after Clear")
+
+		hits, err := idx.Lookup(ctx, []BlockHash{key}, sets.Set[string]{})
+		require.NoError(t, err)
+		assert.Len(t, hits[key], 1)
+	})
+}
+
+// TestConcurrentSweepAndAdd_FreshEntriesPreserved exercises the Bug 2 fix:
+// Sweep must not delete a requestKey whose PodCache a concurrent Add has
+// populated after the key appeared empty.
+//
+// Invariant: after Add(post-Clear) and Sweep both finish, the added entry is
+// always reachable via Lookup (Add rebuilds the entry if Sweep removed the key
+// before Add ran, or Sweep skips removal if Add already populated the cache).
+func TestConcurrentSweepAndAdd_FreshEntriesPreserved(t *testing.T) {
+	const rounds = 200
+	pod := PodEntry{PodIdentifier: "pod", DeviceTier: "gpu"}
+	ctx := context.Background()
+
+	for round := 0; round < rounds; round++ {
+		idx, err := NewInMemoryIndex(nil)
+		require.NoError(t, err)
+
+		key := BlockHash(uint64(round + 1))
+
+		// Pre-populate so Sweep has stale entries to remove.
+		require.NoError(t, idx.Add(ctx, nil, []BlockHash{key}, []PodEntry{pod}))
+		require.NoError(t, idx.Clear(ctx, pod)) // gen 0→1; entry is now stale
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			idx.Sweep(ctx) // removes the stale gen-0 entry, key becomes empty
+		}()
+		go func() {
+			defer wg.Done()
+			// Re-adds with stamped gen = 1 (current); must survive Sweep.
+			_ = idx.Add(ctx, nil, []BlockHash{key}, []PodEntry{pod})
+		}()
+		wg.Wait()
+
+		hits, err := idx.Lookup(ctx, []BlockHash{key}, sets.Set[string]{})
+		require.NoError(t, err)
+		assert.Len(t, hits[key], 1,
+			"round %d: entry added after Clear must be visible post Sweep", round)
+	}
+}
+
+// TestConcurrentClearAndAdd verifies no panics or corruption when Clear and Add
+// race on the same index. Run with -race to detect data races.
+func TestConcurrentClearAndAdd(t *testing.T) {
+	idx, err := NewInMemoryIndex(nil)
+	require.NoError(t, err)
+
+	const goroutines = 20
+	const iterations = 200
+	pod := PodEntry{PodIdentifier: "pod", DeviceTier: "gpu"}
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for g := range goroutines / 2 {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			key := BlockHash(uint64(id + 1))
+			for range iterations {
+				_ = idx.Add(ctx, nil, []BlockHash{key}, []PodEntry{pod})
+			}
+		}(g)
+	}
+	for range goroutines / 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				_ = idx.Clear(ctx, pod)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestStartSweeper_ConcurrentClear checks that the eager sweepCh initialization
+// (Bug 1 fix) prevents a data race between Clear and StartSweeper.
+// Run with -race to verify.
+func TestStartSweeper_ConcurrentClear(t *testing.T) {
+	idx, err := NewInMemoryIndex(nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	pod := PodEntry{PodIdentifier: "pod", DeviceTier: "gpu"}
+
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = idx.Clear(context.Background(), pod)
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		idx.StartSweeper(ctx, time.Millisecond)
+	}()
+	wg.Wait()
+}
+
+// TestMultipleClearMultiplePods verifies that Clear for one pod does not
+// invalidate entries for another pod.
+func TestMultipleClearMultiplePods(t *testing.T) {
+	idx, err := NewInMemoryIndex(nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	podA := PodEntry{PodIdentifier: "A", DeviceTier: "gpu"}
+	podB := PodEntry{PodIdentifier: "B", DeviceTier: "gpu"}
+	key := BlockHash(1)
+
+	require.NoError(t, idx.Add(ctx, nil, []BlockHash{key}, []PodEntry{podA, podB}))
+	require.NoError(t, idx.Clear(ctx, podA))
+
+	hits, err := idx.Lookup(ctx, []BlockHash{key}, sets.Set[string]{})
+	require.NoError(t, err)
+	assert.Len(t, hits[key], 1, "only podB should remain after clearing podA")
+	assert.Equal(t, podB, hits[key][0])
+
+	// Sweep should evict podA's stale entry only.
+	removed := idx.Sweep(ctx)
+	assert.Equal(t, 1, removed)
+
+	hits, err = idx.Lookup(ctx, []BlockHash{key}, sets.Set[string]{})
+	require.NoError(t, err)
+	assert.Len(t, hits[key], 1, "podB still present after Sweep")
+}
+
+// --- Benchmarks ---------------------------------------------------------------
+
+// BenchmarkClear_InMemory confirms Clear is O(1) regardless of index size.
+func BenchmarkClear_InMemory(b *testing.B) {
+	idx, _ := NewInMemoryIndex(nil)
+	ctx := context.Background()
+	pod := PodEntry{PodIdentifier: "pod", DeviceTier: "gpu"}
+
+	keys := make([]BlockHash, 10_000)
+	for i := range keys {
+		keys[i] = BlockHash(uint64(i + 1))
+	}
+	_ = idx.Add(ctx, nil, keys, []PodEntry{pod})
+
+	b.ResetTimer()
+	for range b.N {
+		_ = idx.Clear(ctx, pod)
+	}
+}
+
+// BenchmarkLookup_HotPath_InMemory measures the no-Clear fast path (one slice copy).
+func BenchmarkLookup_HotPath_InMemory(b *testing.B) {
+	idx, _ := NewInMemoryIndex(nil)
+	ctx := context.Background()
+	pod := PodEntry{PodIdentifier: "pod", DeviceTier: "gpu"}
+
+	keys := make([]BlockHash, 100)
+	for i := range keys {
+		keys[i] = BlockHash(uint64(i + 1))
+	}
+	_ = idx.Add(ctx, nil, keys, []PodEntry{pod})
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = idx.Lookup(ctx, keys, sets.Set[string]{})
+		}
+	})
+}
+
+// BenchmarkLookup_WithGenFilter_InMemory measures the per-entry generation
+// filter path that activates once any Clear has occurred.
+func BenchmarkLookup_WithGenFilter_InMemory(b *testing.B) {
+	idx, _ := NewInMemoryIndex(nil)
+	ctx := context.Background()
+	podA := PodEntry{PodIdentifier: "A", DeviceTier: "gpu"}
+	podB := PodEntry{PodIdentifier: "B", DeviceTier: "gpu"}
+
+	keys := make([]BlockHash, 100)
+	for i := range keys {
+		keys[i] = BlockHash(uint64(i + 1))
+	}
+	_ = idx.Add(ctx, nil, keys, []PodEntry{podA, podB})
+	// One Clear activates the gen-filter branch in Lookup.
+	_ = idx.Clear(ctx, PodEntry{PodIdentifier: "other", DeviceTier: "gpu"})
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = idx.Lookup(ctx, keys, sets.Set[string]{})
+		}
+	})
+}
+
+// BenchmarkSweep_1k_InMemory characterizes Sweep over a 1 000-entry stale index.
+func BenchmarkSweep_1k_InMemory(b *testing.B) {
+	ctx := context.Background()
+	pod := PodEntry{PodIdentifier: "pod", DeviceTier: "gpu"}
+	keys := make([]BlockHash, 1_000)
+	for i := range keys {
+		keys[i] = BlockHash(uint64(i + 1))
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		b.StopTimer()
+		idx, _ := NewInMemoryIndex(nil)
+		_ = idx.Add(ctx, nil, keys, []PodEntry{pod})
+		_ = idx.Clear(ctx, pod)
+		b.StartTimer()
+		idx.Sweep(ctx)
+	}
+}
+
+// BenchmarkConcurrentClearLookup_InMemory simulates a realistic workload where
+// most goroutines read (Lookup) while a minority write (Clear+Add).
+func BenchmarkConcurrentClearLookup_InMemory(b *testing.B) {
+	idx, _ := NewInMemoryIndex(nil)
+	ctx := context.Background()
+	pod := PodEntry{PodIdentifier: "pod", DeviceTier: "gpu"}
+
+	keys := make([]BlockHash, 100)
+	for i := range keys {
+		keys[i] = BlockHash(uint64(i + 1))
+	}
+	_ = idx.Add(ctx, nil, keys, []PodEntry{pod})
+
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			if i%10 == 0 {
+				_ = idx.Clear(ctx, pod)
+				_ = idx.Add(ctx, nil, keys, []PodEntry{pod})
+			} else {
+				_, _ = idx.Lookup(ctx, keys, sets.Set[string]{})
+			}
+			i++
+		}
+	})
+}

--- a/pkg/kvcache/kvblock/gen_tracker.go
+++ b/pkg/kvcache/kvblock/gen_tracker.go
@@ -22,7 +22,8 @@ import (
 //
 // This is the in-process variant used by InMemoryIndex and CostAwareMemoryIndex.
 type podGenTracker struct {
-	gens sync.Map // map[string]*atomic.Uint64
+	gens         sync.Map      // map[string]*atomic.Uint64
+	totalClears  atomic.Uint64 // monotonically incremented on every bump; cheap "anyone cleared?" predicate
 }
 
 // current returns the current generation for the pod (0 if pod is unknown).
@@ -36,5 +37,34 @@ func (g *podGenTracker) current(pod string) uint64 {
 // bump increments and returns the new generation for the pod.
 func (g *podGenTracker) bump(pod string) uint64 {
 	v, _ := g.gens.LoadOrStore(pod, new(atomic.Uint64))
+	g.totalClears.Add(1)
 	return v.(*atomic.Uint64).Add(1)
+}
+
+// anyClears returns the total number of Clear operations performed across all pods.
+// Lookup uses this as a cheap fast-path predicate: if zero, no entry can be stale
+// and per-entry generation filtering can be skipped.
+func (g *podGenTracker) anyClears() uint64 {
+	return g.totalClears.Load()
+}
+
+// genCache is a one-call-scoped memoization of per-pod current generations.
+// Lookup builds one of these at call entry and reuses it across all entries
+// in the call to avoid repeated sync.Map lookups in the hot path.
+type genCache struct {
+	tracker *podGenTracker
+	cache   map[string]uint64
+}
+
+func (g *podGenTracker) snapshot() *genCache {
+	return &genCache{tracker: g, cache: make(map[string]uint64)}
+}
+
+func (c *genCache) current(pod string) uint64 {
+	if v, ok := c.cache[pod]; ok {
+		return v
+	}
+	v := c.tracker.current(pod)
+	c.cache[pod] = v
+	return v
 }

--- a/pkg/kvcache/kvblock/gen_tracker.go
+++ b/pkg/kvcache/kvblock/gen_tracker.go
@@ -16,17 +16,14 @@ import (
 )
 
 // podGenTracker holds a per-pod monotonic generation counter. Add stamps the
-// current generation onto each entry; Lookup filters entries whose stamped
-// generation is below the current. Clear bumps the pod's generation, which
-// invalidates all prior entries lazily.
-//
-// This is the in-process variant used by InMemoryIndex and CostAwareMemoryIndex.
+// current value onto each entry, Lookup filters entries whose stamp is below
+// the current, Clear bumps. Stale entries are reclaimed lazily (LRU/cost
+// pressure) or eagerly via Sweep.
 type podGenTracker struct {
-	gens         sync.Map      // map[string]*atomic.Uint64
-	totalClears  atomic.Uint64 // monotonically incremented on every bump; cheap "anyone cleared?" predicate
+	gens        sync.Map      // map[string]*atomic.Uint64
+	totalClears atomic.Uint64 // any pod ever cleared? — cheap fast-path predicate
 }
 
-// current returns the current generation for the pod (0 if pod is unknown).
 func (g *podGenTracker) current(pod string) uint64 {
 	if v, ok := g.gens.Load(pod); ok {
 		return v.(*atomic.Uint64).Load()
@@ -34,23 +31,16 @@ func (g *podGenTracker) current(pod string) uint64 {
 	return 0
 }
 
-// bump increments and returns the new generation for the pod.
 func (g *podGenTracker) bump(pod string) uint64 {
 	v, _ := g.gens.LoadOrStore(pod, new(atomic.Uint64))
 	g.totalClears.Add(1)
 	return v.(*atomic.Uint64).Add(1)
 }
 
-// anyClears returns the total number of Clear operations performed across all pods.
-// Lookup uses this as a cheap fast-path predicate: if zero, no entry can be stale
-// and per-entry generation filtering can be skipped.
-func (g *podGenTracker) anyClears() uint64 {
-	return g.totalClears.Load()
-}
+func (g *podGenTracker) anyClears() uint64 { return g.totalClears.Load() }
 
-// genCache is a one-call-scoped memoization of per-pod current generations.
-// Lookup builds one of these at call entry and reuses it across all entries
-// in the call to avoid repeated sync.Map lookups in the hot path.
+// genCache memoizes per-pod current generations within a single Lookup call,
+// avoiding repeated sync.Map lookups when the same pod appears many times.
 type genCache struct {
 	tracker *podGenTracker
 	cache   map[string]uint64

--- a/pkg/kvcache/kvblock/gen_tracker.go
+++ b/pkg/kvcache/kvblock/gen_tracker.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package kvblock
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// podGenTracker holds a per-pod monotonic generation counter. Add stamps the
+// current generation onto each entry; Lookup filters entries whose stamped
+// generation is below the current. Clear bumps the pod's generation, which
+// invalidates all prior entries lazily.
+//
+// This is the in-process variant used by InMemoryIndex and CostAwareMemoryIndex.
+type podGenTracker struct {
+	gens sync.Map // map[string]*atomic.Uint64
+}
+
+// current returns the current generation for the pod (0 if pod is unknown).
+func (g *podGenTracker) current(pod string) uint64 {
+	if v, ok := g.gens.Load(pod); ok {
+		return v.(*atomic.Uint64).Load()
+	}
+	return 0
+}
+
+// bump increments and returns the new generation for the pod.
+func (g *podGenTracker) bump(pod string) uint64 {
+	v, _ := g.gens.LoadOrStore(pod, new(atomic.Uint64))
+	return v.(*atomic.Uint64).Add(1)
+}

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -358,14 +358,13 @@ func (m *InMemoryIndex) GetRequestKey(ctx context.Context, engineKey BlockHash) 
 	return rks[len(rks)-1], nil
 }
 
-// Clear invalidates all entries for the given podEntry by bumping the pod's
-// generation counter. Stale entries are filtered at Lookup time and reclaimed
-// lazily by normal LRU pressure (or eagerly via Sweep). O(1).
+// Clear bumps the pod's generation counter, invalidating all prior entries for
+// that pod lazily. Stale entries are filtered at Lookup and reclaimed by Sweep
+// or by LRU pressure. O(1).
 func (m *InMemoryIndex) Clear(ctx context.Context, podEntry PodEntry) error {
 	m.gen.bump(podEntry.PodIdentifier)
 	log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.InMemoryIndex.Clear").
 		Info("bumped pod generation", "pod", podEntry.PodIdentifier)
-	// Non-blocking notify of any active sweeper. Coalesces bursts.
 	if m.sweepCh != nil {
 		select {
 		case m.sweepCh <- struct{}{}:
@@ -375,13 +374,8 @@ func (m *InMemoryIndex) Clear(ctx context.Context, podEntry PodEntry) error {
 	return nil
 }
 
-// Sweep performs an immediate scan over the entire index, removing entries whose
-// stamped generation is below their pod's current generation. Returns the count
-// of removed entries. Safe to call concurrently with Add/Lookup/Clear.
-//
-// Sweep is O(N) over total cached entries and is intended to run off the hot path,
-// either invoked explicitly by the operator or driven by a background goroutine
-// (see StartSweeper).
+// Sweep removes entries whose stamped generation is below their pod's current
+// generation. Returns the count removed. O(N) over the index; off the hot path.
 func (m *InMemoryIndex) Sweep(ctx context.Context) int {
 	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.InMemoryIndex.Sweep")
 	if m.gen.anyClears() == 0 {
@@ -422,13 +416,8 @@ func (m *InMemoryIndex) Sweep(ctx context.Context) int {
 	return removed
 }
 
-// StartSweeper runs a background goroutine that calls Sweep() whenever Clear is
-// invoked, debounced by `debounce`. Multiple Clears within the debounce window
-// coalesce into a single sweep. Returns when ctx is cancelled.
-//
-// Typical usage:
-//
-//	go idx.StartSweeper(ctx, 100*time.Millisecond)
+// StartSweeper runs Sweep on every Clear, debounced and coalesced.
+// Returns when ctx is cancelled. NewIndex starts this by default.
 func (m *InMemoryIndex) StartSweeper(ctx context.Context, debounce time.Duration) {
 	if debounce <= 0 {
 		debounce = 100 * time.Millisecond

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -73,6 +73,7 @@ func NewInMemoryIndex(cfg *InMemoryIndexConfig) (*InMemoryIndex, error) {
 		data:                cache,
 		engineToRequestKeys: engineToRequestKeys,
 		podCacheSize:        cfg.PodCacheSize,
+		sweepCh:             make(chan struct{}, 1),
 	}, nil
 }
 
@@ -407,7 +408,19 @@ func (m *InMemoryIndex) Sweep(ctx context.Context) int {
 		empty := cache.cache.Len() == 0
 		cache.mu.Unlock()
 		if empty {
-			m.data.Remove(requestKey)
+			// Hold m.mu before removing the key. Add always holds m.mu while
+			// it has a reference to a PodCache, so taking m.mu here ensures a
+			// concurrent Add cannot populate this cache between our empty-check
+			// and the Remove, which would silently discard freshly-added entries.
+			m.mu.Lock()
+			if current, ok := m.data.Peek(requestKey); ok && current != nil {
+				current.mu.Lock()
+				if current.cache.Len() == 0 {
+					m.data.Remove(requestKey)
+				}
+				current.mu.Unlock()
+			}
+			m.mu.Unlock()
 		}
 	}
 	if removed > 0 {
@@ -422,11 +435,7 @@ func (m *InMemoryIndex) StartSweeper(ctx context.Context, debounce time.Duration
 	if debounce <= 0 {
 		debounce = 100 * time.Millisecond
 	}
-	if m.sweepCh == nil {
-		// First caller wins; avoid races by guarding here. The benchmarks/tests
-		// only call StartSweeper from one goroutine so this is sufficient.
-		m.sweepCh = make(chan struct{}, 1)
-	}
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -86,15 +86,18 @@ type InMemoryIndex struct {
 	engineToRequestKeys *lru.Cache[BlockHash, []BlockHash]
 	// podCacheSize is the maximum number of pod entries per key.
 	podCacheSize int
+	// gen tracks per-pod generation counters for O(1) Clear via lazy invalidation.
+	gen podGenTracker
 }
 
 var _ Index = &InMemoryIndex{}
 
 // PodCache represents a cache for pod entries.
+// The map value is the generation at which the entry was admitted (see podGenTracker).
 type PodCache struct {
-	// cache is an LRU cache that maps PodEntry to their last access time.
+	// cache is an LRU cache that maps PodEntry to its admission generation.
 	// thread-safe.
-	cache *lru.Cache[PodEntry, struct{}]
+	cache *lru.Cache[PodEntry, uint64]
 	// mu protects the cache from concurrent access during check-and-set operations.
 	mu sync.Mutex
 }
@@ -128,16 +131,22 @@ func (m *InMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 
 			highestHitIdx = idx
 
-			if podIdentifierSet.Len() == 0 {
-				// If no pod identifiers are provided, return all pods
-				podsPerKey[requestKey] = pods.cache.Keys()
-			} else {
-				// Filter pods based on the provided pod identifiers
-				for _, pod := range pods.cache.Keys() {
-					if podIdentifierSet.Has(pod.PodIdentifier) {
-						podsPerKey[requestKey] = append(podsPerKey[requestKey], pod)
-					}
+			// Filter pods based on the provided pod identifiers AND the per-pod generation
+			// counter. An entry whose stamped generation is below the current generation
+			// for its pod is considered cleared.
+			filterPodSet := podIdentifierSet.Len() != 0
+			for _, pod := range pods.cache.Keys() {
+				if filterPodSet && !podIdentifierSet.Has(pod.PodIdentifier) {
+					continue
 				}
+				stampedGen, ok := pods.cache.Peek(pod)
+				if !ok {
+					continue
+				}
+				if stampedGen < m.gen.current(pod.PodIdentifier) {
+					continue
+				}
+				podsPerKey[requestKey] = append(podsPerKey[requestKey], pod)
 			}
 		} else {
 			traceLogger.Info("key not found in index", "key", requestKey)
@@ -194,7 +203,7 @@ func (m *InMemoryIndex) Add(ctx context.Context, engineKeys, requestKeys []Block
 		//nolint:nestif // double-checked locking pattern
 		if !found {
 			// Create new cache
-			cache, err := lru.New[PodEntry, struct{}](m.podCacheSize)
+			cache, err := lru.New[PodEntry, uint64](m.podCacheSize)
 			if err != nil {
 				return fmt.Errorf("failed to create pod cache for key %s: %w", requestKey.String(), err)
 			}
@@ -221,7 +230,7 @@ func (m *InMemoryIndex) Add(ctx context.Context, engineKeys, requestKeys []Block
 
 		podCache.mu.Lock()
 		for _, entry := range entries {
-			podCache.cache.Add(entry, struct{}{})
+			podCache.cache.Add(entry, m.gen.current(entry.PodIdentifier))
 		}
 		podCache.mu.Unlock()
 
@@ -321,6 +330,16 @@ func (m *InMemoryIndex) GetRequestKey(ctx context.Context, engineKey BlockHash) 
 		return EmptyBlockHash, fmt.Errorf("engine key not found: %s", engineKey.String())
 	}
 	return rks[len(rks)-1], nil
+}
+
+// Clear invalidates all entries for the given podEntry by bumping the pod's
+// generation counter. Stale entries are filtered at Lookup time and reclaimed
+// lazily by normal LRU pressure. O(1).
+func (m *InMemoryIndex) Clear(ctx context.Context, podEntry PodEntry) error {
+	m.gen.bump(podEntry.PodIdentifier)
+	log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.InMemoryIndex.Clear").
+		Info("bumped pod generation", "pod", podEntry.PodIdentifier)
+	return nil
 }
 
 // podsPerKeyPrintHelper formats a map of keys to pod names for printing.

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -88,6 +89,9 @@ type InMemoryIndex struct {
 	podCacheSize int
 	// gen tracks per-pod generation counters for O(1) Clear via lazy invalidation.
 	gen podGenTracker
+	// sweepCh is signalled by Clear when a background sweeper is running.
+	// Lazily initialized by StartSweeper to keep New cheap and side-effect-free.
+	sweepCh chan struct{}
 }
 
 var _ Index = &InMemoryIndex{}
@@ -122,6 +126,16 @@ func (m *InMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 	podsPerKey := make(map[BlockHash][]PodEntry)
 	highestHitIdx := 0
 
+	// Fast-path predicates evaluated once per call:
+	//   - filterPodSet: caller restricted to a subset of pods
+	//   - needGenFilter: at least one Clear has ever happened, so entries may be stale
+	filterPodSet := podIdentifierSet.Len() != 0
+	needGenFilter := m.gen.anyClears() != 0
+	var gens *genCache
+	if needGenFilter {
+		gens = m.gen.snapshot()
+	}
+
 	for idx, requestKey := range requestKeys {
 		if pods, found := m.data.Get(requestKey); found { //nolint:nestif // TODO: can this be optimized?
 			if pods == nil || pods.cache.Len() == 0 {
@@ -131,22 +145,34 @@ func (m *InMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 
 			highestHitIdx = idx
 
-			// Filter pods based on the provided pod identifiers AND the per-pod generation
-			// counter. An entry whose stamped generation is below the current generation
-			// for its pod is considered cleared.
-			filterPodSet := podIdentifierSet.Len() != 0
-			for _, pod := range pods.cache.Keys() {
-				if filterPodSet && !podIdentifierSet.Has(pod.PodIdentifier) {
-					continue
+			switch {
+			case !filterPodSet && !needGenFilter:
+				// Hot fast path: no pod filter and no Clear has ever happened on this index,
+				// so every cached entry is current. One slice copy, no per-entry work.
+				podsPerKey[requestKey] = pods.cache.Keys()
+			case !filterPodSet:
+				// Pod filter empty but at least one pod has been cleared: must check gen per entry.
+				for _, pod := range pods.cache.Keys() {
+					stampedGen, ok := pods.cache.Peek(pod)
+					if !ok || stampedGen < gens.current(pod.PodIdentifier) {
+						continue
+					}
+					podsPerKey[requestKey] = append(podsPerKey[requestKey], pod)
 				}
-				stampedGen, ok := pods.cache.Peek(pod)
-				if !ok {
-					continue
+			default:
+				// Caller restricted to a subset of pods; combine with gen filter when needed.
+				for _, pod := range pods.cache.Keys() {
+					if !podIdentifierSet.Has(pod.PodIdentifier) {
+						continue
+					}
+					if needGenFilter {
+						stampedGen, ok := pods.cache.Peek(pod)
+						if !ok || stampedGen < gens.current(pod.PodIdentifier) {
+							continue
+						}
+					}
+					podsPerKey[requestKey] = append(podsPerKey[requestKey], pod)
 				}
-				if stampedGen < m.gen.current(pod.PodIdentifier) {
-					continue
-				}
-				podsPerKey[requestKey] = append(podsPerKey[requestKey], pod)
 			}
 		} else {
 			traceLogger.Info("key not found in index", "key", requestKey)
@@ -334,12 +360,106 @@ func (m *InMemoryIndex) GetRequestKey(ctx context.Context, engineKey BlockHash) 
 
 // Clear invalidates all entries for the given podEntry by bumping the pod's
 // generation counter. Stale entries are filtered at Lookup time and reclaimed
-// lazily by normal LRU pressure. O(1).
+// lazily by normal LRU pressure (or eagerly via Sweep). O(1).
 func (m *InMemoryIndex) Clear(ctx context.Context, podEntry PodEntry) error {
 	m.gen.bump(podEntry.PodIdentifier)
 	log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.InMemoryIndex.Clear").
 		Info("bumped pod generation", "pod", podEntry.PodIdentifier)
+	// Non-blocking notify of any active sweeper. Coalesces bursts.
+	if m.sweepCh != nil {
+		select {
+		case m.sweepCh <- struct{}{}:
+		default:
+		}
+	}
 	return nil
+}
+
+// Sweep performs an immediate scan over the entire index, removing entries whose
+// stamped generation is below their pod's current generation. Returns the count
+// of removed entries. Safe to call concurrently with Add/Lookup/Clear.
+//
+// Sweep is O(N) over total cached entries and is intended to run off the hot path,
+// either invoked explicitly by the operator or driven by a background goroutine
+// (see StartSweeper).
+func (m *InMemoryIndex) Sweep(ctx context.Context) int {
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.InMemoryIndex.Sweep")
+	if m.gen.anyClears() == 0 {
+		return 0
+	}
+	gens := m.gen.snapshot()
+
+	removed := 0
+	for _, requestKey := range m.data.Keys() {
+		cache, ok := m.data.Peek(requestKey)
+		if !ok || cache == nil {
+			continue
+		}
+		cache.mu.Lock()
+		var toRemove []PodEntry
+		for _, entry := range cache.cache.Keys() {
+			stamped, ok := cache.cache.Peek(entry)
+			if !ok {
+				continue
+			}
+			if stamped < gens.current(entry.PodIdentifier) {
+				toRemove = append(toRemove, entry)
+			}
+		}
+		for _, e := range toRemove {
+			cache.cache.Remove(e)
+		}
+		removed += len(toRemove)
+		empty := cache.cache.Len() == 0
+		cache.mu.Unlock()
+		if empty {
+			m.data.Remove(requestKey)
+		}
+	}
+	if removed > 0 {
+		traceLogger.Info("sweep removed stale entries", "removed", removed)
+	}
+	return removed
+}
+
+// StartSweeper runs a background goroutine that calls Sweep() whenever Clear is
+// invoked, debounced by `debounce`. Multiple Clears within the debounce window
+// coalesce into a single sweep. Returns when ctx is cancelled.
+//
+// Typical usage:
+//
+//	go idx.StartSweeper(ctx, 100*time.Millisecond)
+func (m *InMemoryIndex) StartSweeper(ctx context.Context, debounce time.Duration) {
+	if debounce <= 0 {
+		debounce = 100 * time.Millisecond
+	}
+	if m.sweepCh == nil {
+		// First caller wins; avoid races by guarding here. The benchmarks/tests
+		// only call StartSweeper from one goroutine so this is sufficient.
+		m.sweepCh = make(chan struct{}, 1)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-m.sweepCh:
+			// Coalesce bursts within the debounce window.
+			timer := time.NewTimer(debounce)
+			drained := false
+			for !drained {
+				select {
+				case <-m.sweepCh:
+					// extra signal arrived during debounce, keep waiting
+				case <-timer.C:
+					drained = true
+				case <-ctx.Done():
+					timer.Stop()
+					return
+				}
+			}
+			m.Sweep(ctx)
+		}
+	}
 }
 
 // podsPerKeyPrintHelper formats a map of keys to pod names for printing.

--- a/pkg/kvcache/kvblock/index.go
+++ b/pkg/kvcache/kvblock/index.go
@@ -46,6 +46,17 @@ type IndexConfig struct {
 	// If zero, metrics logging is disabled.
 	// Requires `EnableMetrics` to be true.
 	MetricsLoggingInterval time.Duration `json:"metricsLoggingInterval"`
+
+	// DisableSweeper turns off the background sweeper that physically reclaims
+	// entries invalidated by Clear. The sweeper runs by default — Clear is O(1)
+	// (a single generation bump) and the sweeper handles reclamation off the
+	// hot path, debounced by SweeperDebounce. Set this to true only if you want
+	// to drive Sweep manually or rely entirely on LRU/cost-pressure reclamation.
+	DisableSweeper bool `json:"disableSweeper"`
+	// SweeperDebounce is the minimum interval between two sweeps. Multiple Clears
+	// arriving within this window coalesce into a single sweep. If zero,
+	// defaults to 100ms. Ignored when DisableSweeper is true.
+	SweeperDebounce time.Duration `json:"sweeperDebounce"`
 }
 
 // DefaultIndexConfig returns a default configuration for the KV-block index.
@@ -92,6 +103,15 @@ func NewIndex(ctx context.Context, cfg *IndexConfig) (Index, error) {
 		return nil, fmt.Errorf("no valid index configuration provided")
 	}
 
+	// Default-on: spawn a background sweeper that reclaims entries invalidated
+	// by Clear. Tied to ctx — cancel ctx to stop. Checked on the underlying
+	// backend before metrics wrapping so the type assertion isn't hidden.
+	if !cfg.DisableSweeper {
+		if s, ok := idx.(sweeper); ok {
+			go s.StartSweeper(ctx, cfg.SweeperDebounce)
+		}
+	}
+
 	// wrap in metrics only if enabled
 	if cfg.EnableMetrics {
 		idx = NewInstrumentedIndex(idx)
@@ -103,6 +123,12 @@ func NewIndex(ctx context.Context, cfg *IndexConfig) (Index, error) {
 	}
 
 	return idx, nil
+}
+
+// sweeper is implemented by backends that support eager reclamation of entries
+// invalidated by Clear via a background goroutine.
+type sweeper interface {
+	StartSweeper(ctx context.Context, debounce time.Duration)
 }
 
 // Index defines the interface for a backend that manages KV-block

--- a/pkg/kvcache/kvblock/index.go
+++ b/pkg/kvcache/kvblock/index.go
@@ -146,6 +146,11 @@ type Index interface {
 	Evict(ctx context.Context, key BlockHash, keyType KeyType, entries []PodEntry) error
 	// GetRequestKey returns the requestKey associated with the given engineKey.
 	GetRequestKey(ctx context.Context, engineKey BlockHash) (BlockHash, error)
+	// Clear invalidates all entries for the given podEntry.
+	// In the generation-counter implementation, this is a single atomic increment;
+	// stale entries are filtered out at Lookup time and reclaimed lazily by normal
+	// LRU/cost pressure.
+	Clear(ctx context.Context, podEntry PodEntry) error
 }
 
 // KeyType indicates whether a key passed to Evict is an engine key or a request key.

--- a/pkg/kvcache/kvblock/index_test.go
+++ b/pkg/kvcache/kvblock/index_test.go
@@ -118,6 +118,31 @@ func testCommonIndexBehavior(t *testing.T, indexFactory func(t *testing.T) Index
 		index := indexFactory(t)
 		testEvictPreservesEngineMappingForOtherTiers(t, ctx, index)
 	})
+
+	t.Run("ClearBasic", func(t *testing.T) {
+		index := indexFactory(t)
+		testClearBasic(t, ctx, index)
+	})
+
+	t.Run("ClearIsolatesOtherPods", func(t *testing.T) {
+		index := indexFactory(t)
+		testClearIsolatesOtherPods(t, ctx, index)
+	})
+
+	t.Run("ClearThenReAdd", func(t *testing.T) {
+		index := indexFactory(t)
+		testClearThenReAdd(t, ctx, index)
+	})
+
+	t.Run("ClearMultipleTimes", func(t *testing.T) {
+		index := indexFactory(t)
+		testClearMultipleTimes(t, ctx, index)
+	})
+
+	t.Run("StressConcurrentClearAndLookup", func(t *testing.T) {
+		index := indexFactory(t)
+		testStressConcurrentClearAndLookup(t, ctx, index)
+	})
 }
 
 // testBasicAddAndLookup tests basic Add and Lookup functionality.
@@ -790,4 +815,155 @@ func testEvictPreservesEngineMappingForOtherTiers(t *testing.T, ctx context.Cont
 	// Engine→request mapping should be gone.
 	_, err = index.GetRequestKey(ctx, engineKey)
 	assert.Error(t, err, "engine→request mapping should be removed after full eviction")
+}
+
+// testClearBasic verifies that Clear makes all pre-existing entries for a pod
+// invisible to Lookup immediately after the call.
+func testClearBasic(t *testing.T, ctx context.Context, index Index) {
+	t.Helper()
+	pod := PodEntry{PodIdentifier: "pod-clear", DeviceTier: "gpu"}
+	key := BlockHash(0xC1EA0001)
+
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{key}, []PodEntry{pod}))
+
+	hits, err := index.Lookup(ctx, []BlockHash{key}, sets.Set[string]{})
+	require.NoError(t, err)
+	assert.Len(t, hits[key], 1, "pod should be visible before Clear")
+
+	require.NoError(t, index.Clear(ctx, pod))
+
+	hits, err = index.Lookup(ctx, []BlockHash{key}, sets.Set[string]{})
+	require.NoError(t, err)
+	assert.Empty(t, hits[key], "pod must not be visible after Clear")
+}
+
+// testClearIsolatesOtherPods verifies that Clear for one pod does not affect
+// entries belonging to a different pod.
+func testClearIsolatesOtherPods(t *testing.T, ctx context.Context, index Index) {
+	t.Helper()
+	podA := PodEntry{PodIdentifier: "pod-A", DeviceTier: "gpu"}
+	podB := PodEntry{PodIdentifier: "pod-B", DeviceTier: "gpu"}
+	key := BlockHash(0xC1EA0002)
+
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{key}, []PodEntry{podA, podB}))
+
+	require.NoError(t, index.Clear(ctx, podA))
+
+	hits, err := index.Lookup(ctx, []BlockHash{key}, sets.Set[string]{})
+	require.NoError(t, err)
+	assert.Len(t, hits[key], 1, "podB must survive clearing podA")
+	assert.Equal(t, podB, hits[key][0])
+}
+
+// testClearThenReAdd verifies that after Clear, a subsequent Add for the same
+// pod stamps the new generation so entries become visible in Lookup again.
+func testClearThenReAdd(t *testing.T, ctx context.Context, index Index) {
+	t.Helper()
+	pod := PodEntry{PodIdentifier: "pod-readd", DeviceTier: "gpu"}
+	key := BlockHash(0xC1EA0003)
+
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{key}, []PodEntry{pod}))
+	require.NoError(t, index.Clear(ctx, pod))
+
+	// Entry must be invisible immediately after Clear.
+	hits, err := index.Lookup(ctx, []BlockHash{key}, sets.Set[string]{})
+	require.NoError(t, err)
+	assert.Empty(t, hits[key], "pod must be invisible right after Clear")
+
+	// Re-adding the same pod stamps the current (post-Clear) generation.
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{key}, []PodEntry{pod}))
+
+	hits, err = index.Lookup(ctx, []BlockHash{key}, sets.Set[string]{})
+	require.NoError(t, err)
+	assert.Len(t, hits[key], 1, "re-added pod must be visible after Clear")
+}
+
+// testClearMultipleTimes verifies that repeated Clear calls are safe and that
+// the pod remains invisible between Clears, then visible again after a re-add.
+func testClearMultipleTimes(t *testing.T, ctx context.Context, index Index) {
+	t.Helper()
+	pod := PodEntry{PodIdentifier: "pod-multi-clear", DeviceTier: "gpu"}
+	keys := []BlockHash{0xC1EA0010, 0xC1EA0011, 0xC1EA0012}
+
+	require.NoError(t, index.Add(ctx, nil, keys, []PodEntry{pod}))
+
+	const clears = 5
+	for i := range clears {
+		require.NoError(t, index.Clear(ctx, pod), "Clear %d must not error", i)
+
+		// Pod must be invisible after every Clear.
+		for _, k := range keys {
+			hits, err := index.Lookup(ctx, []BlockHash{k}, sets.Set[string]{})
+			require.NoError(t, err)
+			assert.Empty(t, hits[k], "Clear %d: pod must be invisible for key %v", i, k)
+		}
+
+		// Re-add for next iteration.
+		if i < clears-1 {
+			require.NoError(t, index.Add(ctx, nil, keys, []PodEntry{pod}))
+		}
+	}
+}
+
+// testStressConcurrentClearAndLookup runs Clear and Lookup in parallel to
+// verify no panics, errors, or deadlocks under concurrent access.
+func testStressConcurrentClearAndLookup(t *testing.T, ctx context.Context, index Index) {
+	t.Helper()
+	const numClearers = 25
+	const numReaders = 25
+	const numIterations = 30
+
+	pod := PodEntry{PodIdentifier: "pod-stress-clear", DeviceTier: "gpu"}
+	keys := make([]BlockHash, 5)
+	for i := range keys {
+		keys[i] = BlockHash(uint64(0xC1EA1000) + uint64(i)) // #nosec G115 -- test data, i is small
+	}
+
+	// Pre-populate so Lookup has something to filter.
+	require.NoError(t, index.Add(ctx, nil, keys, []PodEntry{pod}))
+
+	var wg sync.WaitGroup
+	errChan := make(chan error, (numClearers+numReaders)*numIterations)
+
+	// Clearers — repeatedly clear then re-add.
+	for range numClearers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range numIterations {
+				if err := index.Clear(ctx, pod); err != nil {
+					errChan <- err
+					return
+				}
+				if err := index.Add(ctx, nil, keys, []PodEntry{pod}); err != nil {
+					errChan <- err
+					return
+				}
+			}
+		}()
+	}
+
+	// Readers — Lookup must never error regardless of concurrent Clears.
+	for range numReaders {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range numIterations {
+				if _, err := index.Lookup(ctx, keys, sets.Set[string]{}); err != nil {
+					errChan <- err
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errChan)
+	for err := range errChan {
+		require.NoError(t, err)
+	}
+
+	// Index must still be queryable after the storm.
+	_, err := index.Lookup(ctx, keys, sets.Set[string]{})
+	require.NoError(t, err)
 }

--- a/pkg/kvcache/kvblock/instrumented_index.go
+++ b/pkg/kvcache/kvblock/instrumented_index.go
@@ -68,6 +68,10 @@ func (m *instrumentedIndex) GetRequestKey(ctx context.Context, engineKey BlockHa
 	return m.next.GetRequestKey(ctx, engineKey)
 }
 
+func (m *instrumentedIndex) Clear(ctx context.Context, podEntry PodEntry) error {
+	return m.next.Clear(ctx, podEntry)
+}
+
 func recordHitMetrics(keyToPods map[BlockHash][]PodEntry) {
 	podCount := make(map[string]int)
 	for _, pods := range keyToPods {

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -199,60 +199,30 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 		gens = r.gen.snapshot()
 	}
 
-	// pipeline for single RTT.
-	// Fast path: if no Clear has ever happened, we only need field names (HKeys),
-	// which avoids fetching and decoding the per-entry generation values.
+	// Fast path skips the per-entry generation value (HKeys vs HGetAll).
 	pipe := r.RedisClient.Pipeline()
-
-	if !needGenFilter {
-		results := make([]*redis.StringSliceCmd, len(requestKeys))
-		for i, key := range requestKeys {
-			results[i] = pipe.HKeys(ctx, key.String())
-		}
-		if _, err := pipe.Exec(ctx); err != nil {
-			return nil, fmt.Errorf("redis pipeline execution failed: %w", err)
-		}
-		for idx, cmd := range results {
-			key := requestKeys[idx]
-			pods, cmdErr := cmd.Result()
-			if cmdErr != nil {
-				if !errors.Is(cmdErr, redis.Nil) {
-					logger.Error(cmdErr, "failed to get pods for key", "key", key)
-				}
-				return podsPerKey, nil
-			}
-			var filteredPods []PodEntry
-			for _, p := range pods {
-				entry, ok := parseRedisPodField(p)
-				if !ok {
-					continue
-				}
-				if filterPods && !podIdentifierSet.Has(entry.PodIdentifier) {
-					continue
-				}
-				filteredPods = append(filteredPods, entry)
-			}
-			if len(filteredPods) == 0 {
-				logger.Info("no pods found for key, cutting search", "key", key)
-				return podsPerKey, nil
-			}
-			podsPerKey[key] = filteredPods
-		}
-		return podsPerKey, nil
-	}
-
-	// Slow path: at least one Clear has happened, so we need values to filter by gen.
-	results := make([]*redis.MapStringStringCmd, len(requestKeys))
+	hkeys := make([]*redis.StringSliceCmd, len(requestKeys))
+	hgetall := make([]*redis.MapStringStringCmd, len(requestKeys))
 	for i, key := range requestKeys {
-		results[i] = pipe.HGetAll(ctx, key.String())
+		if needGenFilter {
+			hgetall[i] = pipe.HGetAll(ctx, key.String())
+		} else {
+			hkeys[i] = pipe.HKeys(ctx, key.String())
+		}
 	}
 	if _, err := pipe.Exec(ctx); err != nil {
 		return nil, fmt.Errorf("redis pipeline execution failed: %w", err)
 	}
 
-	for idx, cmd := range results {
-		key := requestKeys[idx]
-		pods, cmdErr := cmd.Result()
+	for i, key := range requestKeys {
+		var fields map[string]string
+		var fieldNames []string
+		var cmdErr error
+		if needGenFilter {
+			fields, cmdErr = hgetall[i].Result()
+		} else {
+			fieldNames, cmdErr = hkeys[i].Result()
+		}
 		if cmdErr != nil {
 			if !errors.Is(cmdErr, redis.Nil) {
 				logger.Error(cmdErr, "failed to get pods for key", "key", key)
@@ -260,19 +230,30 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 			return podsPerKey, nil
 		}
 		var filteredPods []PodEntry
-		for p, genStr := range pods {
+		emit := func(p, genStr string) {
 			entry, ok := parseRedisPodField(p)
 			if !ok {
-				continue
+				return
 			}
 			if filterPods && !podIdentifierSet.Has(entry.PodIdentifier) {
-				continue
+				return
 			}
-			stampedGen, _ := strconv.ParseUint(genStr, 10, 64)
-			if stampedGen < gens.current(entry.PodIdentifier) {
-				continue
+			if needGenFilter {
+				stamped, _ := strconv.ParseUint(genStr, 10, 64)
+				if stamped < gens.current(entry.PodIdentifier) {
+					return
+				}
 			}
 			filteredPods = append(filteredPods, entry)
+		}
+		if needGenFilter {
+			for p, g := range fields {
+				emit(p, g)
+			}
+		} else {
+			for _, p := range fieldNames {
+				emit(p, "")
+			}
 		}
 		if len(filteredPods) == 0 {
 			logger.Info("no pods found for key, cutting search", "key", key)
@@ -445,14 +426,10 @@ func redisEngineKey(engineKey BlockHash) string {
 	return "engine:" + engineKey.String()
 }
 
-// Clear invalidates all entries for the given podEntry by bumping the pod's
-// generation counter. Stale entries are filtered at Lookup time and reclaimed
-// lazily (or eagerly via Sweep). O(1) — a single atomic increment locally.
+// Clear bumps the pod's generation counter locally. O(1).
 //
-// NOTE: in a multi-replica deployment, this would also issue a Redis INCR on
-// `podgen:<id>` and propagate via pubsub so other replicas converge. That cross-
-// process plumbing is intentionally elided in this prototype to keep the
-// benchmark apples-to-apples with the in-process backends.
+// NOTE: prototype is single-process — multi-replica deployments would replicate
+// the bump via Redis INCR + pubsub so peers converge.
 func (r *RedisIndex) Clear(ctx context.Context, podEntry PodEntry) error {
 	r.gen.bump(podEntry.PodIdentifier)
 	log.FromContext(ctx).WithName("kvblock.RedisIndex.Clear").
@@ -466,13 +443,8 @@ func (r *RedisIndex) Clear(ctx context.Context, podEntry PodEntry) error {
 	return nil
 }
 
-// Sweep walks all request-key hashes in Redis and removes entries whose stamped
-// generation is below their pod's current generation. Pages via SCAN to avoid
-// blocking the server; HDels stale fields in pipelined batches.
-//
-// Engine-key entries (prefixed "engine:") are skipped. Empty hashes are deleted.
-//
-// Returns the count of removed entries.
+// Sweep removes hash fields whose stamped generation is below their pod's
+// current. Pages via SCAN; pipelines HDel; prunes empty hashes. Skips engine: keys.
 func (r *RedisIndex) Sweep(ctx context.Context) (int, error) {
 	logger := log.FromContext(ctx).WithName("kvblock.RedisIndex.Sweep")
 	if r.gen.anyClears() == 0 {
@@ -490,8 +462,8 @@ func (r *RedisIndex) Sweep(ctx context.Context) (int, error) {
 			return removed, fmt.Errorf("scan failed: %w", err)
 		}
 		pages++
-		// Filter: skip engine-key entries, keep request-key hashes.
-		// Allocate a fresh slice to avoid aliasing the SCAN result buffer.
+		// Skip engine-key entries; only request-key hashes carry generation values.
+		// Fresh slice avoids aliasing the SCAN result buffer.
 		filtered := make([]string, 0, len(keys))
 		for _, k := range keys {
 			if strings.HasPrefix(k, "engine:") {
@@ -511,15 +483,13 @@ func (r *RedisIndex) Sweep(ctx context.Context) (int, error) {
 			break
 		}
 	}
-	logger.V(1).Info("sweep complete", "pages", pages, "removed", removed)
 	if removed > 0 {
-		logger.Info("sweep removed stale entries", "removed", removed)
+		logger.Info("sweep removed stale entries", "removed", removed, "pages", pages)
 	}
 	return removed, nil
 }
 
-// sweepBatch processes one SCAN page: HGETALL each, identify stale fields, HDEL
-// them in a single pipeline, prune now-empty hashes.
+// sweepBatch handles one SCAN page: HGETALL pipeline, then HDEL stale fields, then prune empty hashes.
 func (r *RedisIndex) sweepBatch(ctx context.Context, keys []string, gens *genCache) (int, error) {
 	pipe := r.RedisClient.Pipeline()
 	getCmds := make([]*redis.MapStringStringCmd, len(keys))
@@ -531,7 +501,7 @@ func (r *RedisIndex) sweepBatch(ctx context.Context, keys []string, gens *genCac
 	}
 
 	delPipe := r.RedisClient.Pipeline()
-	pruneKeys := make([]string, 0)
+	var pruneKeys []string
 	removed := 0
 	for i, cmd := range getCmds {
 		fields, err := cmd.Result()
@@ -552,14 +522,8 @@ func (r *RedisIndex) sweepBatch(ctx context.Context, keys []string, gens *genCac
 		if len(stale) == 0 {
 			continue
 		}
-		// HDel takes (key, fields...). Pass as variadic.
-		args := make([]any, 0, len(stale))
-		for _, s := range stale {
-			args = append(args, s)
-		}
 		delPipe.HDel(ctx, keys[i], stale...)
 		removed += len(stale)
-		// If we're removing all current fields, mark for prune.
 		if len(stale) == len(fields) {
 			pruneKeys = append(pruneKeys, keys[i])
 		}
@@ -578,8 +542,8 @@ func (r *RedisIndex) sweepBatch(ctx context.Context, keys []string, gens *genCac
 	return removed, nil
 }
 
-// StartSweeper runs Sweep on every Clear, debounced by `debounce`. Returns when
-// ctx is cancelled.
+// StartSweeper runs Sweep on every Clear, debounced and coalesced.
+// Returns when ctx is cancelled. NewIndex starts this by default.
 func (r *RedisIndex) StartSweeper(ctx context.Context, debounce time.Duration) {
 	logger := log.FromContext(ctx).WithName("kvblock.RedisIndex.StartSweeper")
 	if debounce <= 0 {

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -143,6 +144,8 @@ type RedisIndex struct {
 	// Cached locally; bumped on Clear (and would be replicated cross-process via
 	// a Redis INCR + pubsub in a multi-replica deployment — out of scope here).
 	gen podGenTracker
+	// sweepCh is signalled by Clear when a background sweeper is running.
+	sweepCh chan struct{}
 }
 
 var _ Index = &RedisIndex{}
@@ -189,67 +192,114 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 	logger := log.FromContext(ctx).WithName("kvblock.RedisIndex.Lookup")
 	podsPerKey := make(map[BlockHash][]PodEntry)
 
-	// pipeline for single RTT
-	pipe := r.RedisClient.Pipeline()
-	results := make([]*redis.MapStringStringCmd, len(requestKeys))
+	filterPods := len(podIdentifierSet) > 0
+	needGenFilter := r.gen.anyClears() != 0
+	var gens *genCache
+	if needGenFilter {
+		gens = r.gen.snapshot()
+	}
 
-	// queue an HGetAll command for each key in the pipeline.
-	// We need both fields (pod entries) and values (admission generation) so we can
-	// filter out entries that were invalidated by a Clear (lazy filtering).
+	// pipeline for single RTT.
+	// Fast path: if no Clear has ever happened, we only need field names (HKeys),
+	// which avoids fetching and decoding the per-entry generation values.
+	pipe := r.RedisClient.Pipeline()
+
+	if !needGenFilter {
+		results := make([]*redis.StringSliceCmd, len(requestKeys))
+		for i, key := range requestKeys {
+			results[i] = pipe.HKeys(ctx, key.String())
+		}
+		if _, err := pipe.Exec(ctx); err != nil {
+			return nil, fmt.Errorf("redis pipeline execution failed: %w", err)
+		}
+		for idx, cmd := range results {
+			key := requestKeys[idx]
+			pods, cmdErr := cmd.Result()
+			if cmdErr != nil {
+				if !errors.Is(cmdErr, redis.Nil) {
+					logger.Error(cmdErr, "failed to get pods for key", "key", key)
+				}
+				return podsPerKey, nil
+			}
+			var filteredPods []PodEntry
+			for _, p := range pods {
+				entry, ok := parseRedisPodField(p)
+				if !ok {
+					continue
+				}
+				if filterPods && !podIdentifierSet.Has(entry.PodIdentifier) {
+					continue
+				}
+				filteredPods = append(filteredPods, entry)
+			}
+			if len(filteredPods) == 0 {
+				logger.Info("no pods found for key, cutting search", "key", key)
+				return podsPerKey, nil
+			}
+			podsPerKey[key] = filteredPods
+		}
+		return podsPerKey, nil
+	}
+
+	// Slow path: at least one Clear has happened, so we need values to filter by gen.
+	results := make([]*redis.MapStringStringCmd, len(requestKeys))
 	for i, key := range requestKeys {
 		results[i] = pipe.HGetAll(ctx, key.String())
 	}
-
-	_, execErr := pipe.Exec(ctx)
-	if execErr != nil {
-		return nil, fmt.Errorf("redis pipeline execution failed: %w", execErr)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return nil, fmt.Errorf("redis pipeline execution failed: %w", err)
 	}
-
-	filterPods := len(podIdentifierSet) > 0 // predicate for filtering
 
 	for idx, cmd := range results {
 		key := requestKeys[idx]
-
 		pods, cmdErr := cmd.Result()
 		if cmdErr != nil {
 			if !errors.Is(cmdErr, redis.Nil) {
 				logger.Error(cmdErr, "failed to get pods for key", "key", key)
 			}
-
-			return podsPerKey, nil // early stop since prefix-chain breaks here
+			return podsPerKey, nil
 		}
-
 		var filteredPods []PodEntry
 		for p, genStr := range pods {
-			ip := strings.SplitN(p, "@", 2)[0]
-			if filterPods && !podIdentifierSet.Has(ip) {
+			entry, ok := parseRedisPodField(p)
+			if !ok {
 				continue
 			}
-			// Lazy generation filter: skip entries whose admission generation
-			// is below the pod's current generation (i.e. Clear was issued after Add).
+			if filterPods && !podIdentifierSet.Has(entry.PodIdentifier) {
+				continue
+			}
 			stampedGen, _ := strconv.ParseUint(genStr, 10, 64)
-			if stampedGen < r.gen.current(ip) {
+			if stampedGen < gens.current(entry.PodIdentifier) {
 				continue
 			}
-			tier := strings.SplitN(p, "@", 2)[1]
-			speculative := false
-			// Strip annotation suffix e.g. "gpu[speculative]" -> "gpu"
-			if idx := strings.Index(tier, "["); idx != -1 {
-				speculative = strings.Contains(tier[idx:], "speculative")
-				tier = tier[:idx]
-			}
-			filteredPods = append(filteredPods, PodEntry{PodIdentifier: ip, DeviceTier: tier, Speculative: speculative})
+			filteredPods = append(filteredPods, entry)
 		}
-
 		if len(filteredPods) == 0 {
 			logger.Info("no pods found for key, cutting search", "key", key)
-			return podsPerKey, nil // early stop since prefix-chain breaks here
+			return podsPerKey, nil
 		}
-
 		podsPerKey[key] = filteredPods
 	}
 
 	return podsPerKey, nil
+}
+
+// parseRedisPodField parses a Redis hash field of the form
+// "<podIdentifier>@<tier>[speculative]" back into a PodEntry. Returns false
+// if the field doesn't contain the expected separator.
+func parseRedisPodField(p string) (PodEntry, bool) {
+	at := strings.IndexByte(p, '@')
+	if at < 0 {
+		return PodEntry{}, false
+	}
+	id := p[:at]
+	tier := p[at+1:]
+	speculative := false
+	if i := strings.IndexByte(tier, '['); i != -1 {
+		speculative = strings.Contains(tier[i:], "speculative")
+		tier = tier[:i]
+	}
+	return PodEntry{PodIdentifier: id, DeviceTier: tier, Speculative: speculative}, true
 }
 
 // Add adds a set of keys and their associated pod entries to the index backend.
@@ -397,8 +447,7 @@ func redisEngineKey(engineKey BlockHash) string {
 
 // Clear invalidates all entries for the given podEntry by bumping the pod's
 // generation counter. Stale entries are filtered at Lookup time and reclaimed
-// lazily by Redis-side memory pressure (or a background sweep, out of scope).
-// O(1) — a single atomic increment in the local tracker.
+// lazily (or eagerly via Sweep). O(1) — a single atomic increment locally.
 //
 // NOTE: in a multi-replica deployment, this would also issue a Redis INCR on
 // `podgen:<id>` and propagate via pubsub so other replicas converge. That cross-
@@ -408,5 +457,157 @@ func (r *RedisIndex) Clear(ctx context.Context, podEntry PodEntry) error {
 	r.gen.bump(podEntry.PodIdentifier)
 	log.FromContext(ctx).WithName("kvblock.RedisIndex.Clear").
 		Info("bumped pod generation", "pod", podEntry.PodIdentifier)
+	if r.sweepCh != nil {
+		select {
+		case r.sweepCh <- struct{}{}:
+		default:
+		}
+	}
 	return nil
+}
+
+// Sweep walks all request-key hashes in Redis and removes entries whose stamped
+// generation is below their pod's current generation. Pages via SCAN to avoid
+// blocking the server; HDels stale fields in pipelined batches.
+//
+// Engine-key entries (prefixed "engine:") are skipped. Empty hashes are deleted.
+//
+// Returns the count of removed entries.
+func (r *RedisIndex) Sweep(ctx context.Context) (int, error) {
+	logger := log.FromContext(ctx).WithName("kvblock.RedisIndex.Sweep")
+	if r.gen.anyClears() == 0 {
+		return 0, nil
+	}
+	gens := r.gen.snapshot()
+
+	const scanBatch int64 = 1024
+	removed := 0
+	var cursor uint64
+	pages := 0
+	for {
+		keys, next, err := r.RedisClient.Scan(ctx, cursor, "*", scanBatch).Result()
+		if err != nil {
+			return removed, fmt.Errorf("scan failed: %w", err)
+		}
+		pages++
+		// Filter: skip engine-key entries, keep request-key hashes.
+		// Allocate a fresh slice to avoid aliasing the SCAN result buffer.
+		filtered := make([]string, 0, len(keys))
+		for _, k := range keys {
+			if strings.HasPrefix(k, "engine:") {
+				continue
+			}
+			filtered = append(filtered, k)
+		}
+		if len(filtered) > 0 {
+			n, err := r.sweepBatch(ctx, filtered, gens)
+			if err != nil {
+				return removed, err
+			}
+			removed += n
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	logger.V(1).Info("sweep complete", "pages", pages, "removed", removed)
+	if removed > 0 {
+		logger.Info("sweep removed stale entries", "removed", removed)
+	}
+	return removed, nil
+}
+
+// sweepBatch processes one SCAN page: HGETALL each, identify stale fields, HDEL
+// them in a single pipeline, prune now-empty hashes.
+func (r *RedisIndex) sweepBatch(ctx context.Context, keys []string, gens *genCache) (int, error) {
+	pipe := r.RedisClient.Pipeline()
+	getCmds := make([]*redis.MapStringStringCmd, len(keys))
+	for i, k := range keys {
+		getCmds[i] = pipe.HGetAll(ctx, k)
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		return 0, fmt.Errorf("hgetall pipeline failed: %w", err)
+	}
+
+	delPipe := r.RedisClient.Pipeline()
+	pruneKeys := make([]string, 0)
+	removed := 0
+	for i, cmd := range getCmds {
+		fields, err := cmd.Result()
+		if err != nil || len(fields) == 0 {
+			continue
+		}
+		var stale []string
+		for fieldName, valStr := range fields {
+			entry, ok := parseRedisPodField(fieldName)
+			if !ok {
+				continue
+			}
+			stamped, _ := strconv.ParseUint(valStr, 10, 64)
+			if stamped < gens.current(entry.PodIdentifier) {
+				stale = append(stale, fieldName)
+			}
+		}
+		if len(stale) == 0 {
+			continue
+		}
+		// HDel takes (key, fields...). Pass as variadic.
+		args := make([]any, 0, len(stale))
+		for _, s := range stale {
+			args = append(args, s)
+		}
+		delPipe.HDel(ctx, keys[i], stale...)
+		removed += len(stale)
+		// If we're removing all current fields, mark for prune.
+		if len(stale) == len(fields) {
+			pruneKeys = append(pruneKeys, keys[i])
+		}
+	}
+	if removed > 0 {
+		if _, err := delPipe.Exec(ctx); err != nil {
+			return removed, fmt.Errorf("hdel pipeline failed: %w", err)
+		}
+	}
+	// Prune empty hashes.
+	for _, k := range pruneKeys {
+		if err := pruneRequestKeyScript.Run(ctx, r.RedisClient, []string{k}).Err(); err != nil {
+			return removed, fmt.Errorf("prune empty hash: %w", err)
+		}
+	}
+	return removed, nil
+}
+
+// StartSweeper runs Sweep on every Clear, debounced by `debounce`. Returns when
+// ctx is cancelled.
+func (r *RedisIndex) StartSweeper(ctx context.Context, debounce time.Duration) {
+	logger := log.FromContext(ctx).WithName("kvblock.RedisIndex.StartSweeper")
+	if debounce <= 0 {
+		debounce = 100 * time.Millisecond
+	}
+	if r.sweepCh == nil {
+		r.sweepCh = make(chan struct{}, 1)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-r.sweepCh:
+			timer := time.NewTimer(debounce)
+			drained := false
+			for !drained {
+				select {
+				case <-r.sweepCh:
+				case <-timer.C:
+					drained = true
+				case <-ctx.Done():
+					timer.Stop()
+					return
+				}
+			}
+			if _, err := r.Sweep(ctx); err != nil {
+				logger.Error(err, "sweep failed")
+			}
+		}
+	}
 }

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -116,6 +116,7 @@ func NewRedisIndex(config *RedisIndexConfig) (Index, error) {
 		RedisClient: redisClient,
 		BackendType: config.BackendType,
 		EnableRDMA:  config.EnableRDMA,
+		sweepCh:     make(chan struct{}, 1),
 	}, nil
 }
 
@@ -158,6 +159,22 @@ var pruneRequestKeyScript = redis.NewScript(`
 		return 1
 	end
 	return 0
+`)
+
+// compareAndDelScript atomically removes hash fields only when their current value
+// still matches the stale generation observed during the HGETALL phase of Sweep.
+// This prevents a concurrent Add from losing a freshly re-admitted entry because
+// the Sweep's HDel pipeline fired after Add's HSET.
+// KEYS[1] = request key hash; ARGV = interleaved (field, expected_gen) pairs.
+var compareAndDelScript = redis.NewScript(`
+	local removed = 0
+	for i = 1, #ARGV, 2 do
+		if redis.call('HGET', KEYS[1], ARGV[i]) == ARGV[i+1] then
+			redis.call('HDEL', KEYS[1], ARGV[i])
+			removed = removed + 1
+		end
+	end
+	return removed
 `)
 
 // pruneEngineKeyScript atomically deletes an engine key mapping only if all
@@ -246,6 +263,14 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 			}
 			filteredPods = append(filteredPods, entry)
 		}
+		// Early-stop: a physically absent/empty hash means the prefix chain breaks here.
+		// This matches InMemory semantics (pods.cache.Len() == 0 checked before filtering).
+		// We do NOT cut on filteredPods == 0 because entries may simply be filtered by
+		// pod-set or are stale-but-not-yet-swept; that doesn't break the chain.
+		if (needGenFilter && len(fields) == 0) || (!needGenFilter && len(fieldNames) == 0) {
+			logger.Info("no pods found for key, cutting search", "key", key)
+			return podsPerKey, nil
+		}
 		if needGenFilter {
 			for p, g := range fields {
 				emit(p, g)
@@ -255,11 +280,9 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 				emit(p, "")
 			}
 		}
-		if len(filteredPods) == 0 {
-			logger.Info("no pods found for key, cutting search", "key", key)
-			return podsPerKey, nil
+		if len(filteredPods) > 0 {
+			podsPerKey[key] = filteredPods
 		}
-		podsPerKey[key] = filteredPods
 	}
 
 	return podsPerKey, nil
@@ -489,7 +512,8 @@ func (r *RedisIndex) Sweep(ctx context.Context) (int, error) {
 	return removed, nil
 }
 
-// sweepBatch handles one SCAN page: HGETALL pipeline, then HDEL stale fields, then prune empty hashes.
+// sweepBatch handles one SCAN page: HGETALL pipeline, then atomically compare-and-delete
+// stale fields, then prune empty hashes.
 func (r *RedisIndex) sweepBatch(ctx context.Context, keys []string, gens *genCache) (int, error) {
 	pipe := r.RedisClient.Pipeline()
 	getCmds := make([]*redis.MapStringStringCmd, len(keys))
@@ -500,7 +524,6 @@ func (r *RedisIndex) sweepBatch(ctx context.Context, keys []string, gens *genCac
 		return 0, fmt.Errorf("hgetall pipeline failed: %w", err)
 	}
 
-	delPipe := r.RedisClient.Pipeline()
 	var pruneKeys []string
 	removed := 0
 	for i, cmd := range getCmds {
@@ -522,15 +545,23 @@ func (r *RedisIndex) sweepBatch(ctx context.Context, keys []string, gens *genCac
 		if len(stale) == 0 {
 			continue
 		}
-		delPipe.HDel(ctx, keys[i], stale...)
-		removed += len(stale)
-		if len(stale) == len(fields) {
-			pruneKeys = append(pruneKeys, keys[i])
+		// Build interleaved (field, expected_gen) args and atomically remove each
+		// field only if its stored value still matches the stale generation we saw in
+		// Phase 1. A concurrent Add that ran between Phase 1 and now will have written
+		// a higher generation, so compareAndDelScript leaves that field untouched.
+		args := make([]any, 0, len(stale)*2)
+		for _, f := range stale {
+			args = append(args, f, fields[f])
 		}
-	}
-	if removed > 0 {
-		if _, err := delPipe.Exec(ctx); err != nil {
-			return removed, fmt.Errorf("hdel pipeline failed: %w", err)
+		n, err := compareAndDelScript.Run(ctx, r.RedisClient, []string{keys[i]}, args...).Int()
+		if err != nil {
+			return removed, fmt.Errorf("compare-and-delete script failed: %w", err)
+		}
+		removed += n
+		if len(stale) == len(fields) {
+			// All observed fields were stale candidates; hash may now be empty.
+			// pruneRequestKeyScript will verify HLEN before deleting.
+			pruneKeys = append(pruneKeys, keys[i])
 		}
 	}
 	// Prune empty hashes.
@@ -549,9 +580,7 @@ func (r *RedisIndex) StartSweeper(ctx context.Context, debounce time.Duration) {
 	if debounce <= 0 {
 		debounce = 100 * time.Millisecond
 	}
-	if r.sweepCh == nil {
-		r.sweepCh = make(chan struct{}, 1)
-	}
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -139,6 +139,10 @@ type RedisIndex struct {
 	BackendType string
 	// EnableRDMA indicates if RDMA transport is enabled (for Valkey)
 	EnableRDMA bool
+	// gen tracks per-pod generation counters for O(1) Clear via lazy invalidation.
+	// Cached locally; bumped on Clear (and would be replicated cross-process via
+	// a Redis INCR + pubsub in a multi-replica deployment — out of scope here).
+	gen podGenTracker
 }
 
 var _ Index = &RedisIndex{}
@@ -187,12 +191,13 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 
 	// pipeline for single RTT
 	pipe := r.RedisClient.Pipeline()
-	results := make([]*redis.StringSliceCmd, len(requestKeys))
+	results := make([]*redis.MapStringStringCmd, len(requestKeys))
 
-	// queue an HKeys command for each key in the pipeline
+	// queue an HGetAll command for each key in the pipeline.
+	// We need both fields (pod entries) and values (admission generation) so we can
+	// filter out entries that were invalidated by a Clear (lazy filtering).
 	for i, key := range requestKeys {
-		// HKeys gets all field names
-		results[i] = pipe.HKeys(ctx, key.String())
+		results[i] = pipe.HGetAll(ctx, key.String())
 	}
 
 	_, execErr := pipe.Exec(ctx)
@@ -205,7 +210,6 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 	for idx, cmd := range results {
 		key := requestKeys[idx]
 
-		// cmd.Result() returns the slice of strings (pod IDs) which is the first layer in the mapping
 		pods, cmdErr := cmd.Result()
 		if cmdErr != nil {
 			if !errors.Is(cmdErr, redis.Nil) {
@@ -216,18 +220,25 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 		}
 
 		var filteredPods []PodEntry
-		for _, p := range pods {
+		for p, genStr := range pods {
 			ip := strings.SplitN(p, "@", 2)[0]
-			if !filterPods || podIdentifierSet.Has(ip) {
-				tier := strings.SplitN(p, "@", 2)[1]
-				speculative := false
-				// Strip annotation suffix e.g. "gpu[speculative]" -> "gpu"
-				if idx := strings.Index(tier, "["); idx != -1 {
-					speculative = strings.Contains(tier[idx:], "speculative")
-					tier = tier[:idx]
-				}
-				filteredPods = append(filteredPods, PodEntry{PodIdentifier: ip, DeviceTier: tier, Speculative: speculative})
+			if filterPods && !podIdentifierSet.Has(ip) {
+				continue
 			}
+			// Lazy generation filter: skip entries whose admission generation
+			// is below the pod's current generation (i.e. Clear was issued after Add).
+			stampedGen, _ := strconv.ParseUint(genStr, 10, 64)
+			if stampedGen < r.gen.current(ip) {
+				continue
+			}
+			tier := strings.SplitN(p, "@", 2)[1]
+			speculative := false
+			// Strip annotation suffix e.g. "gpu[speculative]" -> "gpu"
+			if idx := strings.Index(tier, "["); idx != -1 {
+				speculative = strings.Contains(tier[idx:], "speculative")
+				tier = tier[:idx]
+			}
+			filteredPods = append(filteredPods, PodEntry{PodIdentifier: ip, DeviceTier: tier, Speculative: speculative})
 		}
 
 		if len(filteredPods) == 0 {
@@ -267,10 +278,13 @@ func (r *RedisIndex) Add(ctx context.Context, engineKeys, requestKeys []BlockHas
 	}
 
 	// Store requestKey -> PodEntry mappings for all request keys.
+	// The HSet value is the entry's admission generation (per-pod), so Lookup can
+	// filter entries that pre-date the latest Clear without an extra round-trip.
 	for _, requestKey := range requestKeys {
 		redisKey := requestKey.String()
 		for _, entry := range entries {
-			pipe.HSet(ctx, redisKey, entry.String(), "")
+			genStr := strconv.FormatUint(r.gen.current(entry.PodIdentifier), 10)
+			pipe.HSet(ctx, redisKey, entry.String(), genStr)
 		}
 	}
 
@@ -379,4 +393,20 @@ func (r *RedisIndex) GetRequestKey(ctx context.Context, engineKey BlockHash) (Bl
 
 func redisEngineKey(engineKey BlockHash) string {
 	return "engine:" + engineKey.String()
+}
+
+// Clear invalidates all entries for the given podEntry by bumping the pod's
+// generation counter. Stale entries are filtered at Lookup time and reclaimed
+// lazily by Redis-side memory pressure (or a background sweep, out of scope).
+// O(1) — a single atomic increment in the local tracker.
+//
+// NOTE: in a multi-replica deployment, this would also issue a Redis INCR on
+// `podgen:<id>` and propagate via pubsub so other replicas converge. That cross-
+// process plumbing is intentionally elided in this prototype to keep the
+// benchmark apples-to-apples with the in-process backends.
+func (r *RedisIndex) Clear(ctx context.Context, podEntry PodEntry) error {
+	r.gen.bump(podEntry.PodIdentifier)
+	log.FromContext(ctx).WithName("kvblock.RedisIndex.Clear").
+		Info("bumped pod generation", "pod", podEntry.PodIdentifier)
+	return nil
 }

--- a/pkg/kvcache/kvblock/traced_index.go
+++ b/pkg/kvcache/kvblock/traced_index.go
@@ -86,3 +86,7 @@ func (t *tracedIndex) Lookup(
 func (t *tracedIndex) GetRequestKey(ctx context.Context, engineKey BlockHash) (BlockHash, error) {
 	return t.next.GetRequestKey(ctx, engineKey)
 }
+
+func (t *tracedIndex) Clear(ctx context.Context, podEntry PodEntry) error {
+	return t.next.Clear(ctx, podEntry)
+}

--- a/tests/profiling/kv_cache_index/index_benchmark_test.go
+++ b/tests/profiling/kv_cache_index/index_benchmark_test.go
@@ -170,6 +170,55 @@ func benchmarkLookup(b *testing.B, indexType string) {
 	}
 }
 
+// benchmarkClear measures the performance of clearing all entries for a single pod.
+// The index is created and populated once; each timed iteration calls Clear and then
+// repopulates (untimed) so every Clear call sees the same pre-populated state.
+// This avoids the per-iteration client-creation overhead that would otherwise cause
+// b.N to grow unboundedly when Clear is fast relative to setup.
+func benchmarkClear(b *testing.B, indexType string) {
+	b.Helper()
+	ctx := context.Background()
+	pod := kvblock.PodEntry{PodIdentifier: "pod1", DeviceTier: "gpu"}
+	keys := generateWorkloadKeys(benchNumKeys)
+
+	var redisAddr string
+	if indexType == "redis" {
+		mr, cleanup := setupMiniredis(b)
+		defer cleanup()
+		redisAddr = mr.Addr()
+	}
+
+	cfg := getIndexConfig(indexType, redisAddr)
+	index, err := kvblock.NewIndex(ctx, cfg)
+	if err != nil {
+		b.Fatalf("failed to create index: %v", err)
+	}
+	if ri, ok := index.(*kvblock.RedisIndex); ok {
+		b.Cleanup(func() { _ = ri.RedisClient.Close() })
+	}
+
+	// Initial population before the timed loop begins.
+	if err := index.Add(ctx, keys, keys, []kvblock.PodEntry{pod}); err != nil {
+		b.Fatalf("failed to populate index: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if err := index.Clear(ctx, pod); err != nil {
+			b.Fatalf("failed to clear index: %v", err)
+		}
+
+		// Repopulate outside the timed region so the next iteration sees the same state.
+		b.StopTimer()
+		if err := index.Add(ctx, keys, keys, []kvblock.PodEntry{pod}); err != nil {
+			b.Fatalf("failed to repopulate index: %v", err)
+		}
+		b.StartTimer()
+	}
+}
+
 // --- Benchmark Entry Points ---
 
 func BenchmarkInMemory_Add(b *testing.B) {
@@ -194,4 +243,16 @@ func BenchmarkCostAware_Add(b *testing.B) {
 
 func BenchmarkCostAware_Lookup(b *testing.B) {
 	benchmarkLookup(b, "cost")
+}
+
+func BenchmarkInMemory_Clear(b *testing.B) {
+	benchmarkClear(b, "memory")
+}
+
+func BenchmarkRedis_Clear(b *testing.B) {
+	benchmarkClear(b, "redis")
+}
+
+func BenchmarkCostAware_Clear(b *testing.B) {
+	benchmarkClear(b, "cost")
 }


### PR DESCRIPTION
Issue: #396 

This PR adds support to Invalidate KV cache via the `AllBlocksCleared` event.
- Updated event processing in vllm_adapter.go and pool.go to parse and handle the `AllBlocksCleared` event.
- Added Clear method to the `Index` interface and implemented it for all the index types (CostAwareMemoryIndex, InMemoryIndex, RedisIndex).
- Introduced podToRequestKeys reverse index: podIdentifier -> []engineKeyToRequestKeyMapping for all the indexes.
  - Clear: Looks up only the request keys for the target pod via podToRequestKeys
  - Iterates those keys, and removes matching entries, prunes empty hashes + their engine-key mappings
  - Updates the reverse index: drops the pod entirely if DeviceTier is empty, or trims to still-alive request keys if a specific tier was targeted

Testing
- `pkg/kvcache/kvblock/index_test.go`

Examples:
- Updated the `kv_events/offline` and `valkey_example` to simulate the Clear event.