### PR TITLE
enable toolcalling from renderer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PROD_VERSION ?= 0.0.0
 IMAGE_TAG_BASE ?= ghcr.io/llm-d/$(PROJECT_NAME)
 IMG = $(IMAGE_TAG_BASE):$(DEV_VERSION)
 NAMESPACE ?= hc4ai-operator
-VLLM_VERSION := 0.14.0
+VLLM_VERSION := 0.18.0
 
 TARGETOS ?= $(shell go env GOOS)
 TARGETARCH ?= $(shell go env GOARCH)

--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,11 @@ e2e-test-embedded: check-go download-local-llama3 install-python-deps download-z
 .PHONY: image-build-uds
 image-build-uds: check-container-tool ## Build the UDS tokenizer container image
 	@printf "\033[33;1m==== Building UDS tokenizer image $(UDS_TOKENIZER_IMAGE) ====\033[0m\n"
-	$(CONTAINER_TOOL) build -t $(UDS_TOKENIZER_IMAGE) services/uds_tokenizer
+	$(CONTAINER_TOOL) build \
+		--platform $(TARGETOS)/$(TARGETARCH) \
+		--build-arg TARGETOS=$(TARGETOS) \
+		--build-arg TARGETARCH=$(TARGETARCH) \
+		-t $(UDS_TOKENIZER_IMAGE) services/uds_tokenizer
 
 .PHONY: e2e-test-uds
 e2e-test-uds: check-go download-zmq image-build-uds ## Run UDS tokenizer e2e tests (requires Docker or Podman)

--- a/services/uds_tokenizer/tokenizer_service/renderer.py
+++ b/services/uds_tokenizer/tokenizer_service/renderer.py
@@ -87,6 +87,7 @@ class RendererService:
             request_logger=None,
             chat_template=chat_template,
             chat_template_content_format="auto",
+            enable_auto_tools=True,
         )
 
     def _get_renderer(self, model_name: str):


### PR DESCRIPTION
When tools are provided without an explicit tool_choice, vLLM defaults tool_choice to "auto", which then fails validation because our renderer was created with enable_auto_tools=False. Setting enable_auto_tools=True bypasses this validation and is safe because the tokenizer service only renders prompts — it never parses tool calls from model output, so no tool parsing logic is activated.

Fixes: #506 