### PR TITLE
feat: support SGLang KV events in VLLMAdapter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -324,6 +324,7 @@ Configures the ZMQ event processing pool for handling KV cache events. The pool 
 | `zmqEndpoint` | `string`                                                              | ZMQ address to connect to | `""`    |
 | `topicFilter` | `string`                                                              | ZMQ subscription filter | `"kv@"` |
 | `concurrency` | `integer`                                                             | Number of parallel workers | `4`     |
+| `engineType` | `string`                                                              | Inference engine adapter type (`"vllm"` or `"sglang"`) | `"vllm"` |
 | `discoverPods` | `boolean`                                                             | Enable Kubernetes pod reconciler for automatic per-pod subscriber management | `true`  |
 | `podDiscoveryConfig` | [PodDiscoveryConfig](#pod-discovery-configuration-podDiscoveryConfig) | Configuration for pod reconciler (only used when `discoverPods` is true) | `null`  |
 
@@ -336,6 +337,7 @@ For connecting to a single ZMQ endpoint:
   "zmqEndpoint": "tcp://indexer:5557",
   "topicFilter": "kv@",
   "concurrency": 8,
+  "engineType": "vllm",
   "discoverPods": false
 }
 ```

--- a/examples/helper/events.go
+++ b/examples/helper/events.go
@@ -121,7 +121,12 @@ func SetupEventsPool(ctx context.Context, kvBlockIndex kvblock.Index) (*kvevents
 		return nil, fmt.Errorf("failed to create token processor: %w", err)
 	}
 
-	pool := kvevents.NewPool(cfg, kvBlockIndex, tokenProcessor, engineadapter.NewVLLMAdapter())
+	adapter, err := engineadapter.NewAdapter(cfg.EngineType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create engine adapter: %w", err)
+	}
+
+	pool := kvevents.NewPool(cfg, kvBlockIndex, tokenProcessor, adapter)
 
 	return pool, nil
 }

--- a/examples/kv_cache_aware_scorer/kvcache_aware_scorer.go
+++ b/examples/kv_cache_aware_scorer/kvcache_aware_scorer.go
@@ -118,7 +118,12 @@ func New(ctx context.Context, config PrecisePrefixCachePluginConfig) (*PrecisePr
 	go kvCacheIndexer.Run(ctx)
 
 	// initialize the KV-events pool
-	pool := kvevents.NewPool(config.KVEventsConfig, kvCacheIndexer.KVBlockIndex(), tokenProcessor, engineadapter.NewVLLMAdapter())
+	adapter, err := engineadapter.NewAdapter(config.KVEventsConfig.EngineType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create engine adapter: %w", err)
+	}
+
+	pool := kvevents.NewPool(config.KVEventsConfig, kvCacheIndexer.KVBlockIndex(), tokenProcessor, adapter)
 	pool.Start(ctx)
 
 	subscribersManager := kvevents.NewSubscriberManager(pool)

--- a/examples/kv_events/online/main.go
+++ b/examples/kv_events/online/main.go
@@ -277,7 +277,13 @@ func setupEventsPool(ctx context.Context, kvBlockIndex kvblock.Index) *kvevents.
 		logger.Error(err, "Failed to create token processor")
 		return nil
 	}
-	pool := kvevents.NewPool(cfg, kvBlockIndex, tokenProcessor, engineadapter.NewVLLMAdapter())
+	adapter, err := engineadapter.NewAdapter(cfg.EngineType)
+	if err != nil {
+		logger.Error(err, "Failed to create engine adapter")
+		return nil
+	}
+
+	pool := kvevents.NewPool(cfg, kvBlockIndex, tokenProcessor, adapter)
 
 	return pool
 }

--- a/examples/kv_events/pod_reconciler/main.go
+++ b/examples/kv_events/pod_reconciler/main.go
@@ -87,7 +87,12 @@ func run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create token processor: %w", err)
 	}
-	pool := kvevents.NewPool(poolConfig, index, tokenProcessor, engineadapter.NewVLLMAdapter())
+	adapter, err := engineadapter.NewAdapter(poolConfig.EngineType)
+	if err != nil {
+		return fmt.Errorf("failed to create engine adapter: %w", err)
+	}
+
+	pool := kvevents.NewPool(poolConfig, index, tokenProcessor, adapter)
 	pool.Start(ctx)
 
 	// Create subscriber manager

--- a/pkg/kvevents/engineadapter/adapter.go
+++ b/pkg/kvevents/engineadapter/adapter.go
@@ -15,7 +15,33 @@ limitations under the License.
 */
 
 // Package engineadapter provides engine-specific implementations of the
-// kvevents.EngineAdapter interface. Each inference engine (e.g. vLLM) has
-// its own adapter that knows how to parse raw transport messages into
+// kvevents.EngineAdapter interface. Each inference engine (e.g. vLLM, SGLang)
+// has its own adapter that knows how to parse raw transport messages into
 // domain events.
 package engineadapter
+
+import (
+	"fmt"
+
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents"
+)
+
+const (
+	// EngineTypeVLLM selects the vLLM adapter.
+	EngineTypeVLLM = "vllm"
+	// EngineTypeSGLang selects the SGLang adapter.
+	EngineTypeSGLang = "sglang"
+)
+
+// NewAdapter creates an EngineAdapter for the given engine type.
+// Supported types: "vllm" (default), "sglang".
+func NewAdapter(engineType string) (kvevents.EngineAdapter, error) {
+	switch engineType {
+	case EngineTypeVLLM, "":
+		return NewVLLMAdapter(), nil
+	case EngineTypeSGLang:
+		return NewSGLangAdapter(), nil
+	default:
+		return nil, fmt.Errorf("unsupported engine type: %q (supported: %q, %q)", engineType, EngineTypeVLLM, EngineTypeSGLang)
+	}
+}

--- a/pkg/kvevents/engineadapter/common.go
+++ b/pkg/kvevents/engineadapter/common.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engineadapter
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/vmihailenco/msgpack/v5"
+
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents"
+)
+
+const (
+	// Common event type tags shared across engine adapters.
+	eventTagBlockStored      = "BlockStored"
+	eventTagBlockRemoved     = "BlockRemoved"
+	eventTagAllBlocksCleared = "AllBlocksCleared"
+)
+
+// parseTopic extracts pod ID and model name from the topic format "kv@<pod-id>@<model-name>".
+// This format is shared by vLLM and SGLang.
+//
+//nolint:gocritic // unnamedResult: named returns conflict with nonamedreturns linter
+func parseTopic(topic string) (string, string) {
+	topicParts := strings.Split(topic, "@")
+	if len(topicParts) == 3 {
+		return topicParts[1], topicParts[2]
+	}
+	return topic, ""
+}
+
+// getHashAsUint64 converts engine hash formats (uint64, int64, or []byte) to uint64.
+// This handles both legacy uint64 hashes and new []byte hashes by taking
+// the last 8 bytes and interpreting them as a big-endian integer.
+func getHashAsUint64(raw any) (uint64, error) {
+	switch val := raw.(type) {
+	case uint64:
+		return val, nil
+	case int64:
+		// msgpack can decode small integers as int64
+		//nolint:gosec // int64 to uint64 conversion is safe here
+		return uint64(val), nil
+	case []byte:
+		if len(val) == 0 {
+			return 0, fmt.Errorf("hash byte slice is empty")
+		}
+		if len(val) >= 8 {
+			return binary.BigEndian.Uint64(val[len(val)-8:]), nil
+		}
+		padded := make([]byte, 8)
+		copy(padded[8-len(val):], val)
+		return binary.BigEndian.Uint64(padded), nil
+	default:
+		return 0, fmt.Errorf("unsupported hash type: %T", val)
+	}
+}
+
+// decodeEvent decodes a single msgpack event, extracts the tag, and dispatches to the appropriate converter.
+func decodeEvent(
+	rawEventBytes []byte,
+	converters map[string]func([]byte) (kvevents.GenericEvent, error),
+	engineName string,
+) (kvevents.GenericEvent, error) {
+	var taggedUnion []any
+	if err := msgpack.Unmarshal(rawEventBytes, &taggedUnion); err != nil {
+		return nil, fmt.Errorf("failed to decode tagged union: %w", err)
+	}
+
+	if len(taggedUnion) < 1 {
+		return nil, fmt.Errorf("malformed tagged union: no tag")
+	}
+
+	tag, ok := taggedUnion[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("event tag is not a string: %T", taggedUnion[0])
+	}
+
+	converter, exists := converters[tag]
+	if !exists {
+		return nil, fmt.Errorf("unknown %s event tag: %s", engineName, tag)
+	}
+
+	return converter(rawEventBytes)
+}
+
+// convertBlockHashes converts raw hash values to uint64 slice.
+func convertBlockHashes(rawHashes []any) ([]uint64, error) {
+	blockHashes := make([]uint64, 0, len(rawHashes))
+	for _, rawHash := range rawHashes {
+		hash, err := getHashAsUint64(rawHash)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse block hash: %w", err)
+		}
+		blockHashes = append(blockHashes, hash)
+	}
+	return blockHashes, nil
+}
+
+// convertExtraKeys converts raw extra_keys to typed slice.
+func convertExtraKeys(rawExtraKeys []any) ([][]any, error) {
+	if rawExtraKeys == nil {
+		return nil, nil
+	}
+	extraKeys := make([][]any, 0, len(rawExtraKeys))
+	for i, rawKey := range rawExtraKeys {
+		if rawKey == nil {
+			extraKeys = append(extraKeys, nil)
+		} else if keySlice, ok := rawKey.([]any); ok {
+			extraKeys = append(extraKeys, keySlice)
+		} else {
+			return nil, fmt.Errorf("extra_keys[%d] has invalid type %T, expected []any or nil", i, rawKey)
+		}
+	}
+	return extraKeys, nil
+}

--- a/pkg/kvevents/engineadapter/common_test.go
+++ b/pkg/kvevents/engineadapter/common_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engineadapter //nolint:testpackage // Tests access unexported functions
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseTopic_Valid tests topic parsing with valid format.
+func TestParseTopic_Valid(t *testing.T) {
+	podID, modelName := parseTopic("kv@pod-123@llama-2-7b")
+	assert.Equal(t, "pod-123", podID)
+	assert.Equal(t, "llama-2-7b", modelName)
+}
+
+// TestParseTopic_NoModel tests topic parsing with only two segments.
+func TestParseTopic_NoModel(t *testing.T) {
+	podID, modelName := parseTopic("pod-123@llama-2-7b")
+	assert.Equal(t, "pod-123@llama-2-7b", podID)
+	assert.Equal(t, "", modelName)
+}
+
+// TestParseTopic_Plain tests topic parsing with no @ separator.
+func TestParseTopic_Plain(t *testing.T) {
+	podID, modelName := parseTopic("fallback")
+	assert.Equal(t, "fallback", podID)
+	assert.Equal(t, "", modelName)
+}
+
+// TestGetHashAsUint64 tests hash format conversions.
+func TestGetHashAsUint64(t *testing.T) {
+	t.Run("uint64", func(t *testing.T) {
+		result, err := getHashAsUint64(uint64(42))
+		require.NoError(t, err)
+		assert.Equal(t, uint64(42), result)
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		result, err := getHashAsUint64(int64(42))
+		require.NoError(t, err)
+		assert.Equal(t, uint64(42), result)
+	})
+
+	t.Run("bytes_8", func(t *testing.T) {
+		b := make([]byte, 8)
+		binary.BigEndian.PutUint64(b, 12345)
+		result, err := getHashAsUint64(b)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(12345), result)
+	})
+
+	t.Run("bytes_empty", func(t *testing.T) {
+		_, err := getHashAsUint64([]byte{})
+		assert.Error(t, err)
+	})
+
+	t.Run("unsupported_type", func(t *testing.T) {
+		_, err := getHashAsUint64("not a hash")
+		assert.Error(t, err)
+	})
+}

--- a/pkg/kvevents/engineadapter/sglang_adapter.go
+++ b/pkg/kvevents/engineadapter/sglang_adapter.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engineadapter
+
+import (
+	"fmt"
+
+	"github.com/vmihailenco/msgpack/v5"
+
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents"
+)
+
+const (
+	// Expected field counts for SGLang msgpack array structs.
+	// SGLang uses the same positional wire format as vLLM but may omit trailing optional fields
+	// via omit_defaults=True in msgspec.
+	// See: sglang/srt/disaggregation/kv_events.py (BlockStored, BlockRemoved classes).
+	sglangBlockStoredFieldCount  = 9 // tag + block_hashes + parent + tokens + block_size + lora_id + medium + lora_name + extra_keys
+	sglangBlockRemovedFieldCount = 3 // tag + block_hashes + medium
+
+	// Minimum required fields (excluding trailing optional ones).
+	sglangBlockStoredMinFields  = 5 // tag + block_hashes + parent + tokens + block_size
+	sglangBlockRemovedMinFields = 2 // tag + block_hashes
+)
+
+// SGLangAdapter implements the kvevents.EngineAdapter interface for SGLang engines.
+// SGLang uses the same msgpack wire format as vLLM but may omit trailing optional fields.
+type SGLangAdapter struct {
+	eventConverters map[string]func([]byte) (kvevents.GenericEvent, error)
+}
+
+// NewSGLangAdapter creates a new SGLang adapter.
+func NewSGLangAdapter() *SGLangAdapter {
+	adapter := &SGLangAdapter{}
+
+	adapter.eventConverters = map[string]func([]byte) (kvevents.GenericEvent, error){
+		eventTagBlockStored:      adapter.convertBlockStoredEvent,
+		eventTagBlockRemoved:     adapter.convertBlockRemovedEvent,
+		eventTagAllBlocksCleared: adapter.convertAllBlocksClearedEvent,
+	}
+
+	return adapter
+}
+
+// ShardingKey extracts the pod-id segment from a SGLang raw message topic.
+// Expected topic format: "kv@<pod-id>@<model-name>" (same as vLLM).
+func (s *SGLangAdapter) ShardingKey(msg *kvevents.RawMessage) string {
+	podID, _ := parseTopic(msg.Topic)
+	return podID
+}
+
+// ParseMessage parses a raw transport message into domain data.
+// It extracts pod identity and model name from the topic,
+// and decodes the msgpack payload into an EventBatch.
+//
+//nolint:gocritic // unnamedResult: named returns conflict with nonamedreturns linter
+func (s *SGLangAdapter) ParseMessage(msg *kvevents.RawMessage) (string, string, kvevents.EventBatch, error) {
+	podID, modelName := parseTopic(msg.Topic)
+
+	var batch msgpackSGLangEventBatch
+	if err := msgpack.Unmarshal(msg.Payload, &batch); err != nil {
+		return "", "", kvevents.EventBatch{}, fmt.Errorf("failed to decode SGLang event batch: %w", err)
+	}
+
+	genericEvents := make([]kvevents.GenericEvent, len(batch.Events))
+	for i, rawEventBytes := range batch.Events {
+		genericEvent, err := decodeEvent(rawEventBytes, s.eventConverters, "SGLang")
+		if err != nil {
+			return "", "", kvevents.EventBatch{}, fmt.Errorf("failed to decode SGLang event: %w", err)
+		}
+		genericEvents[i] = genericEvent
+	}
+
+	eventBatch := kvevents.EventBatch{
+		Timestamp: batch.TS,
+		Events:    genericEvents,
+	}
+
+	return podID, modelName, eventBatch, nil
+}
+
+// SGLang msgpack event structures.
+// These match the vLLM wire format (SGLang uses the same positional encoding).
+type msgpackSGLangEventBatch struct {
+	_                struct{} `msgpack:",array"`
+	TS               float64
+	Events           []msgpack.RawMessage
+	DataParallelRank *int `msgpack:",omitempty"`
+}
+
+type msgpackSGLangBlockStoredEvent struct {
+	_               struct{} `msgpack:",array"`
+	Tag             string
+	BlockHashes     []any
+	ParentBlockHash any
+	TokenIds        []uint32
+	BlockSize       int
+	LoraID          *int    `msgpack:",omitempty"`
+	Medium          *string `msgpack:",omitempty"`
+	LoraName        *string `msgpack:",omitempty"`
+	ExtraKeys       []any   `msgpack:",omitempty"`
+}
+
+type msgpackSGLangBlockRemovedEvent struct {
+	_           struct{} `msgpack:",array"`
+	Tag         string
+	BlockHashes []any
+	Medium      *string `msgpack:",omitempty"`
+}
+
+// padFields pads a msgpack array to the expected field count with nil values.
+// Returns the original bytes if already at the expected length, avoiding unnecessary re-marshal overhead.
+func padFields(rawEventBytes []byte, fields []any, expectedCount int) ([]byte, error) {
+	if len(fields) >= expectedCount {
+		return rawEventBytes, nil
+	}
+	for len(fields) < expectedCount {
+		fields = append(fields, nil)
+	}
+	paddedBytes, err := msgpack.Marshal(fields)
+	if err != nil {
+		return nil, fmt.Errorf("failed to re-marshal padded event: %w", err)
+	}
+	return paddedBytes, nil
+}
+
+// convertBlockStoredEvent decodes and converts a BlockStored event to a generic event.
+// Handles SGLang's shorter arrays by padding missing trailing optional fields with nil.
+func (s *SGLangAdapter) convertBlockStoredEvent(rawEventBytes []byte) (kvevents.GenericEvent, error) {
+	var fields []any
+	if err := msgpack.Unmarshal(rawEventBytes, &fields); err != nil {
+		return nil, fmt.Errorf("failed to decode BlockStored event: %w", err)
+	}
+
+	if len(fields) < sglangBlockStoredMinFields {
+		return nil, fmt.Errorf("BlockStored event has too few fields: %d (minimum %d)", len(fields), sglangBlockStoredMinFields)
+	}
+
+	eventBytes, err := padFields(rawEventBytes, fields, sglangBlockStoredFieldCount)
+	if err != nil {
+		return nil, err
+	}
+
+	var event msgpackSGLangBlockStoredEvent
+	if err := msgpack.Unmarshal(eventBytes, &event); err != nil {
+		return nil, fmt.Errorf("failed to decode BlockStored event: %w", err)
+	}
+
+	deviceTier := ""
+	if event.Medium != nil {
+		deviceTier = *event.Medium
+	}
+
+	blockHashes, err := convertBlockHashes(event.BlockHashes)
+	if err != nil {
+		return nil, err
+	}
+
+	var parentHash uint64
+	if event.ParentBlockHash != nil {
+		hash, err := getHashAsUint64(event.ParentBlockHash)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse parent hash: %w", err)
+		}
+		parentHash = hash
+	}
+
+	extraKeys, err := convertExtraKeys(event.ExtraKeys)
+	if err != nil {
+		return nil, err
+	}
+
+	return &kvevents.BlockStoredEvent{
+		BlockHashes: blockHashes,
+		Tokens:      event.TokenIds,
+		ParentHash:  parentHash,
+		DeviceTier:  deviceTier,
+		LoraID:      event.LoraID,
+		LoraName:    event.LoraName,
+		ExtraKeys:   extraKeys,
+	}, nil
+}
+
+// convertBlockRemovedEvent decodes and converts a BlockRemoved event to a generic event.
+// Handles SGLang's shorter arrays by padding missing trailing optional fields with nil.
+func (s *SGLangAdapter) convertBlockRemovedEvent(rawEventBytes []byte) (kvevents.GenericEvent, error) {
+	var fields []any
+	if err := msgpack.Unmarshal(rawEventBytes, &fields); err != nil {
+		return nil, fmt.Errorf("failed to decode BlockRemoved event: %w", err)
+	}
+
+	if len(fields) < sglangBlockRemovedMinFields {
+		return nil, fmt.Errorf("BlockRemoved event has too few fields: %d (minimum %d)", len(fields), sglangBlockRemovedMinFields)
+	}
+
+	eventBytes, err := padFields(rawEventBytes, fields, sglangBlockRemovedFieldCount)
+	if err != nil {
+		return nil, err
+	}
+
+	var event msgpackSGLangBlockRemovedEvent
+	if err := msgpack.Unmarshal(eventBytes, &event); err != nil {
+		return nil, fmt.Errorf("failed to decode BlockRemoved event: %w", err)
+	}
+
+	deviceTier := ""
+	if event.Medium != nil {
+		deviceTier = *event.Medium
+	}
+
+	blockHashes, err := convertBlockHashes(event.BlockHashes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &kvevents.BlockRemovedEvent{
+		BlockHashes: blockHashes,
+		DeviceTier:  deviceTier,
+	}, nil
+}
+
+// convertAllBlocksClearedEvent converts an AllBlocksCleared event.
+func (s *SGLangAdapter) convertAllBlocksClearedEvent(_ []byte) (kvevents.GenericEvent, error) {
+	return &kvevents.AllBlocksClearedEvent{}, nil
+}

--- a/pkg/kvevents/engineadapter/sglang_adapter_test.go
+++ b/pkg/kvevents/engineadapter/sglang_adapter_test.go
@@ -1,0 +1,281 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engineadapter //nolint:testpackage // Tests access unexported functions
+
+import (
+	"testing"
+
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+// TestSGLangShardingKey tests the sharding key extraction.
+func TestSGLangShardingKey(t *testing.T) {
+	adapter := NewSGLangAdapter()
+	assert.Equal(t, "pod-123", adapter.ShardingKey(&kvevents.RawMessage{Topic: "kv@pod-123@llama-2-7b"}))
+	assert.Equal(t, "fallback", adapter.ShardingKey(&kvevents.RawMessage{Topic: "fallback"}))
+}
+
+// TestSGLangParseMessage_Valid tests full message parsing through the SGLang adapter.
+func TestSGLangParseMessage_Valid(t *testing.T) {
+	adapter := NewSGLangAdapter()
+
+	// SGLang format: 7 fields (no lora_name, no extra_keys)
+	blockStoredEvent := []any{
+		"BlockStored",
+		[]any{uint64(100), uint64(101)},
+		uint64(99),
+		[]uint32{1, 2, 3},
+		16,
+		nil,
+		"GPU",
+	}
+
+	batch := []any{
+		1234567890.0,
+		[]any{blockStoredEvent},
+		nil,
+	}
+	payload, err := msgpack.Marshal(batch)
+	require.NoError(t, err)
+
+	msg := &kvevents.RawMessage{
+		Topic:    "kv@pod-1@llama-2-7b",
+		Sequence: 42,
+		Payload:  payload,
+	}
+
+	podID, modelName, eventBatch, err := adapter.ParseMessage(msg)
+	require.NoError(t, err)
+	assert.Equal(t, "pod-1", podID)
+	assert.Equal(t, "llama-2-7b", modelName)
+	assert.Len(t, eventBatch.Events, 1)
+
+	blockStored, ok := eventBatch.Events[0].(*kvevents.BlockStoredEvent)
+	require.True(t, ok)
+	assert.Equal(t, []uint64{100, 101}, blockStored.BlockHashes)
+	assert.Equal(t, uint64(99), blockStored.ParentHash)
+}
+
+// TestSGLangParseMessage_InvalidPayload tests error handling for invalid msgpack data.
+func TestSGLangParseMessage_InvalidPayload(t *testing.T) {
+	adapter := NewSGLangAdapter()
+
+	msg := &kvevents.RawMessage{
+		Topic:   "kv@pod-1@model",
+		Payload: []byte{0xFF, 0xFF, 0xFF},
+	}
+
+	_, _, _, err := adapter.ParseMessage(msg)
+	assert.Error(t, err)
+}
+
+// TestSGLangBlockStored_FullFields tests decoding with all 9 fields (same as vLLM).
+func TestSGLangBlockStored_FullFields(t *testing.T) {
+	adapter := NewSGLangAdapter()
+
+	event := []any{
+		"BlockStored",
+		[]any{uint64(100), uint64(101)},
+		uint64(99),
+		[]uint32{1, 2, 3},
+		16,
+		nil,
+		"gpu",
+		nil,
+		nil,
+	}
+
+	rawBytes, err := msgpack.Marshal(event)
+	require.NoError(t, err)
+
+	result, err := decodeEvent(rawBytes, adapter.eventConverters, "SGLang")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	blockStored, ok := result.(*kvevents.BlockStoredEvent)
+	require.True(t, ok)
+	assert.Equal(t, []uint64{100, 101}, blockStored.BlockHashes)
+	assert.Equal(t, uint64(99), blockStored.ParentHash)
+	assert.Equal(t, []uint32{1, 2, 3}, blockStored.Tokens)
+	assert.Equal(t, "gpu", blockStored.DeviceTier)
+	assert.Nil(t, blockStored.LoraID)
+	assert.Nil(t, blockStored.LoraName)
+	assert.Nil(t, blockStored.ExtraKeys)
+}
+
+// TestSGLangBlockStored_7Fields tests decoding with 7 fields (no lora_name, no extra_keys).
+func TestSGLangBlockStored_7Fields(t *testing.T) {
+	adapter := NewSGLangAdapter()
+
+	event := []any{
+		"BlockStored",
+		[]any{uint64(300), uint64(301)},
+		uint64(299),
+		[]uint32{7, 8, 9},
+		64,
+		nil,   // lora_id
+		"GPU", // medium
+	}
+
+	rawBytes, err := msgpack.Marshal(event)
+	require.NoError(t, err)
+
+	result, err := decodeEvent(rawBytes, adapter.eventConverters, "SGLang")
+	require.NoError(t, err, "SGLang 7-field format should decode successfully")
+	require.NotNil(t, result)
+
+	blockStored, ok := result.(*kvevents.BlockStoredEvent)
+	require.True(t, ok)
+	assert.Equal(t, []uint64{300, 301}, blockStored.BlockHashes)
+	assert.Equal(t, uint64(299), blockStored.ParentHash)
+	assert.Equal(t, []uint32{7, 8, 9}, blockStored.Tokens)
+	assert.Equal(t, "GPU", blockStored.DeviceTier)
+	assert.Nil(t, blockStored.LoraID)
+	assert.Nil(t, blockStored.LoraName, "SGLang does not send lora_name")
+	assert.Nil(t, blockStored.ExtraKeys, "SGLang does not send extra_keys")
+}
+
+// TestSGLangBlockStored_MinimalFields tests decoding with only the minimum required fields.
+func TestSGLangBlockStored_MinimalFields(t *testing.T) {
+	adapter := NewSGLangAdapter()
+
+	// Only 5 fields: tag + block_hashes + parent + tokens + block_size
+	event := []any{
+		"BlockStored",
+		[]any{uint64(400)},
+		uint64(399),
+		[]uint32{10, 11},
+		128,
+	}
+
+	rawBytes, err := msgpack.Marshal(event)
+	require.NoError(t, err)
+
+	result, err := decodeEvent(rawBytes, adapter.eventConverters, "SGLang")
+	require.NoError(t, err, "minimal 5-field BlockStored should decode successfully")
+	require.NotNil(t, result)
+
+	blockStored, ok := result.(*kvevents.BlockStoredEvent)
+	require.True(t, ok)
+	assert.Equal(t, []uint64{400}, blockStored.BlockHashes)
+	assert.Equal(t, uint64(399), blockStored.ParentHash)
+	assert.Equal(t, []uint32{10, 11}, blockStored.Tokens)
+	assert.Equal(t, "", blockStored.DeviceTier, "medium should default to empty")
+	assert.Nil(t, blockStored.LoraID)
+	assert.Nil(t, blockStored.LoraName)
+	assert.Nil(t, blockStored.ExtraKeys)
+}
+
+// TestSGLangBlockStored_TooFewFields tests that fewer than minimum fields returns an error.
+func TestSGLangBlockStored_TooFewFields(t *testing.T) {
+	adapter := NewSGLangAdapter()
+
+	event := []any{
+		"BlockStored",
+		[]any{uint64(500)},
+		uint64(499),
+		[]uint32{1},
+	}
+
+	rawBytes, err := msgpack.Marshal(event)
+	require.NoError(t, err)
+
+	_, err = decodeEvent(rawBytes, adapter.eventConverters, "SGLang")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too few fields")
+}
+
+// TestSGLangBlockRemoved_FullFields tests decoding with all 3 fields.
+func TestSGLangBlockRemoved_FullFields(t *testing.T) {
+	adapter := NewSGLangAdapter()
+
+	medium := "cpu"
+	event := []any{
+		"BlockRemoved",
+		[]any{uint64(200), uint64(201), uint64(202)},
+		&medium,
+	}
+
+	rawBytes, err := msgpack.Marshal(event)
+	require.NoError(t, err)
+
+	result, err := decodeEvent(rawBytes, adapter.eventConverters, "SGLang")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	blockRemoved, ok := result.(*kvevents.BlockRemovedEvent)
+	require.True(t, ok)
+	assert.Equal(t, []uint64{200, 201, 202}, blockRemoved.BlockHashes)
+	assert.Equal(t, "cpu", blockRemoved.DeviceTier)
+}
+
+// TestSGLangBlockRemoved_NoMedium tests decoding without the trailing medium field.
+func TestSGLangBlockRemoved_NoMedium(t *testing.T) {
+	adapter := NewSGLangAdapter()
+
+	event := []any{
+		"BlockRemoved",
+		[]any{uint64(500), uint64(501)},
+	}
+
+	rawBytes, err := msgpack.Marshal(event)
+	require.NoError(t, err)
+
+	result, err := decodeEvent(rawBytes, adapter.eventConverters, "SGLang")
+	require.NoError(t, err, "SGLang BlockRemoved without medium should decode successfully")
+	require.NotNil(t, result)
+
+	blockRemoved, ok := result.(*kvevents.BlockRemovedEvent)
+	require.True(t, ok)
+	assert.Equal(t, []uint64{500, 501}, blockRemoved.BlockHashes)
+	assert.Equal(t, "", blockRemoved.DeviceTier, "medium should default to empty")
+}
+
+// TestSGLangAllBlocksCleared tests decoding a valid AllBlocksCleared event.
+func TestSGLangAllBlocksCleared(t *testing.T) {
+	adapter := NewSGLangAdapter()
+
+	event := []any{"AllBlocksCleared"}
+
+	rawBytes, err := msgpack.Marshal(event)
+	require.NoError(t, err)
+
+	result, err := decodeEvent(rawBytes, adapter.eventConverters, "SGLang")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	_, ok := result.(*kvevents.AllBlocksClearedEvent)
+	require.True(t, ok, "expected AllBlocksClearedEvent")
+}
+
+// TestSGLangUnknownTag tests error handling for unknown event tags.
+func TestSGLangUnknownTag(t *testing.T) {
+	adapter := NewSGLangAdapter()
+
+	event := []any{"UnknownEventType", "some", "data"}
+
+	rawBytes, err := msgpack.Marshal(event)
+	require.NoError(t, err)
+
+	result, err := decodeEvent(rawBytes, adapter.eventConverters, "SGLang")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "unknown SGLang event tag")
+}

--- a/pkg/kvevents/engineadapter/vllm_adapter.go
+++ b/pkg/kvevents/engineadapter/vllm_adapter.go
@@ -17,20 +17,11 @@ limitations under the License.
 package engineadapter
 
 import (
-	"encoding/binary"
 	"fmt"
-	"strings"
 
 	"github.com/vmihailenco/msgpack/v5"
 
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents"
-)
-
-const (
-	// vLLM event type tags.
-	eventTagBlockStored      = "BlockStored"
-	eventTagBlockRemoved     = "BlockRemoved"
-	eventTagAllBlocksCleared = "AllBlocksCleared"
 )
 
 // VLLMAdapter implements the kvevents.EngineAdapter interface for vLLM engines.
@@ -55,7 +46,7 @@ func NewVLLMAdapter() *VLLMAdapter {
 // ShardingKey extracts the pod-id segment from a vLLM raw message topic.
 // Expected topic format: "kv@<pod-id>@<model-name>".
 func (v *VLLMAdapter) ShardingKey(msg *kvevents.RawMessage) string {
-	podID, _ := parseVLLMTopic(msg.Topic)
+	podID, _ := parseTopic(msg.Topic)
 	return podID
 }
 
@@ -65,19 +56,16 @@ func (v *VLLMAdapter) ShardingKey(msg *kvevents.RawMessage) string {
 //
 //nolint:gocritic // unnamedResult: named returns conflict with nonamedreturns linter
 func (v *VLLMAdapter) ParseMessage(msg *kvevents.RawMessage) (string, string, kvevents.EventBatch, error) {
-	// Extract pod ID and model name from topic
-	podID, modelName := parseVLLMTopic(msg.Topic)
+	podID, modelName := parseTopic(msg.Topic)
 
-	// Decode the payload into vLLM event batch using msgpack
 	var vllmBatch msgpackVLLMEventBatch
 	if err := msgpack.Unmarshal(msg.Payload, &vllmBatch); err != nil {
 		return "", "", kvevents.EventBatch{}, fmt.Errorf("failed to decode vLLM event batch: %w", err)
 	}
 
-	// Convert vLLM events to generic events
 	genericEvents := make([]kvevents.GenericEvent, len(vllmBatch.Events))
 	for i, rawEventBytes := range vllmBatch.Events {
-		genericEvent, err := v.decodeVLLMEvent(rawEventBytes)
+		genericEvent, err := decodeEvent(rawEventBytes, v.eventConverters, "vLLM")
 		if err != nil {
 			return "", "", kvevents.EventBatch{}, fmt.Errorf("failed to decode vLLM event: %w", err)
 		}
@@ -90,32 +78,6 @@ func (v *VLLMAdapter) ParseMessage(msg *kvevents.RawMessage) (string, string, kv
 	}
 
 	return podID, modelName, batch, nil
-}
-
-// getHashAsUint64 converts vLLM hash formats (uint64 or []byte) to uint64.
-// This handles both legacy uint64 hashes and new []byte hashes by taking
-// the last 8 bytes and interpreting them as a big-endian integer.
-func (v *VLLMAdapter) getHashAsUint64(raw any) (uint64, error) {
-	switch val := raw.(type) {
-	case uint64:
-		return val, nil
-	case int64:
-		// msgpack can decode small integers as int64
-		//nolint:gosec // int64 to uint64 conversion is safe here
-		return uint64(val), nil
-	case []byte:
-		if len(val) == 0 {
-			return 0, fmt.Errorf("hash byte slice is empty")
-		}
-		if len(val) >= 8 {
-			return binary.BigEndian.Uint64(val[len(val)-8:]), nil
-		}
-		padded := make([]byte, 8)
-		copy(padded[8-len(val):], val)
-		return binary.BigEndian.Uint64(padded), nil
-	default:
-		return 0, fmt.Errorf("unsupported hash type: %T", val)
-	}
 }
 
 // vLLM msgpack-specific event structures.
@@ -151,43 +113,6 @@ type msgpackVLLMAllBlocksClearedEvent struct {
 	_ struct{} `msgpack:",array"`
 }
 
-// parseVLLMTopic extracts pod ID and model name from vLLM topic format.
-// Expected format: "kv@<pod-id>@<model-name>".
-//
-//nolint:gocritic // unnamedResult: named returns conflict with nonamedreturns linter
-func parseVLLMTopic(topic string) (string, string) {
-	topicParts := strings.Split(topic, "@")
-	if len(topicParts) == 3 {
-		return topicParts[1], topicParts[2]
-	}
-	return topic, ""
-}
-
-// decodeVLLMEvent decodes a single vLLM event using msgpack and converts it to a generic event.
-func (v *VLLMAdapter) decodeVLLMEvent(rawEventBytes []byte) (kvevents.GenericEvent, error) {
-	// First decode to extract just the tag
-	var taggedUnion []any
-	if err := msgpack.Unmarshal(rawEventBytes, &taggedUnion); err != nil {
-		return nil, fmt.Errorf("failed to decode tagged union: %w", err)
-	}
-
-	if len(taggedUnion) < 1 {
-		return nil, fmt.Errorf("malformed tagged union: no tag")
-	}
-
-	tag, ok := taggedUnion[0].(string)
-	if !ok {
-		return nil, fmt.Errorf("event tag is not a string: %T", taggedUnion[0])
-	}
-
-	converter, exists := v.eventConverters[tag]
-	if !exists {
-		return nil, fmt.Errorf("unknown vLLM event tag: %s", tag)
-	}
-
-	return converter(rawEventBytes)
-}
-
 // convertBlockStoredEvent decodes and converts a msgpack vLLM BlockStored event to a generic event.
 func (v *VLLMAdapter) convertBlockStoredEvent(rawEventBytes []byte) (kvevents.GenericEvent, error) {
 	var vllmEvent msgpackVLLMBlockStoredEvent
@@ -200,37 +125,23 @@ func (v *VLLMAdapter) convertBlockStoredEvent(rawEventBytes []byte) (kvevents.Ge
 		deviceTier = *vllmEvent.Medium
 	}
 
-	blockHashes := make([]uint64, 0, len(vllmEvent.BlockHashes))
-	for _, rawHash := range vllmEvent.BlockHashes {
-		hash, err := v.getHashAsUint64(rawHash)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse block hash: %w", err)
-		}
-		blockHashes = append(blockHashes, hash)
+	blockHashes, err := convertBlockHashes(vllmEvent.BlockHashes)
+	if err != nil {
+		return nil, err
 	}
 
 	var parentHash uint64
 	if vllmEvent.ParentBlockHash != nil {
-		hash, err := v.getHashAsUint64(vllmEvent.ParentBlockHash)
+		hash, err := getHashAsUint64(vllmEvent.ParentBlockHash)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse parent hash: %w", err)
 		}
 		parentHash = hash
 	}
 
-	// Convert extra_keys if present
-	var extraKeys [][]any
-	if vllmEvent.ExtraKeys != nil {
-		extraKeys = make([][]any, 0, len(vllmEvent.ExtraKeys))
-		for i, rawKey := range vllmEvent.ExtraKeys {
-			if rawKey == nil {
-				extraKeys = append(extraKeys, nil)
-			} else if keySlice, ok := rawKey.([]any); ok {
-				extraKeys = append(extraKeys, keySlice)
-			} else {
-				return nil, fmt.Errorf("extra_keys[%d] has invalid type %T, expected []any or nil", i, rawKey)
-			}
-		}
+	extraKeys, err := convertExtraKeys(vllmEvent.ExtraKeys)
+	if err != nil {
+		return nil, err
 	}
 
 	return &kvevents.BlockStoredEvent{
@@ -256,13 +167,9 @@ func (v *VLLMAdapter) convertBlockRemovedEvent(rawEventBytes []byte) (kvevents.G
 		deviceTier = *vllmEvent.Medium
 	}
 
-	blockHashes := make([]uint64, 0, len(vllmEvent.BlockHashes))
-	for _, rawHash := range vllmEvent.BlockHashes {
-		hash, err := v.getHashAsUint64(rawHash)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse block hash: %w", err)
-		}
-		blockHashes = append(blockHashes, hash)
+	blockHashes, err := convertBlockHashes(vllmEvent.BlockHashes)
+	if err != nil {
+		return nil, err
 	}
 
 	return &kvevents.BlockRemovedEvent{

--- a/pkg/kvevents/engineadapter/vllm_adapter_test.go
+++ b/pkg/kvevents/engineadapter/vllm_adapter_test.go
@@ -14,10 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package engineadapter //nolint:testpackage // Tests access unexported functions parseVLLMTopic and decodeVLLMEvent
+package engineadapter //nolint:testpackage // Tests access unexported functions
 
 import (
-	"encoding/binary"
 	"testing"
 
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents"
@@ -26,32 +25,17 @@ import (
 	"github.com/vmihailenco/msgpack/v5"
 )
 
-// TestParseVLLMTopic tests topic parsing.
-func TestParseVLLMTopic_Valid(t *testing.T) {
-	podID, modelName := parseVLLMTopic("kv@pod-123@llama-2-7b")
-	assert.Equal(t, "pod-123", podID)
-	assert.Equal(t, "llama-2-7b", modelName)
-}
-
-func TestParseVLLMTopic_NoModel(t *testing.T) {
-	podID, modelName := parseVLLMTopic("pod-123@llama-2-7b")
-	// Only 2 parts, falls through to default
-	assert.Equal(t, "pod-123@llama-2-7b", podID)
-	assert.Equal(t, "", modelName)
-}
-
-// TestShardingKey tests the sharding key extraction from raw messages.
-func TestShardingKey(t *testing.T) {
+// TestVLLMShardingKey tests the sharding key extraction from raw messages.
+func TestVLLMShardingKey(t *testing.T) {
 	adapter := NewVLLMAdapter()
 	assert.Equal(t, "pod-123", adapter.ShardingKey(&kvevents.RawMessage{Topic: "kv@pod-123@llama-2-7b"}))
 	assert.Equal(t, "fallback", adapter.ShardingKey(&kvevents.RawMessage{Topic: "fallback"}))
 }
 
-// TestParseMessage_Valid tests full message parsing through the adapter.
-func TestParseMessage_Valid(t *testing.T) {
+// TestVLLMParseMessage_Valid tests full message parsing through the adapter.
+func TestVLLMParseMessage_Valid(t *testing.T) {
 	adapter := NewVLLMAdapter()
 
-	// Build a valid msgpack payload with a BlockStored event
 	blockStoredEvent := []any{
 		"BlockStored",
 		[]any{uint64(100), uint64(101)},
@@ -61,7 +45,7 @@ func TestParseMessage_Valid(t *testing.T) {
 		nil,
 		"gpu",
 		nil,
-		nil, // extra_keys
+		nil,
 	}
 	blockStoredPayload, err := msgpack.Marshal(blockStoredEvent)
 	require.NoError(t, err)
@@ -74,7 +58,7 @@ func TestParseMessage_Valid(t *testing.T) {
 	payload, err := msgpack.Marshal(batch)
 	require.NoError(t, err)
 
-	_ = blockStoredPayload // used indirectly via batch
+	_ = blockStoredPayload
 
 	msg := &kvevents.RawMessage{
 		Topic:    "kv@pod-1@llama-2-7b",
@@ -94,8 +78,8 @@ func TestParseMessage_Valid(t *testing.T) {
 	assert.Equal(t, uint64(99), blockStored.ParentHash)
 }
 
-// TestParseMessage_InvalidPayload tests error handling for invalid msgpack data.
-func TestParseMessage_InvalidPayload(t *testing.T) {
+// TestVLLMParseMessage_InvalidPayload tests error handling for invalid msgpack data.
+func TestVLLMParseMessage_InvalidPayload(t *testing.T) {
 	adapter := NewVLLMAdapter()
 
 	msg := &kvevents.RawMessage{
@@ -107,8 +91,8 @@ func TestParseMessage_InvalidPayload(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestDecodeVLLMEvent_BlockStored tests decoding a valid BlockStored event without LoRA.
-func TestDecodeVLLMEvent_BlockStored(t *testing.T) {
+// TestVLLMBlockStored tests decoding a valid BlockStored event without LoRA.
+func TestVLLMBlockStored(t *testing.T) {
 	adapter := NewVLLMAdapter()
 
 	vllmEvent := []any{
@@ -120,13 +104,13 @@ func TestDecodeVLLMEvent_BlockStored(t *testing.T) {
 		nil,
 		"gpu",
 		nil,
-		nil, // extra_keys not present
+		nil,
 	}
 
 	rawBytes, err := msgpack.Marshal(vllmEvent)
 	require.NoError(t, err)
 
-	event, err := adapter.decodeVLLMEvent(rawBytes)
+	event, err := decodeEvent(rawBytes, adapter.eventConverters, "vLLM")
 	require.NoError(t, err)
 	require.NotNil(t, event)
 
@@ -141,8 +125,8 @@ func TestDecodeVLLMEvent_BlockStored(t *testing.T) {
 	assert.Nil(t, blockStored.ExtraKeys)
 }
 
-// TestDecodeVLLMEvent_BlockStoredWithLora tests decoding a valid BlockStored event.
-func TestDecodeVLLMEvent_BlockStoredWithLora(t *testing.T) {
+// TestVLLMBlockStoredWithLora tests decoding a valid BlockStored event with LoRA.
+func TestVLLMBlockStoredWithLora(t *testing.T) {
 	adapter := NewVLLMAdapter()
 
 	vllmEvent := []any{
@@ -154,13 +138,13 @@ func TestDecodeVLLMEvent_BlockStoredWithLora(t *testing.T) {
 		42,
 		"gpu",
 		"test-lora",
-		[]any{[]any{"uuid-A", "salt"}, nil}, // extra_keys
+		[]any{[]any{"uuid-A", "salt"}, nil},
 	}
 
 	rawBytes, err := msgpack.Marshal(vllmEvent)
 	require.NoError(t, err)
 
-	event, err := adapter.decodeVLLMEvent(rawBytes)
+	event, err := decodeEvent(rawBytes, adapter.eventConverters, "vLLM")
 	require.NoError(t, err)
 	require.NotNil(t, event)
 
@@ -178,8 +162,8 @@ func TestDecodeVLLMEvent_BlockStoredWithLora(t *testing.T) {
 	assert.Equal(t, [][]any{{"uuid-A", "salt"}, nil}, blockStored.ExtraKeys)
 }
 
-// TestDecodeVLLMEvent_BlockStoredMissingLoraName tests decoding with missing field.
-func TestDecodeVLLMEvent_BlockStoredMissingLoraName(t *testing.T) {
+// TestVLLMBlockStoredMissingLoraName tests that vLLM adapter errors on missing fields.
+func TestVLLMBlockStoredMissingLoraName(t *testing.T) {
 	adapter := NewVLLMAdapter()
 
 	vllmEvent := []any{
@@ -195,13 +179,13 @@ func TestDecodeVLLMEvent_BlockStoredMissingLoraName(t *testing.T) {
 	rawBytes, err := msgpack.Marshal(vllmEvent)
 	require.NoError(t, err)
 
-	event, err := adapter.decodeVLLMEvent(rawBytes)
+	event, err := decodeEvent(rawBytes, adapter.eventConverters, "vLLM")
 	assert.Error(t, err)
 	assert.Nil(t, event)
 }
 
-// TestDecodeVLLMEvent_BlockStoredInvalidExtraKeys tests invalid extra_keys type.
-func TestDecodeVLLMEvent_BlockStoredInvalidExtraKeys(t *testing.T) {
+// TestVLLMBlockStoredInvalidExtraKeys tests invalid extra_keys type.
+func TestVLLMBlockStoredInvalidExtraKeys(t *testing.T) {
 	adapter := NewVLLMAdapter()
 
 	vllmEvent := []any{
@@ -213,19 +197,19 @@ func TestDecodeVLLMEvent_BlockStoredInvalidExtraKeys(t *testing.T) {
 		nil,
 		"gpu",
 		nil,
-		[]any{"invalid_string"}, // Should be []any or nil, not string
+		[]any{"invalid_string"},
 	}
 
 	rawBytes, err := msgpack.Marshal(vllmEvent)
 	require.NoError(t, err)
 
-	_, err = adapter.decodeVLLMEvent(rawBytes)
+	_, err = decodeEvent(rawBytes, adapter.eventConverters, "vLLM")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "extra_keys[0] has invalid type")
 }
 
-// TestDecodeVLLMEvent_BlockRemoved tests decoding a valid BlockRemoved event.
-func TestDecodeVLLMEvent_BlockRemoved(t *testing.T) {
+// TestVLLMBlockRemoved tests decoding a valid BlockRemoved event.
+func TestVLLMBlockRemoved(t *testing.T) {
 	adapter := NewVLLMAdapter()
 
 	medium := "cpu"
@@ -238,7 +222,7 @@ func TestDecodeVLLMEvent_BlockRemoved(t *testing.T) {
 	rawBytes, err := msgpack.Marshal(vllmEvent)
 	require.NoError(t, err)
 
-	event, err := adapter.decodeVLLMEvent(rawBytes)
+	event, err := decodeEvent(rawBytes, adapter.eventConverters, "vLLM")
 	require.NoError(t, err)
 	require.NotNil(t, event)
 
@@ -248,8 +232,8 @@ func TestDecodeVLLMEvent_BlockRemoved(t *testing.T) {
 	assert.Equal(t, "cpu", blockRemoved.DeviceTier)
 }
 
-// TestDecodeVLLMEvent_AllBlocksCleared tests decoding a valid AllBlocksCleared event.
-func TestDecodeVLLMEvent_AllBlocksCleared(t *testing.T) {
+// TestVLLMAllBlocksCleared tests decoding a valid AllBlocksCleared event.
+func TestVLLMAllBlocksCleared(t *testing.T) {
 	adapter := NewVLLMAdapter()
 
 	vllmEvent := []any{"AllBlocksCleared"}
@@ -257,7 +241,7 @@ func TestDecodeVLLMEvent_AllBlocksCleared(t *testing.T) {
 	rawBytes, err := msgpack.Marshal(vllmEvent)
 	require.NoError(t, err)
 
-	event, err := adapter.decodeVLLMEvent(rawBytes)
+	event, err := decodeEvent(rawBytes, adapter.eventConverters, "vLLM")
 	require.NoError(t, err)
 	require.NotNil(t, event)
 
@@ -265,8 +249,8 @@ func TestDecodeVLLMEvent_AllBlocksCleared(t *testing.T) {
 	require.True(t, ok, "expected AllBlocksClearedEvent")
 }
 
-// TestDecodeVLLMEvent_UnknownTag tests error handling for unknown event tags.
-func TestDecodeVLLMEvent_UnknownTag(t *testing.T) {
+// TestVLLMUnknownTag tests error handling for unknown event tags.
+func TestVLLMUnknownTag(t *testing.T) {
 	adapter := NewVLLMAdapter()
 
 	vllmEvent := []any{"UnknownEventType", "some", "data"}
@@ -274,36 +258,36 @@ func TestDecodeVLLMEvent_UnknownTag(t *testing.T) {
 	rawBytes, err := msgpack.Marshal(vllmEvent)
 	require.NoError(t, err)
 
-	event, err := adapter.decodeVLLMEvent(rawBytes)
+	event, err := decodeEvent(rawBytes, adapter.eventConverters, "vLLM")
 	assert.Error(t, err)
 	assert.Nil(t, event)
 	assert.Contains(t, err.Error(), "unknown vLLM event tag")
 }
 
-// TestDecodeVLLMEvent_MalformedPayload tests error handling for malformed msgpack data.
-func TestDecodeVLLMEvent_MalformedPayload(t *testing.T) {
+// TestVLLMMalformedPayload tests error handling for malformed msgpack data.
+func TestVLLMMalformedPayload(t *testing.T) {
 	adapter := NewVLLMAdapter()
 
 	rawBytes := []byte{0xFF, 0xFF, 0xFF}
 
-	event, err := adapter.decodeVLLMEvent(rawBytes)
+	event, err := decodeEvent(rawBytes, adapter.eventConverters, "vLLM")
 	assert.Error(t, err)
 	assert.Nil(t, event)
 }
 
-// TestDecodeVLLMEvent_EmptyPayload tests error handling for empty event bytes.
-func TestDecodeVLLMEvent_EmptyPayload(t *testing.T) {
+// TestVLLMEmptyPayload tests error handling for empty event bytes.
+func TestVLLMEmptyPayload(t *testing.T) {
 	adapter := NewVLLMAdapter()
 
 	rawBytes := []byte{}
 
-	event, err := adapter.decodeVLLMEvent(rawBytes)
+	event, err := decodeEvent(rawBytes, adapter.eventConverters, "vLLM")
 	assert.Error(t, err)
 	assert.Nil(t, event)
 }
 
-// TestDecodeVLLMEvent_MissingTag tests error handling for events without a tag.
-func TestDecodeVLLMEvent_MissingTag(t *testing.T) {
+// TestVLLMMissingTag tests error handling for events without a tag.
+func TestVLLMMissingTag(t *testing.T) {
 	adapter := NewVLLMAdapter()
 
 	vllmEvent := []any{}
@@ -311,15 +295,14 @@ func TestDecodeVLLMEvent_MissingTag(t *testing.T) {
 	rawBytes, err := msgpack.Marshal(vllmEvent)
 	require.NoError(t, err)
 
-	event, err := adapter.decodeVLLMEvent(rawBytes)
+	event, err := decodeEvent(rawBytes, adapter.eventConverters, "vLLM")
 	assert.Error(t, err)
 	assert.Nil(t, event)
 	assert.Contains(t, err.Error(), "malformed tagged union")
 }
 
-// TestDecodeEventBatch_NestedArrayEvents tests that the batch decoder correctly handles
-// events sent as nested msgpack arrays.
-func TestDecodeEventBatch_NestedArrayEvents(t *testing.T) {
+// TestVLLMEventBatch_NestedArrayEvents tests batch decoding with nested msgpack arrays.
+func TestVLLMEventBatch_NestedArrayEvents(t *testing.T) {
 	adapter := NewVLLMAdapter()
 
 	blockStoredEvent := []any{
@@ -331,7 +314,7 @@ func TestDecodeEventBatch_NestedArrayEvents(t *testing.T) {
 		nil,
 		"gpu",
 		nil,
-		nil, // extra_keys
+		nil,
 	}
 
 	batch := []any{
@@ -343,7 +326,6 @@ func TestDecodeEventBatch_NestedArrayEvents(t *testing.T) {
 	payload, err := msgpack.Marshal(batch)
 	require.NoError(t, err)
 
-	// Decode the batch via ParseMessage
 	msg := &kvevents.RawMessage{
 		Topic:    "kv@pod-1@model",
 		Sequence: 1,
@@ -360,39 +342,4 @@ func TestDecodeEventBatch_NestedArrayEvents(t *testing.T) {
 	assert.Equal(t, uint64(9), blockStored.ParentHash)
 	assert.Equal(t, []uint32{1, 2, 3}, blockStored.Tokens)
 	assert.Equal(t, "gpu", blockStored.DeviceTier)
-}
-
-// TestGetHashAsUint64 tests hash format conversions.
-func TestGetHashAsUint64(t *testing.T) {
-	adapter := NewVLLMAdapter()
-
-	t.Run("uint64", func(t *testing.T) {
-		result, err := adapter.getHashAsUint64(uint64(42))
-		require.NoError(t, err)
-		assert.Equal(t, uint64(42), result)
-	})
-
-	t.Run("int64", func(t *testing.T) {
-		result, err := adapter.getHashAsUint64(int64(42))
-		require.NoError(t, err)
-		assert.Equal(t, uint64(42), result)
-	})
-
-	t.Run("bytes_8", func(t *testing.T) {
-		b := make([]byte, 8)
-		binary.BigEndian.PutUint64(b, 12345)
-		result, err := adapter.getHashAsUint64(b)
-		require.NoError(t, err)
-		assert.Equal(t, uint64(12345), result)
-	})
-
-	t.Run("bytes_empty", func(t *testing.T) {
-		_, err := adapter.getHashAsUint64([]byte{})
-		assert.Error(t, err)
-	})
-
-	t.Run("unsupported_type", func(t *testing.T) {
-		_, err := adapter.getHashAsUint64("not a hash")
-		assert.Error(t, err)
-	})
 }

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -40,6 +40,9 @@ type Config struct {
 	TopicFilter string `json:"topicFilter"`
 	// Concurrency is the number of parallel workers to run.
 	Concurrency int `json:"concurrency"`
+	// EngineType selects the inference engine adapter ("vllm" or "sglang").
+	// Default: "vllm".
+	EngineType string `json:"engineType,omitempty"`
 	// DiscoverPods enables the Kubernetes pod reconciler for automatic
 	// per-pod subscriber management. When enabled, the reconciler watches
 	// Kubernetes pods and creates/removes ZMQ subscribers dynamically.


### PR DESCRIPTION
## Summary
Enable SGLang inference engines to participate in precise-prefix-cache-aware routing in llm-d. This allows the EPP to receive and index KV cache events from SGLang, enabling cache-hit-based scheduling alongside vLLM engines.

Changes:
- Pad shorter msgpack arrays with nil for trailing optional fields in `convertBlockStoredEvent` and `convertBlockRemovedEvent`, allowing `VLLMAdapter` to handle both vLLM and SGLang events transparently
- SGLang's `BlockStored` may omit `medium`, `lora_name`, and `extra_keys` fields (via `omit_defaults=True` in msgspec), and `BlockRemoved` may omit `medium`
- Add field count constants and minimum field guards to prevent silent failures
- No separate `SGLangAdapter` needed — wire format is identical except for trailing optional fields

## SGLang Deployment Configuration

### KV Events Config

SGLang's `--kv-events-config` should use the same topic format as vLLM for `VLLMAdapter` compatibility:

```bash
python3 -m sglang.launch_server \
  ...
  --page-size 16 \
  --kv-events-config '{
    "enable_kv_cache_events": true,
    "publisher": "zmq",
    "endpoint": "tcp://<indexer-service>:5557",
    "topic": "kv@${POD_IP}:8000@${MODEL_NAME}"
  }' \
  ...
```

- endpoint: ZMQ endpoint of the kv-cache-manager indexer service
- topic: Must follow kv@<pod-ip>:<port>@<model-name> format so VLLMAdapter can extract podID and modelName
- page_size: Should match EPP's tokenProcessorConfig.blockSize

## Test plan

- [x] Unit tests pass (17/17)
- [x] Real SGLang E2E on MI300 cluster
- [x] `BlockStored`/`BlockRemoved`/`AllBlocksCleared` events all handled
- [x] `precise-prefix-cache-scorer` produces correct cache hit scores