### PR TITLE
fix: register MaxPodHitCount metric in Collectors()

### DIFF
--- a/pkg/kvcache/metrics/collector.go
+++ b/pkg/kvcache/metrics/collector.go
@@ -78,7 +78,7 @@ var (
 func Collectors() []prometheus.Collector {
 	return []prometheus.Collector{
 		Admissions, Evictions,
-		LookupRequests, LookupHits, LookupLatency,
+		LookupRequests, LookupHits, LookupLatency, MaxPodHitCount,
 		RenderChatTemplateLatency, TokenizationLatency, TokenizedTokensCount,
 	}
 }
@@ -145,11 +145,19 @@ func logMetrics(ctx context.Context) {
 		latencyAvg = latencySum / float64(latencyCount)
 	}
 
+	var maxPodHitMetric dto.Metric
+	err = MaxPodHitCount.Write(&maxPodHitMetric)
+	if err != nil {
+		return
+	}
+	maxPodHitCount := maxPodHitMetric.GetCounter().GetValue()
+
 	log.FromContext(ctx).WithName("metrics").Info("metrics beat",
 		"admissions", admissions,
 		"evictions", evictions,
 		"lookups", lookups,
 		"hits", hits,
+		"max_pod_hit_count", maxPodHitCount,
 		"latency_count", latencyCount,
 		"latency_sum", latencySum,
 		"latency_avg", latencyAvg,

--- a/pkg/kvcache/metrics/collector_test.go
+++ b/pkg/kvcache/metrics/collector_test.go
@@ -30,9 +30,13 @@ import (
 func TestCollectorsIncludesAllMetrics(t *testing.T) {
 	collectors := Collectors()
 
-	// Build a set of collector pointers for lookup.
+	// Build a set of collector pointers for lookup and ensure Collectors()
+	// does not return duplicates, which would panic during MustRegister.
 	collectorSet := make(map[prometheus.Collector]bool, len(collectors))
 	for _, c := range collectors {
+		if collectorSet[c] {
+			t.Fatalf("Collectors() contains a duplicate collector: %T", c)
+		}
 		collectorSet[c] = true
 	}
 
@@ -135,8 +139,8 @@ func TestLogMetrics(t *testing.T) {
 		logMetrics(ctx)
 
 		output := buf.String()
-		if !strings.Contains(output, "max_pod_hit_count=") {
-			t.Errorf("Expected 'max_pod_hit_count' in log output, but it was not found. Full output: %s", output)
+		if !strings.Contains(output, "max_pod_hit_count=42") {
+			t.Errorf("Expected 'max_pod_hit_count=42' in log output, but it was not found. Full output: %s", output)
 		}
 	})
 }

--- a/pkg/kvcache/metrics/collector_test.go
+++ b/pkg/kvcache/metrics/collector_test.go
@@ -23,8 +23,40 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+func TestCollectorsIncludesAllMetrics(t *testing.T) {
+	collectors := Collectors()
+
+	// Build a set of collector pointers for lookup.
+	collectorSet := make(map[prometheus.Collector]bool, len(collectors))
+	for _, c := range collectors {
+		collectorSet[c] = true
+	}
+
+	expected := []struct {
+		name      string
+		collector prometheus.Collector
+	}{
+		{"Admissions", Admissions},
+		{"Evictions", Evictions},
+		{"LookupRequests", LookupRequests},
+		{"LookupHits", LookupHits},
+		{"LookupLatency", LookupLatency},
+		{"MaxPodHitCount", MaxPodHitCount},
+		{"RenderChatTemplateLatency", RenderChatTemplateLatency},
+		{"TokenizationLatency", TokenizationLatency},
+		{"TokenizedTokensCount", TokenizedTokensCount},
+	}
+
+	for _, e := range expected {
+		if !collectorSet[e.collector] {
+			t.Errorf("Collectors() is missing %s", e.name)
+		}
+	}
+}
 
 func TestLogMetrics(t *testing.T) {
 	// Set up a buffer to capture log output
@@ -92,6 +124,19 @@ func TestLogMetrics(t *testing.T) {
 			if !strings.Contains(output, part) {
 				t.Errorf("Expected '%s' in log output, but it was not found. Full output: %s", part, output)
 			}
+		}
+	})
+
+	t.Run("max_pod_hit_count_logged", func(t *testing.T) {
+		buf.Reset()
+
+		MaxPodHitCount.Add(42)
+
+		logMetrics(ctx)
+
+		output := buf.String()
+		if !strings.Contains(output, "max_pod_hit_count=") {
+			t.Errorf("Expected 'max_pod_hit_count' in log output, but it was not found. Full output: %s", output)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Add `MaxPodHitCount` to the `Collectors()` return slice so it is registered with the Prometheus registry
- Add `MaxPodHitCount` to the periodic `logMetrics()` output
- Add `TestCollectorsIncludesAllMetrics` to verify all defined metrics are included in `Collectors()`
- Add `max_pod_hit_count_logged` subtest to verify `logMetrics()` outputs the new field

## Problem

`MaxPodHitCount` is defined in `collector.go:44` and actively used in `instrumented_index.go:90` via `recordHitMetrics()`, but it was not included in the `Collectors()` slice. Since `Register()` calls `metrics.Registry.MustRegister(Collectors()...)`, the metric was never registered — making `kvcache_index_max_pod_hit_count_total` invisible to Prometheus/Grafana.

## Test plan

- [x] `TestCollectorsIncludesAllMetrics` — verifies every defined metric is in `Collectors()`
- [x] `TestLogMetrics/max_pod_hit_count_logged` — verifies `logMetrics()` includes the field
- [x] All existing tests pass: `go test ./pkg/kvcache/metrics/ -v`

Fixes #508