### PR TITLE
build: Upgrade golangci-lint to v2.9.0

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Install golangci-lint without running it
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1.6
+          version: v2.9.0
           args: "--help"
 
       - name: Run precommit checks with CGo environment

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -233,16 +233,16 @@ func realignExtraFeatures(engineFeatures []*kvblock.BlockExtraFeatures, canonica
 		}
 	} else {
 		// many:1 -> merge constituent engine features into each canonical block
-		for i := range engineBlockCount {
+		for i, ef := range engineFeatures {
 			canonicalIdx := i * canonicalBlockCount / engineBlockCount
-			if engineFeatures[i] == nil {
+			if ef == nil {
 				continue
 			}
 			if canonical[canonicalIdx] == nil {
 				canonical[canonicalIdx] = &kvblock.BlockExtraFeatures{}
 			}
 			canonical[canonicalIdx].MMHashes = append(
-				canonical[canonicalIdx].MMHashes, engineFeatures[i].MMHashes...)
+				canonical[canonicalIdx].MMHashes, ef.MMHashes...)
 		}
 	}
 

--- a/pkg/kvevents/subscriber_manager_test.go
+++ b/pkg/kvevents/subscriber_manager_test.go
@@ -18,6 +18,7 @@ package kvevents_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -199,8 +200,8 @@ func TestSubscriberManager_ConcurrentOperations(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		go func(id int) {
 			defer func() { done <- true }()
-			podID := "default/pod-" + string(rune('0'+id))
-			endpoint := "tcp://10.0.0." + string(rune('0'+id)) + ":5557"
+			podID := fmt.Sprintf("default/pod-%d", id)
+			endpoint := fmt.Sprintf("tcp://10.0.0.%d:5557", id)
 			if err := sm.EnsureSubscriber(ctx, podID, endpoint, "kv@", true); err != nil {
 				t.Errorf("failed to add subscriber %s: %v", podID, err)
 			}

--- a/pkg/kvevents/zmq_subscriber_test.go
+++ b/pkg/kvevents/zmq_subscriber_test.go
@@ -169,7 +169,7 @@ func TestZMQSubscriber_ShortSequenceFrameSkipped(t *testing.T) {
 	pool.Start(ctx)
 
 	// Pick an available ephemeral port to avoid conflicts with parallel tests or CI.
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	endpoint := fmt.Sprintf("tcp://%s", ln.Addr().String())
 	ln.Close()

--- a/pkg/tokenization/uds_tokenizer_test.go
+++ b/pkg/tokenization/uds_tokenizer_test.go
@@ -91,7 +91,7 @@ func (m *mockTokenizationServer) Tokenize(
 	offsets := make([]uint32, 0, len(input)*2)
 
 	for i, r := range input {
-		tokens = append(tokens, uint32(r))
+		tokens = append(tokens, uint32(r)) // #nosec G115 -- rune from valid string is always non-negative
 		// #nosec G115 -- i is bounded by string length, safe conversion
 		offsets = append(offsets, uint32(i), uint32(i+1))
 	}
@@ -119,7 +119,7 @@ func (m *mockTokenizationServer) RenderChatCompletion(
 	var tokens []uint32
 	for _, msg := range req.Messages {
 		for _, r := range msg.GetContent() {
-			tokens = append(tokens, uint32(r))
+			tokens = append(tokens, uint32(r)) // #nosec G115 -- rune from valid string is always non-negative
 		}
 	}
 
@@ -149,7 +149,7 @@ func (m *mockTokenizationServer) RenderCompletion(
 
 	tokens := make([]uint32, 0, len(req.Prompt))
 	for _, r := range req.Prompt {
-		tokens = append(tokens, uint32(r))
+		tokens = append(tokens, uint32(r)) // #nosec G115 -- rune from valid string is always non-negative
 	}
 
 	return &tokenizerpb.RenderCompletionResponse{


### PR DESCRIPTION
Fixed https://github.com/llm-d/llm-d-kv-cache/issues/459

The `string(rune('0'+id))` pattern triggers gosec G115 (integer overflow conversion `int -> rune`) which is a real finding — it silently produces wrong characters for `id >= 10`. Using `fmt.Sprintf` fixes the bug and satisfies the linter.

This is also trying to make the ci lint using same version as gateway-api-inference-extension https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/Makefile#L589