### PR TITLE
fix: align default pod label selector to kebab-case inference-serving

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -354,7 +354,7 @@ For automatic Kubernetes pod discovery:
   "concurrency": 8,
   "discoverPods": true,
   "podDiscoveryConfig": {
-    "podLabelSelector": "llm-d.ai/inferenceServing=true",
+    "podLabelSelector": "llm-d.ai/inference-serving=true",
     "podNamespace": "inference",
     "socketPort": 5557,
   }
@@ -367,7 +367,7 @@ Configures the Kubernetes pod reconciler for automatic per-pod ZMQ subscriber ma
 
 ```json
 {
-  "podLabelSelector": "llm-d.ai/inferenceServing=true",
+  "podLabelSelector": "llm-d.ai/inference-serving=true",
   "podNamespace": "",
   "socketPort": 5556,
 }
@@ -375,7 +375,7 @@ Configures the Kubernetes pod reconciler for automatic per-pod ZMQ subscriber ma
 
 | Field | Type | Description | Default               |
 |-------|------|-------------|-----------------------|
-| `podLabelSelector` | `string` | Label selector for filtering which pods to watch. Examples: `"app=vllm"`, `"app=vllm,tier=gpu"` | `"llm-d.ai/inferenceServing=true"`         |
+| `podLabelSelector` | `string` | Label selector for filtering which pods to watch. Examples: `"app=vllm"`, `"app=vllm,tier=gpu"` | `"llm-d.ai/inference-serving=true"`         |
 | `podNamespace` | `string` | Namespace to watch pods in. If empty, watches all namespaces (requires cluster-wide RBAC) | `""` (all namespaces) |
 | `socketPort` | `integer` | Port number where vLLM pods expose their ZMQ socket | `5557`                |
 

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	defaultEventSourceDeviceTier = "GPU"
-	defaultPodSelector           = "llm-d.ai/inferenceServing=true"
+	defaultPodSelector           = "llm-d.ai/inference-serving=true"
 )
 
 // Config holds the configuration for the event processing pool.


### PR DESCRIPTION
## Summary

- Change default `podLabelSelector` from `llm-d.ai/inferenceServing=true` (camelCase) to `llm-d.ai/inference-serving=true` (kebab-case) in code and docs
- Aligns with the canonical label used across 30+ files in the [llm-d/llm-d](https://github.com/llm-d/llm-d) deployment guides and Kubernetes naming conventions

Closes https://github.com/llm-d/llm-d-kv-cache/issues/524