### PR TITLE
remove obsolete hashBlockSize

### DIFF
--- a/benchmarking/73-capacity/README.md
+++ b/benchmarking/73-capacity/README.md
@@ -110,7 +110,6 @@ plugins:
   - type: single-profile-handler
   - type: prefix-cache-scorer
     parameters:
-      hashBlockSize: 64
       maxPrefixBlocksToMatch: 256
       lruCapacityPerServer: 31250
   - type: kv-cache-scorer


### PR DESCRIPTION
The `hashBlockSize` configuration parameter was removed from `prefix-cache-scorer` and is silently ignored during `json.Unmarshal`