### PR TITLE
Add dockerfile for fsconnector dev on k8s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ TOOLS_DIR := $(shell pwd)/hack/tools
 CONTAINER_TOOL := $(shell { command -v docker >/dev/null 2>&1 && echo docker; } || { command -v podman >/dev/null 2>&1 && echo podman; } || echo "")
 BUILDER := $(shell command -v buildah >/dev/null 2>&1 && echo buildah || echo $(CONTAINER_TOOL))
 UDS_TOKENIZER_IMAGE ?= llm-d-uds-tokenizer:e2e-test
+FS_BACKEND_NAME ?= llmd-fs-backend
+FS_BACKEND_DEV_IMG ?= $(IMAGE_TAG_BASE)/$(FS_BACKEND_NAME):$(DEV_VERSION)
 
 # go source files
 SRC = $(shell find . -type f -name '*.go')
@@ -698,3 +700,18 @@ run-example: ## Run the example with UDS tokenizer in Docker (e.g., make run-exa
 	@$(MAKE) --no-print-directory run-example-only; status=$$?; \
 		$(MAKE) --no-print-directory stop-tokenizer; \
 		exit $$status
+
+.PHONY: image-fs-backend-build
+image-fs-backend-build: check-container-tool load-version-json ## Build the development container for the llmd_fs_backend connector
+	@printf "\033[33;1m==== Building development container $(FS_BACKEND_DEV_IMG) ====\033[0m\n"
+	$(CONTAINER_TOOL) build \
+		--platform $(TARGETOS)/$(TARGETARCH) \
+		--build-arg TARGETOS=$(TARGETOS) \
+		--build-arg TARGETARCH=$(TARGETARCH) \
+		-f kv_connectors/llmd_fs_backend/Dockerfile.dev \
+		-t $(FS_BACKEND_DEV_IMG) .
+
+.PHONY: image-fs-backend-push
+image-fs-backend-push: check-container-tool load-version-json ## Push the development container for the llmd_fs_backend connector
+	@printf "\033[33;1m==== Pushing development container $(FS_BACKEND_DEV_IMG) ====\033[0m\n"
+	$(CONTAINER_TOOL) push $(FS_BACKEND_DEV_IMG)

--- a/kv_connectors/llmd_fs_backend/Dockerfile.dev
+++ b/kv_connectors/llmd_fs_backend/Dockerfile.dev
@@ -1,0 +1,58 @@
+# Copyright 2026 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the vLLM base image
+FROM vllm/vllm-openai:v0.18.0
+
+# 1. Install system dependencies
+# We need the CUDA toolkit headers to compile the C++ extension. Install the 12.9 toolkit
+# to ensure headers (like cusparse.h) are available in /usr/local/cuda.
+RUN apt-get update && apt-get install -y \
+    libnuma-dev \
+    git \
+    wget \
+    gnupg2 \
+    && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb \
+    && dpkg -i cuda-keyring_1.1-1_all.deb \
+    && apt-get update && apt-get install -y cuda-toolkit-12-9 \
+    && rm -rf /var/lib/apt/lists/*
+
+# 2. Set environment variables for the compiler
+ENV PATH="/usr/local/cuda/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
+ENV CUDA_HOME="/usr/local/cuda"
+
+# 3. Set the working directory
+WORKDIR /workspace/llmd_fs_backend
+
+# 4. Copy the code into the image
+COPY . .
+
+# 5. Perform the editable installation (Build from source) and install dev tools
+# We use --no-build-isolation because the build environment needs access to
+# pre-installed system packages for the C++ extension compilation.
+RUN pip install pytest && \
+    if [ -f "setup.py" ]; then \
+        pip install --no-build-isolation -e .; \
+    elif [ -f "kv_connectors/llmd_fs_backend/setup.py" ]; then \
+        pip install --no-build-isolation -e ./kv_connectors/llmd_fs_backend; \
+    else \
+        echo "Error: setup.py not found. Ensure build context contains the connector source." && exit 1; \
+    fi
+
+# 6. Default configuration for development
+ENV STORAGE_LOG_LEVEL="debug"
+
+# Start with bash for easier experimentation
+CMD ["/bin/bash"]

--- a/kv_connectors/llmd_fs_backend/README.md
+++ b/kv_connectors/llmd_fs_backend/README.md
@@ -58,6 +58,16 @@ cd llm-d-kv-cache-manager/kv_connectors/llmd_fs_backend
 pip install -e .
 ```
 
+Alternatively, you can build and push a development container image directly using the provided `Dockerfile.dev`. This image includes all dependencies and performs an editable installation:
+
+```bash
+# Build from the root of the repository
+make image-fs-backend-build IMAGE_TAG_BASE=<your-base-container-registry> FS_BACKEND_NAME=<image-name> DEV_VERSION=<dev-version>
+
+# Push the development image
+make image-fs-backend-push IMAGE_TAG_BASE=<your-base-container-registry> FS_BACKEND_NAME=<image-name> DEV_VERSION=<dev-version>
+```
+
 ## Configuration Flags
 
 ### Connector parameters


### PR DESCRIPTION
Adding a dockerfile which allows dev work and directly create a container image for testing on k8s.

The steps in the dockerfile is an extension of the instructions in https://github.com/llm-d/llm-d-kv-cache/blob/main/kv_connectors/llmd_fs_backend/README.md#3-developer-mode-clone-and-editable-install

Changes:
1. add a Docker.dev file 
2. Make file changes to invoke the build and push command `image-fs-backend-build` `image-fs-backend-push`
3. readme changes

Tests:
Manual verified a docker build and deploy of a pod spec on k8s and perform a basic serving
pod spec snippet
```
      containers:
      - name: vllm-storage
        image: <artifactregistry>/llmd-fs-backend:dev
        command:
        - "/bin/bash"
        args:
        - "-c"
        - |
           mkdir -p /tmp/prometheus_metrics;
           vllm serve meta-llama/Llama-3.3-70B-Instruct \
           --download-dir /model/models \
           --load-format runai_streamer \
           --kv-transfer-config '{ 
                "kv_connector": "OffloadingConnector", 
                "kv_role": "kv_both",
                "kv_connector_extra_config": {
                  "spec_name": "SharedStorageOffloadingSpec",
                  "spec_module_path": "llmd_fs_backend.spec",
                  "shared_storage_path": "/mnt/files-storage/llmd-kv-cache/",
                  "block_size": 256,
                  "threads_per_gpu": "16"
                }
              }' \
           --distributed_executor_backend "mp" \
           --port 8000 \
           --max_num_batched_tokens 16384 \
           --enable-chunked-prefill \
           --tensor-parallel-size 4 \
           --enable_prefix_caching \
           --gpu-memory-utilization 0.9
```