### PR TITLE
fix: Add trivy scan for uds tokenizer

### DIFF
--- a/.github/workflows/ci-dev-uds-tokenizer.yaml
+++ b/.github/workflows/ci-dev-uds-tokenizer.yaml
@@ -39,3 +39,8 @@ jobs:
           context: services/uds_tokenizer
           dockerfile: services/uds_tokenizer/Dockerfile
           platform: linux/amd64,linux/arm64
+
+      - name: Run Trivy scan
+        uses: ./.github/actions/trivy-scan
+        with:
+          image: ghcr.io/${{ github.repository_owner }}/llm-d-uds-tokenizer:${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
Adds a Trivy vulnerability scan step to the `ci-dev-uds-tokenizer` workflow, running after the image build-and-push step. This scans the published `llm-d-uds-tokenizer` image for HIGH and CRITICAL severity vulnerabilities, consistent with the existing Trivy scan steps in `ci-release.yaml` and `ci-release-uds-tokenizer.yaml`.