### PR TITLE
fix(fs_backend): suffix offload metrics via vllm.general_plugins

### DIFF
--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/__init__.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/__init__.py
@@ -17,6 +17,15 @@ import os
 
 from vllm.logger import init_logger
 
+from llmd_fs_backend.metrics import install_offload_metric_suffix_patch
+
+# Apply the OffloadPromMetrics spec-suffix patch before any OffloadingConnector
+# is instantiated. Required so MultiConnector can nest two OffloadingConnector
+# backends without hitting "Duplicated timeseries in CollectorRegistry".
+# TODO: remove once vLLM upstream applies an equivalent spec_name suffix
+# to the OffloadPromMetrics names.
+install_offload_metric_suffix_patch()
+
 _LEVEL_MAP = {
     "TRACE": logging.DEBUG,
     "DEBUG": logging.DEBUG,

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/metrics.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/metrics.py
@@ -1,0 +1,96 @@
+# Copyright 2026 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger(__name__)
+
+PATCHED_FLAG = "llmd_fs_patched"
+
+
+def install_offload_metric_suffix_patch() -> None:
+    """
+    Patch vLLM OffloadPromMetrics so each OffloadingConnector instance
+    registers Prometheus metrics under a spec_name-derived suffix
+    (vllm:kv_offload_total_bytes_sharedstorage, ..._cpu, ...).
+
+    Without this, MultiConnector + two OffloadingConnector children hit
+    "Duplicated timeseries in CollectorRegistry" because both instances
+    register the same fixed metric names. Idempotent; safe to call
+    multiple times.
+
+    TODO: remove once vLLM upstream applies an equivalent spec_name
+    suffix (or other disambiguation) to the OffloadPromMetrics names.
+    """
+    try:
+        from prometheus_client import Counter, Histogram
+        from vllm.distributed.kv_transfer.kv_connector.v1 import (
+            offloading_connector as oc,
+        )
+    except Exception as exc:
+        log.debug("skipping OffloadPromMetrics patch: %s", exc)
+        return
+
+    # Idempotency guard: mark the class after patching; safe to call many times.
+    if getattr(oc.OffloadPromMetrics, PATCHED_FLAG, False):
+        return
+
+    # Keep a handle to the real __init__; the patched version delegates to it.
+    orig_init = oc.OffloadPromMetrics.__init__
+
+    def patched_init(
+        self, vllm_config, metric_types, labelnames, per_engine_labelvalues
+    ):
+        # Per-connector suffix derived from spec_name.
+        # e.g. "SharedStorageOffloadingSpec" -> "sharedstorage",
+        #      "CPUOffloadingSpec"           -> "cpu".
+        extra = vllm_config.kv_transfer_config.kv_connector_extra_config or {}
+        suffix = (
+            str(extra.get("spec_name", "default")).replace("OffloadingSpec", "").lower()
+            or "default"
+        )
+
+        # wrap(cls) returns a drop-in replacement that tries the upstream
+        # name first; only when Prometheus reports a duplicate (the second
+        # OffloadPromMetrics under MultiConnector) does it retry with a
+        # spec_name suffix. Single-connector deployments keep the original
+        # vllm:kv_offload_total_bytes / _time / _size names unchanged.
+        def wrap(cls):
+            def factory(**kwargs):
+                try:
+                    return cls(**kwargs)
+                except ValueError as e:
+                    if "Duplicated timeseries" in str(e) and "name" in kwargs:
+                        kwargs["name"] = f"{kwargs['name']}_{suffix}"
+                        return cls(**kwargs)
+                    raise
+
+            return factory
+
+        # Copy before mutating — metric_types may be shared across instances.
+        patched = dict(metric_types)
+        if Counter in patched:
+            patched[Counter] = wrap(patched[Counter])
+        if Histogram in patched:
+            patched[Histogram] = wrap(patched[Histogram])
+
+        # Delegate to the real __init__ with the wrapped factories.
+        orig_init(self, vllm_config, patched, labelnames, per_engine_labelvalues)
+
+    # Monkey-patch: replace the class method and mark it patched.
+    oc.OffloadPromMetrics.__init__ = patched_init
+    setattr(oc.OffloadPromMetrics, PATCHED_FLAG, True)
+    log.info("installed OffloadPromMetrics spec-suffix patch")

--- a/kv_connectors/llmd_fs_backend/pyproject.toml
+++ b/kv_connectors/llmd_fs_backend/pyproject.toml
@@ -29,6 +29,11 @@ packages = ["llmd_fs_backend"]
 [tool.setuptools.package-data]
 llmd_fs_backend = ["*.so"]
 
+# Auto-load the OffloadPromMetrics monkey-patch during vLLM startup.
+# TODO: remove once vLLM disambiguates kv_offload metric names natively.
+[project.entry-points."vllm.general_plugins"]
+llmd_fs_metric_patch = "llmd_fs_backend.metrics:install_offload_metric_suffix_patch"
+
 [project.optional-dependencies]
 dev = [
     "vllm==0.18.1",


### PR DESCRIPTION
## Summary

When vLLM is deployed with `MultiConnector` wrapping two `OffloadingConnector` children (for example a CPU cache + the FS backend), startup crashes with `ValueError: Duplicated timeseries in CollectorRegistry`. Both children try to register the same Prometheus metric names (`vllm:kv_offload_total_bytes`, `..._time`, `..._size`), and the second one aborts the engine.

This PR adds a small plugin that patches `OffloadPromMetrics` so that when a duplicate name is detected, it retries with a suffix derived from `spec_name` (for example `_cpu`, `_sharedstorage`). The result is two cleanly separated metric families — one per offload backend — instead of a startup crash.

The patch is loaded through the `vllm.general_plugins` entry point so it runs during `EngineCore.__init__()`, before any KV connector builds its metrics. Single-connector deployments are untouched: the original metric names are kept, and the suffix only kicks in on an actual collision. A TODO is left to remove the workaround once vLLM upstream disambiguates these names natively.

## Test plan

- [x] Deployed `MultiConnector(CPU + FS)` in k8s with the rebuilt wheel — pod reaches `Application startup complete` without `Duplicated timeseries`.
- [x] `/metrics` exposes both series:
  - `vllm:kv_offload_total_bytes_total` (CPU — first child, keeps upstream name)
  - `vllm:kv_offload_total_bytes_sharedstorage_total` (FS — second child, takes the `_sharedstorage` suffix)
- [x] Prometheus scrape target reports `up=1`; Grafana datasource reads both series.