### PR TITLE
fix(docs): correct scoring return type and add device-tier weighting description

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,7 +52,7 @@ sequenceDiagram
     Indexer->>Scorer: Score(hitKeys[], keyToPodsMap)
     Scorer-->>Indexer: podScoresMap
     
-    Indexer-->>Router: podScoresMap[string]int
+    Indexer-->>Router: podScoresMap[string]float64
 ```
 
 **Key Steps:**
@@ -60,7 +60,7 @@ sequenceDiagram
 1.  **Tokenization**: The `Indexer` performs synchronous tokenization of the prompt using the worker pool.
 2.  **Key Generation**: The tokenized sequence is sent to the `TokenProcessor`, which chunks and hashes them into a sequence of deterministic KV-block keys that match vLLM's logic.
 3.  **Index Lookup**: With the keys, the `Indexer` queries the `kvblock.Index` to see which pods have them. The lookup is optimized to find the longest *consecutive* chain of hits from the start.
-4.  **Scoring**: The `Scorer` takes the hit data and scores each pod based on its number of consecutive matching blocks.
+4.  **Scoring**: The `Scorer` takes the hit data and scores each pod based on its longest consecutive prefix of matching blocks, weighted by the device tier each block resides on (e.g. GPU = 1.0, CPU = 0.8).
 5.  **Response**: A final map of pod scores is sent back to the router.
 
 Note: The tokenization pool now supports both asynchronous (fire-and-forget) and synchronous modes, ensuring scoring requests can always return complete results.


### PR DESCRIPTION
## Summary

- Fix `podScoresMap` return type from `[string]int` to `[string]float64` in architecture diagram — `LongestPrefixScorer.Score()` returns tier-weighted `float64` values
- Update scoring description to mention device-tier weighting (e.g. gpu=1.0, cpu=0.8)

Found while reviewing llm-d/llm-d#1143 and cross-referencing with source code.