### PR TITLE
fix: test imports and missing gds_mode arg

### DIFF
--- a/kv_connectors/llmd_fs_backend/tests/conftest.py
+++ b/kv_connectors/llmd_fs_backend/tests/conftest.py
@@ -14,7 +14,12 @@
 
 # tests/conftest.py
 import gc
+import sys
 import time
+from pathlib import Path
+
+# Add tests directory to path so test modules can import each other
+sys.path.insert(0, str(Path(__file__).parent))
 
 import pytest
 import torch

--- a/kv_connectors/llmd_fs_backend/tests/test_priority_queue.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_priority_queue.py
@@ -80,6 +80,7 @@ def create_test_handler(
         gpu_block_size=config["gpu_block_size"],
         threads_per_gpu=threads_per_gpu,
         attn_backends=attn_backends,
+        gds_mode="disabled",
     )
 
     return handler, {"file_mapper": file_mapper, "kv_dict": kv_dict}


### PR DESCRIPTION
## Summary
- Add tests directory to `sys.path` in `conftest.py` so test modules can import each other (fixes `ModuleNotFoundError: No module named 'test_fs_backend'`)
- Add missing `gds_mode` argument to `StorageOffloadingHandlers` in priority queue tests

## Test plan
- [x] `make test` — all tests pass