### PR TITLE
fix: use Tokenize RPC instead of RenderCompletion in UdsTokenizer.Render

### DIFF
--- a/pkg/tokenization/uds_tokenizer.go
+++ b/pkg/tokenization/uds_tokenizer.go
@@ -216,24 +216,9 @@ func (u *UdsTokenizer) warmup(ctx context.Context) {
 
 func strPtr(s string) *string { return &s }
 
-// Render tokenizes a plain-text prompt via the UDS renderer service.
+// Render tokenizes a plain-text prompt via the UDS tokenizer service.
 func (u *UdsTokenizer) Render(prompt string) ([]uint32, []types.Offset, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-	defer cancel()
-
-	resp, err := u.client.RenderCompletion(ctx, &tokenizerpb.RenderCompletionRequest{
-		ModelName: u.model,
-		Prompt:    prompt,
-	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("gRPC RenderCompletion request failed: %w", err)
-	}
-
-	if !resp.Success {
-		return nil, nil, fmt.Errorf("render completion failed: %s", resp.ErrorMessage)
-	}
-
-	return resp.TokenIds, nil, nil
+	return u.Encode(prompt, true)
 }
 
 // Encode tokenizes the input string and returns the token IDs and offsets.

--- a/pkg/tokenization/uds_tokenizer_test.go
+++ b/pkg/tokenization/uds_tokenizer_test.go
@@ -295,7 +295,7 @@ func (s *UdsTokenizerTestSuite) TestUdsTokenizer_Render() {
 	tokens, offsets, err := s.tokenizer.Render(input)
 	s.Require().NoError(err)
 	s.Assert().Equal(len([]rune(input)), len(tokens))
-	s.Assert().Nil(offsets, "RenderCompletion does not return character offsets")
+	s.Assert().Equal(len([]rune(input)), len(offsets), "Render now returns character offsets via Tokenize RPC")
 
 	// Verify specific characters (mock converts runes to token IDs)
 	s.Assert().Equal(uint32('h'), tokens[0])
@@ -330,7 +330,7 @@ func (s *UdsTokenizerTestSuite) TestUdsTokenizer_TokenizeError() {
 
 	_, _, err := s.tokenizer.Render("test")
 	s.Assert().Error(err)
-	s.Assert().Contains(err.Error(), "render completion failed")
+	s.Assert().Contains(err.Error(), "tokenization failed")
 }
 
 func (s *UdsTokenizerTestSuite) TestUdsTokenizer_RenderChatTemplateError() {


### PR DESCRIPTION
The RenderCompletion gRPC method is not implemented by the UDS tokenizer server, causing 'Unimplemented' errors for plain completion requests. Delegate Render() to Encode() which calls the Tokenize RPC that the server supports. This fixes both direct Render() callers and the tokenization pool's processTask path.