### PR TITLE
fix: statically link libstdc++ in fs_connector wheel

### DIFF
--- a/kv_connectors/llmd_fs_backend/setup.py
+++ b/kv_connectors/llmd_fs_backend/setup.py
@@ -60,6 +60,7 @@ setup(
             include_dirs=include_dirs,
             libraries=libraries,
             extra_compile_args={"cxx": cxx_args, "nvcc": nvcc_args},
+            extra_link_args=["-static-libstdc++"],
         ),
     ],
     cmdclass={"build_ext": BuildExtension},


### PR DESCRIPTION
The wheel is built on nvidia/cuda:12.9.1-devel-ubuntu22.04 which uses GCC 12, producing a .so that requires GLIBCXX_3.4.30. The target runtime (llm-d-cuda:v0.6.0, RHEL 9) only provides GLIBCXX_3.4.29 (GCC 11), causing an ImportError at load time.

A previous workaround (LD_PRELOAD of Nsight Compute's libstdc++.so.6, documented in #445) is no longer viable in llm-d-cuda:v0.6.0 since Nsight Compute was removed from that image.

Fix: pass -static-libstdc++ as a linker flag so the C++ runtime is embedded directly in storage_offload.so. This eliminates the GLIBCXX version dependency at runtime entirely, with no source code changes.

Fixes #445