### PR TITLE
fix(ci): harden nightly race detector job

### DIFF
--- a/.github/workflows/ci-nightly-race.yaml
+++ b/.github/workflows/ci-nightly-race.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   race-detector:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CGO_ENABLED: "1"  # Required by -race; explicit for documentation
     steps:
       - name: Checkout source
         uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ unit-test-uds: check-go download-zmq ## Run unit tests without embedded tokenize
 .PHONY: unit-test-race
 unit-test-race: check-go download-zmq ## Run unit tests with Go race detector enabled
 	@printf "\033[33;1m==== Running unit tests with race detector ====\033[0m\n"
-	@go test -v -race ./pkg/...
+	@go test -v -race -count=1 ./pkg/...
 
 .PHONY: unit-test-embedded
 unit-test-embedded: check-go install-python-deps download-zmq ## Run unit tests with embedded tokenizers


### PR DESCRIPTION
Follow up for https://github.com/llm-d/llm-d-kv-cache/pull/479#pullrequestreview-4034868368

- Add `-count=1` to disable Go test caching, ensuring intermittent races aren't masked by cached results
- Add `timeout-minutes: 30` to prevent hung tests (e.g., deadlocks) from burning CI minutes
- Add explicit `CGO_ENABLED=1` as documentation since `-race` requires CGO

/cc @yankay 