### PR TITLE
feat(fs_backend): add performance and stress tests

### DIFF
--- a/kv_connectors/llmd_fs_backend/Makefile
+++ b/kv_connectors/llmd_fs_backend/Makefile
@@ -3,7 +3,7 @@ WHEEL_DIR = wheels
 DIST_DIR = dist
 VERSION := $(shell $(PYTHON) -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
 
-.PHONY: wheel build test clean check-gds
+.PHONY: wheel build test test-performance clean check-gds
 
 # Install build dependencies
 deps:
@@ -30,9 +30,13 @@ wheel: deps
 build:
 	$(PYTHON) -m pip install -e .
 
-# Run tests
+# Run unit tests (excludes the performance/ directory)
 test:
-	pytest ./tests/ -v -sq
+	pytest ./tests/ -v -sq --ignore=./tests/performance
+
+# Run performance tests (throughput + stress sweep)
+test-performance:
+	pytest ./tests/performance/ -v -sq
 
 # Clean local build artifacts
 clean:

--- a/kv_connectors/llmd_fs_backend/tests/performance/__init__.py
+++ b/kv_connectors/llmd_fs_backend/tests/performance/__init__.py
@@ -1,0 +1,1 @@
+# Performance and stress tests for fs_connector

--- a/kv_connectors/llmd_fs_backend/tests/performance/conftest.py
+++ b/kv_connectors/llmd_fs_backend/tests/performance/conftest.py
@@ -31,7 +31,7 @@ def pytest_addoption(parser):
             "Root directory for fs_connector storage. Any local Linux path "
             "(e.g., /tmp, /mnt/pvc/kv-cache, /dev/shm). "
             "A unique subdirectory is created under this root per test. "
-            "Default: $FS_CONNECTOR_STORAGE_ROOT env var, or system /tmp."
+            "Default: system /tmp."
         ),
     )
     parser.addoption(
@@ -66,51 +66,11 @@ def _apply_storage_log_level(request):
 
 
 @pytest.fixture
-def storage_root(request):
-    """
-    Resolve the storage root directory for fs_connector tests.
-
-    Precedence:
-      1. --storage-root CLI flag (if set)
-      2. FS_CONNECTOR_STORAGE_ROOT env var (if set)
-      3. System /tmp (default)
-    """
-    root = request.config.getoption("--storage-root")
-    if root is None:
-        root = os.environ.get("FS_CONNECTOR_STORAGE_ROOT")
-    if root is None:
-        root = tempfile.gettempdir()  # typically /tmp
+def storage_path(request):
+    """Unique temp storage dir per test; cleaned up after."""
+    root = request.config.getoption("--storage-root") or tempfile.gettempdir()
     os.makedirs(root, exist_ok=True)
-    return root
-
-
-@pytest.fixture
-def storage_path(storage_root):
-    """
-    Provide a unique temporary storage subdirectory for each test.
-
-    Created under `storage_root` and cleaned up after the test.
-    """
-    tmpdir = tempfile.mkdtemp(prefix="fs_connector_perf_", dir=storage_root)
+    tmpdir = tempfile.mkdtemp(prefix="fs_connector_perf_", dir=root)
     yield tmpdir
     if os.path.exists(tmpdir):
         shutil.rmtree(tmpdir, ignore_errors=True)
-
-
-@pytest.fixture
-def fs_connector_config(storage_path):
-    """Base fs_connector configuration for tests."""
-    return {
-        "kv_connector": "OffloadingConnector",
-        "kv_role": "kv_both",
-        "kv_connector_extra_config": {
-            "spec_name": "SharedStorageOffloadingSpec",
-            "spec_module_path": "llmd_fs_backend.spec",
-            "shared_storage_path": storage_path,
-            "threads_per_gpu": 64,
-            "block_size": 256,
-            "max_staging_memory_gb": 150,
-            "gds_mode": "disabled",
-            "read_preferring_ratio": 0.75,
-        },
-    }

--- a/kv_connectors/llmd_fs_backend/tests/performance/conftest.py
+++ b/kv_connectors/llmd_fs_backend/tests/performance/conftest.py
@@ -1,0 +1,116 @@
+# Copyright 2025 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import tempfile
+
+import pytest
+
+from .utils import set_storage_log_level
+
+
+def pytest_addoption(parser):
+    """Register CLI options for fs_connector performance tests."""
+    parser.addoption(
+        "--storage-root",
+        action="store",
+        default=None,
+        help=(
+            "Root directory for fs_connector storage. Any local Linux path "
+            "(e.g., /tmp, /mnt/pvc/kv-cache, /dev/shm). "
+            "A unique subdirectory is created under this root per test. "
+            "Default: $FS_CONNECTOR_STORAGE_ROOT env var, or system /tmp."
+        ),
+    )
+    parser.addoption(
+        "--storage-log-level",
+        action="store",
+        default=None,
+        choices=("trace", "debug", "info", "warn", "error"),
+        help=(
+            "Set STORAGE_LOG_LEVEL for the fs_connector (trace/debug/info/"
+            "warn/error). Applied before the LLM is built."
+        ),
+    )
+    parser.addoption(
+        "--debug-storage",
+        action="store_true",
+        default=False,
+        help="Shortcut for --storage-log-level=debug.",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _apply_storage_log_level(request):
+    """
+    Apply --storage-log-level / --debug-storage to STORAGE_LOG_LEVEL before
+    any fs_connector code runs. autouse so all tests pick it up.
+    """
+    level = request.config.getoption("--storage-log-level")
+    if request.config.getoption("--debug-storage"):
+        level = "debug"
+    if level:
+        set_storage_log_level(level)
+
+
+@pytest.fixture
+def storage_root(request):
+    """
+    Resolve the storage root directory for fs_connector tests.
+
+    Precedence:
+      1. --storage-root CLI flag (if set)
+      2. FS_CONNECTOR_STORAGE_ROOT env var (if set)
+      3. System /tmp (default)
+    """
+    root = request.config.getoption("--storage-root")
+    if root is None:
+        root = os.environ.get("FS_CONNECTOR_STORAGE_ROOT")
+    if root is None:
+        root = tempfile.gettempdir()  # typically /tmp
+    os.makedirs(root, exist_ok=True)
+    return root
+
+
+@pytest.fixture
+def storage_path(storage_root):
+    """
+    Provide a unique temporary storage subdirectory for each test.
+
+    Created under `storage_root` and cleaned up after the test.
+    """
+    tmpdir = tempfile.mkdtemp(prefix="fs_connector_perf_", dir=storage_root)
+    yield tmpdir
+    if os.path.exists(tmpdir):
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.fixture
+def fs_connector_config(storage_path):
+    """Base fs_connector configuration for tests."""
+    return {
+        "kv_connector": "OffloadingConnector",
+        "kv_role": "kv_both",
+        "kv_connector_extra_config": {
+            "spec_name": "SharedStorageOffloadingSpec",
+            "spec_module_path": "llmd_fs_backend.spec",
+            "shared_storage_path": storage_path,
+            "threads_per_gpu": 64,
+            "block_size": 256,
+            "max_staging_memory_gb": 150,
+            "gds_mode": "disabled",
+            "read_preferring_ratio": 0.75,
+        },
+    }

--- a/kv_connectors/llmd_fs_backend/tests/performance/test_stress.py
+++ b/kv_connectors/llmd_fs_backend/tests/performance/test_stress.py
@@ -352,6 +352,11 @@ def test_stress(
 # ---------------- standalone CLI ----------------
 
 if __name__ == "__main__":
+    # Example manual runs (see --help for the full flag list):
+    #   # Storage tier - default fs (use CPU staging)
+    #   python -m tests.performance.test_stress --backend=storage
+    #   # CPU-only baseline
+    #   python -m tests.performance.test_stress --backend=cpu
     parser = argparse.ArgumentParser(
         description=(
             "Run KV-offload batched stress test with hot/cold-ratio sweep. "

--- a/kv_connectors/llmd_fs_backend/tests/performance/test_stress.py
+++ b/kv_connectors/llmd_fs_backend/tests/performance/test_stress.py
@@ -1,0 +1,452 @@
+# Copyright 2025 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Stress test: batched KV-offload load with a hot/cold ratio sweep.
+
+Each generate() call submits `batch_size` prompts mixed by `hot_ratio`:
+  - hot : reused from the pool of already-seen prompts (READ / reload path)
+  - cold: freshly generated unique prompts             (WRITE / populate path)
+
+    ratio = 0.0 -> all cold  (pure write stress)
+    ratio = 1.0 -> all hot   (pure read stress)
+    in between  -> mix; exercises the scheduler's read_preferring_ratio.
+
+The default sweep walks `hot_ratios` = [0.0, 0.1, ..., 1.0] with
+`num_iterations` iters per ratio. Pass `--num-repeats=N>=2` to repeat the
+full sweep against a growing working set (reveals drift / fragmentation /
+page-cache pressure).
+
+Default budget: batch=32, 10K tokens, 11 ratios, 5 iters, 1 repeat
+  = 55 iterations x 32 prompts = 1,760 prompts total.
+
+Metrics per (repeat, ratio): batch mean / p50 / p99, tokens/s, KV GB/s.
+
+Backends (--backend CLI / @pytest.parametrize):
+  - "base":         No offloading at all
+  - "gpu":          GPU prefix cache only
+  - "cpu":          CPU offloading only
+  - "fs":           Storage offloading only
+  - "multi-cpu-fs": MultiConnector chaining CPU + FS
+"""
+
+import argparse
+import random
+import statistics
+import time
+
+import pytest
+from vllm import LLM, SamplingParams, TokensPrompt
+
+from .utils import (
+    BACKENDS,
+    LOG_LEVELS,
+    calculate_throughput_gb_s,
+    cleanup_storage_dir,
+    del_llm_and_cleanup,
+    get_kv_transfer_config,
+    quiet_vllm_logs,
+    set_storage_log_level,
+    warmup_req,
+)
+
+# Default sweep: 0.0, 0.1, 0.2, ..., 1.0 (11 values), 0.1 granularity reveals
+# latency plateaus/cliffs as the scheduler shifts from all-writes to all-reads.
+DEFAULT_HOT_RATIOS: tuple[float, ...] = tuple(round(i / 10, 1) for i in range(11))
+
+
+def _build_mixed_batch(
+    pool: list[TokensPrompt],
+    next_prefix_id: int,
+    batch_size: int,
+    num_tokens: int,
+    hot_ratio: float,
+    rng: random.Random,
+) -> tuple[list[TokensPrompt], int]:
+    """
+    Build a batch of `batch_size` prompts mixing `hot_ratio` reused prompts
+    from `pool` with fresh unique prompts (appended to `pool` for later reuse).
+    If the pool is smaller than the requested hot count, the shortfall is
+    filled with additional cold prompts.
+
+    Returns (batch, next_prefix_id).
+    """
+    n_hot = round(batch_size * hot_ratio)
+    n_hot = min(n_hot, len(pool))
+    n_cold = batch_size - n_hot
+
+    batch: list[TokensPrompt] = list(rng.sample(pool, n_hot)) if n_hot else []
+    for _ in range(n_cold):
+        # Unique prefix_id -> unique KV block hashes -> no FS overlap with pool.
+        prompt_ids = [next_prefix_id] + [2] * (num_tokens - 1)
+        prompt = TokensPrompt(prompt_token_ids=prompt_ids)
+        pool.append(prompt)
+        batch.append(prompt)
+        next_prefix_id += 1
+
+    return batch, next_prefix_id
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    """Simple nearest-rank percentile (sorted index)."""
+    if not values:
+        return 0.0
+    s = sorted(values)
+    idx = min(int(len(s) * pct), len(s) - 1)
+    return s[idx]
+
+
+def run_stress_test(
+    model_name: str,
+    backend: str,
+    gpu_memory_utilization: float,
+    storage_path: str,
+    batch_size: int = 32,
+    num_iterations: int = 5,
+    num_tokens: int = 10000,
+    hot_ratios: list[float] | None = None,
+    num_repeats: int = 1,
+    seed: int = 42,
+    tensor_parallel_size: int = 1,
+    storage_log_level: str | None = None,
+    gpu_block_size: int = 16,
+    fs_block_size: int = 256,
+    cpu_block_size: int = 48,
+    threads_per_gpu: int = 24,
+) -> tuple[float, float, float, float, float, float]:
+    """
+    Run a hot/cold-ratio sweep stress test (see module docstring).
+
+    Args:
+        batch_size: Number of prompts per generate() call.
+        num_iterations: Iterations per (repeat, ratio) combination.
+        num_tokens: Tokens per prompt.
+        hot_ratios: List of fractions in [0.0, 1.0] — fraction of each batch
+            sampled from the already-seen pool. Default: 0.0..1.0 step 0.1.
+        num_repeats: Number of full sweeps through `hot_ratios`. Multiple
+            repeats grow the working set and reveal drift.
+
+    Returns (for pytest assertions — computed from the final repeat at the
+    maximum ratio in `hot_ratios`, i.e. the steady-state pure-read phase):
+        (tokens_per_sec, kv_gb_s, batch_mean, batch_p50, batch_p99, batch_p100)
+    """
+    if hot_ratios is None:
+        hot_ratios = list(DEFAULT_HOT_RATIOS)
+
+    total_iters = num_repeats * len(hot_ratios) * num_iterations
+    print(f"\n===== Stress Test: backend={backend} model={model_name} =====")
+    print(
+        f"Batch size: {batch_size}, Tokens/prompt: {num_tokens}\n"
+        f"Sweep: hot_ratios={hot_ratios}\n"
+        f"Repeats: {num_repeats}, Iterations/ratio: {num_iterations} "
+        f"-> Total iterations: {total_iters} "
+        f"(= {total_iters * batch_size} prompts)"
+    )
+
+    # -------- Phase 1: Setup (config, LLM, warmup) --------
+    if storage_log_level:
+        set_storage_log_level(storage_log_level)
+
+    kv_transfer_config = get_kv_transfer_config(
+        backend=backend,
+        storage_path=storage_path,
+        fs_block_size=fs_block_size,
+        cpu_block_size=cpu_block_size,
+        threads_per_gpu=threads_per_gpu,
+    )
+
+    llm = LLM(
+        model=model_name,
+        gpu_memory_utilization=gpu_memory_utilization,
+        kv_transfer_config=kv_transfer_config,
+        max_model_len=num_tokens + 1000,
+        seed=seed,
+        # "gpu" uses GPU prefix cache; "base" and offload backends bypass it.
+        enable_prefix_caching=(backend == "gpu"),
+        tensor_parallel_size=tensor_parallel_size,
+        block_size=gpu_block_size,
+    )
+
+    quiet_vllm_logs()
+
+    sampling_params = SamplingParams(
+        detokenize=False,
+        ignore_eos=True,
+        seed=seed,
+        max_tokens=1,
+    )
+
+    warmup_req(llm, sampling_params)
+
+    # -------- Phase 2: Run batch --------
+    rng = random.Random(seed)
+    pool: list[TokensPrompt] = []
+    next_prefix_id = 10  # kept distinct from warmup prefix 999
+
+    # results[(repeat, ratio)] = list[latency_sec]
+    results: dict = {}
+    total_prompts = 0
+    t_start = time.perf_counter()
+
+    for repeat in range(num_repeats):
+        for ratio in hot_ratios:
+            key = (repeat, ratio)
+            results[key] = []
+            print(
+                f"\n[sweep {repeat + 1}/{num_repeats}] ratio={ratio:.2f}  "
+                f"pool_size={len(pool)}"
+            )
+            for i in range(num_iterations):
+                batch, next_prefix_id = _build_mixed_batch(
+                    pool, next_prefix_id, batch_size, num_tokens, ratio, rng
+                )
+                t0 = time.perf_counter()
+                outputs = llm.generate(batch, sampling_params, use_tqdm=False)
+                dt = time.perf_counter() - t0
+                results[key].append(dt)
+                total_prompts += len(outputs)
+                print(
+                    f"  iter {i + 1:2d}/{num_iterations}: {dt:.3f}s "
+                    f"({batch_size / dt:.2f} req/s)"
+                )
+
+    t_total = time.perf_counter() - t_start
+
+    # -------- Phase 3: Print results --------
+    print("\n==================== Per-ratio summary ====================")
+    header = (
+        f"{'ratio':>5}  "
+        + "  ".join(
+            f"{'rep' + str(r + 1) + ' mean':>10}  {'p50':>7}  {'p99':>7}  "
+            f"{'KV GB/s':>8}"
+            for r in range(num_repeats)
+        )
+        + (f"  {'Δmean':>7}" if num_repeats >= 2 else "")
+    )
+    print(header)
+    print("-" * len(header))
+
+    # We use pure-ratio=1.0 of the last repeat as the "steady" representative
+    # to return for pytest assertions (falls back to last ratio if 1.0 absent).
+    steady_ratio = 1.0 if 1.0 in hot_ratios else hot_ratios[-1]
+    steady_lats = results[(num_repeats - 1, steady_ratio)]
+
+    for ratio in hot_ratios:
+        row = f"{ratio:>5.2f}  "
+        means = []
+        for r in range(num_repeats):
+            lats = results[(r, ratio)]
+            mean = statistics.mean(lats)
+            means.append(mean)
+            p50 = statistics.median(lats)
+            p99 = _percentile(lats, 0.99)
+            kv = calculate_throughput_gb_s(model_name, batch_size * num_tokens, mean)
+            row += f"  {mean:>10.3f}  {p50:>7.3f}  {p99:>7.3f}  {kv:>8.2f}"
+        if num_repeats >= 2 and means[0] > 0:
+            drift = (means[-1] - means[0]) / means[0] * 100.0
+            row += f"  {drift:>+6.1f}%"
+        print(row)
+
+    # Steady-state metrics (return value + key line below the table).
+    steady_mean = statistics.mean(steady_lats) if steady_lats else 0.0
+    steady_p50 = statistics.median(steady_lats) if steady_lats else 0.0
+    steady_p99 = _percentile(steady_lats, 0.99)
+    steady_p100 = max(steady_lats) if steady_lats else 0.0
+    tokens_per_sec = (batch_size * num_tokens) / steady_mean if steady_mean > 0 else 0.0
+    kv_gb_s = calculate_throughput_gb_s(
+        model_name, batch_size * num_tokens, steady_mean
+    )
+
+    print(f"\n[RESULTS] backend={backend}  model={model_name}")
+    print(
+        f"  Total prompts: {total_prompts}, wall time: {t_total:.2f}s, "
+        f"pool_size={len(pool)}"
+    )
+    print(
+        f"  Steady-state (repeat {num_repeats}, ratio={steady_ratio}): "
+        f"tokens/s={tokens_per_sec:,.0f}  "
+        + (f"KV={kv_gb_s:.2f} GB/s  " if kv_gb_s > 0 else "KV=NA  ")
+        + f"mean={steady_mean:.3f}s p50={steady_p50:.3f}s "
+        f"p99={steady_p99:.3f}s p100={steady_p100:.3f}s"
+    )
+
+    del_llm_and_cleanup(llm)
+    return (
+        tokens_per_sec,
+        kv_gb_s,
+        steady_mean,
+        steady_p50,
+        steady_p99,
+        steady_p100,
+    )
+
+
+# ---------------- pytest entry points ----------------
+
+
+@pytest.mark.parametrize("backend", ["fs"])
+@pytest.mark.parametrize("batch_size", [32])
+@pytest.mark.parametrize("model_name", ["Qwen/Qwen2.5-7B-Instruct"])
+def test_stress(
+    storage_path: str,
+    backend: str,
+    batch_size: int,
+    model_name: str,
+):
+    """
+    Hot/cold-ratio sweep stress for the selected backend.
+
+    Pytest runs a short single-repeat sweep (hot_ratios=[0.0, 0.5, 1.0],
+    2 iters each) to keep CI fast. For a full stress run, use the CLI.
+
+    Verifies:
+      - Throughput > 0 (no deadlocks in concurrent I/O)
+      - Steady-state p99 latency bounded (backend handles pure-reads well)
+      - p100 not a wild outlier (no tail pathology)
+    """
+    _tps, _gbs, _mean, _p50, p99, p100 = run_stress_test(
+        model_name=model_name,
+        backend=backend,
+        gpu_memory_utilization=0.5,
+        storage_path=storage_path,
+        batch_size=batch_size,
+        num_iterations=2,
+        num_tokens=10000,
+        hot_ratios=[0.0, 0.5, 1.0],
+        num_repeats=1,
+    )
+
+    assert p99 < 10.0, (
+        f"Steady-state p99 latency too high: {p99:.3f}s "
+        "(possible backend contention or I/O queue starvation)."
+    )
+    assert (p100 - p99) < 5.0, (
+        f"Tail latency spike (p100 - p99 = {p100 - p99:.3f}s). "
+        "Possible GC pause, lock contention, or I/O stall."
+    )
+
+
+# ---------------- standalone CLI ----------------
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run KV-offload batched stress test with hot/cold-ratio sweep. "
+            "By default sweeps hot_ratio from 0.0 to 1.0 in 0.1 steps "
+            "(single pass) to stress both write and read paths. Pass "
+            "--num-repeats=2 (or more) to detect drift across repeated sweeps."
+        )
+    )
+    parser.add_argument(
+        "--backend",
+        type=str,
+        default="fs",
+        choices=BACKENDS,
+        help=f"Backend to benchmark (one of {BACKENDS})",
+    )
+    parser.add_argument(
+        "--storage-path",
+        type=str,
+        default="/tmp/fs_connector_stress",
+        help="Storage path for fs / multi-cpu-fs backends",
+    )
+    parser.add_argument("--model", type=str, default="Qwen/Qwen2.5-7B-Instruct")
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument(
+        "--num-iterations",
+        type=int,
+        default=5,
+        help="Iterations per (repeat, hot_ratio) combination (default 5)",
+    )
+    parser.add_argument("--num-tokens", type=int, default=10000)
+    parser.add_argument(
+        "--hot-ratios",
+        type=str,
+        default=",".join(str(r) for r in DEFAULT_HOT_RATIOS),
+        help=(
+            "Comma-separated fractions in [0.0, 1.0] defining the sweep. "
+            "hot_ratio=1.0 -> all prompts reused (pure read); "
+            "0.0 -> all fresh (pure write). "
+            f"Default: {','.join(str(r) for r in DEFAULT_HOT_RATIOS)}"
+        ),
+    )
+    parser.add_argument(
+        "--num-repeats",
+        type=int,
+        default=1,
+        help=(
+            "Number of full sweeps through hot_ratios (default 1). "
+            "Use >=2 to catch drift / FS fragmentation across repeated passes."
+        ),
+    )
+    parser.add_argument("--gpu-mem-util", type=float, default=0.5)
+    parser.add_argument("--tp-size", type=int, default=1, help="Tensor parallel size")
+    parser.add_argument(
+        "--gpu-block-size",
+        type=int,
+        default=16,
+        help="GPU KV cache block size (vLLM block_size)",
+    )
+    parser.add_argument(
+        "--fs-block-size",
+        type=int,
+        default=256,
+        help="fs_connector offloaded block_size (tokens per file)",
+    )
+    parser.add_argument(
+        "--cpu-block-size",
+        type=int,
+        default=48,
+        help="CPU offload block_size (for cpu / multi-cpu-fs backends)",
+    )
+    parser.add_argument(
+        "--threads-per-gpu",
+        type=int,
+        default=24,
+        help="I/O worker threads per GPU for fs backend (default 24)",
+    )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="info",
+        choices=LOG_LEVELS,
+        help=f"Set STORAGE_LOG_LEVEL for fs_connector (one of {LOG_LEVELS})",
+    )
+    args = parser.parse_args()
+
+    hot_ratios = [float(x.strip()) for x in args.hot_ratios.split(",") if x.strip()]
+    for r in hot_ratios:
+        if not 0.0 <= r <= 1.0:
+            raise SystemExit(f"hot_ratio {r} out of [0.0, 1.0]")
+
+    try:
+        run_stress_test(
+            model_name=args.model,
+            backend=args.backend,
+            gpu_memory_utilization=args.gpu_mem_util,
+            storage_path=args.storage_path,
+            batch_size=args.batch_size,
+            num_iterations=args.num_iterations,
+            num_tokens=args.num_tokens,
+            hot_ratios=hot_ratios,
+            num_repeats=args.num_repeats,
+            tensor_parallel_size=args.tp_size,
+            storage_log_level=args.log_level,
+            gpu_block_size=args.gpu_block_size,
+            fs_block_size=args.fs_block_size,
+            cpu_block_size=args.cpu_block_size,
+            threads_per_gpu=args.threads_per_gpu,
+        )
+    finally:
+        cleanup_storage_dir(args.storage_path)

--- a/kv_connectors/llmd_fs_backend/tests/performance/test_stress.py
+++ b/kv_connectors/llmd_fs_backend/tests/performance/test_stress.py
@@ -34,11 +34,15 @@ Default budget: batch=32, 10K tokens, 11 ratios, 5 iters, 1 repeat
 Metrics per (repeat, ratio): batch mean / p50 / p99, tokens/s, KV GB/s.
 
 Backends (--backend CLI / @pytest.parametrize):
-  - "base":         No offloading at all
-  - "gpu":          GPU prefix cache only
-  - "cpu":          CPU offloading only
-  - "fs":           Storage offloading only
-  - "multi-cpu-fs": MultiConnector chaining CPU + FS
+  - "base":              No offloading at all
+  - "gpu":               GPU prefix cache only
+  - "cpu":               CPU offloading only
+  - "storage":           Storage offloading only
+  - "multi-cpu-storage": MultiConnector chaining CPU + storage
+
+Storage implementation flavor (for "storage" / "multi-cpu-storage"):
+  - --storage-type fs (default, CPU staging)
+  - --storage-type gds (full read/write GPUDirect Storage)
 """
 
 import argparse
@@ -52,12 +56,14 @@ from vllm import LLM, SamplingParams, TokensPrompt
 from .utils import (
     BACKENDS,
     LOG_LEVELS,
+    STORAGE_TYPES,
     calculate_throughput_gb_s,
     cleanup_storage_dir,
     del_llm_and_cleanup,
     get_kv_transfer_config,
     quiet_vllm_logs,
     set_storage_log_level,
+    should_enable_prefix_caching,
     warmup_req,
 )
 
@@ -121,9 +127,11 @@ def run_stress_test(
     tensor_parallel_size: int = 1,
     storage_log_level: str | None = None,
     gpu_block_size: int = 16,
-    fs_block_size: int = 256,
+    storage_block_size: int = 256,
     cpu_block_size: int = 48,
     threads_per_gpu: int = 24,
+    with_gpu_prefix_cache: bool = False,
+    storage_type: str = "fs",
 ) -> tuple[float, float, float, float, float, float]:
     """
     Run a hot/cold-ratio sweep stress test (see module docstring).
@@ -161,9 +169,10 @@ def run_stress_test(
     kv_transfer_config = get_kv_transfer_config(
         backend=backend,
         storage_path=storage_path,
-        fs_block_size=fs_block_size,
+        storage_block_size=storage_block_size,
         cpu_block_size=cpu_block_size,
         threads_per_gpu=threads_per_gpu,
+        storage_type=storage_type,
     )
 
     llm = LLM(
@@ -172,8 +181,11 @@ def run_stress_test(
         kv_transfer_config=kv_transfer_config,
         max_model_len=num_tokens + 1000,
         seed=seed,
-        # "gpu" uses GPU prefix cache; "base" and offload backends bypass it.
-        enable_prefix_caching=(backend == "gpu"),
+        # "gpu" always on, "base" always off, offload backends opt-in
+        # via --with-gpu-prefix-cache. See should_enable_prefix_caching().
+        enable_prefix_caching=should_enable_prefix_caching(
+            backend, with_gpu_prefix_cache
+        ),
         tensor_parallel_size=tensor_parallel_size,
         block_size=gpu_block_size,
     )
@@ -295,7 +307,7 @@ def run_stress_test(
 # ---------------- pytest entry points ----------------
 
 
-@pytest.mark.parametrize("backend", ["fs"])
+@pytest.mark.parametrize("backend", ["storage"])
 @pytest.mark.parametrize("batch_size", [32])
 @pytest.mark.parametrize("model_name", ["Qwen/Qwen2.5-7B-Instruct"])
 def test_stress(
@@ -351,7 +363,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--backend",
         type=str,
-        default="fs",
+        default="storage",
         choices=BACKENDS,
         help=f"Backend to benchmark (one of {BACKENDS})",
     )
@@ -359,7 +371,7 @@ if __name__ == "__main__":
         "--storage-path",
         type=str,
         default="/tmp/fs_connector_stress",
-        help="Storage path for fs / multi-cpu-fs backends",
+        help="Storage path for storage / multi-cpu-storage tiers",
     )
     parser.add_argument("--model", type=str, default="Qwen/Qwen2.5-7B-Instruct")
     parser.add_argument("--batch-size", type=int, default=32)
@@ -399,29 +411,47 @@ if __name__ == "__main__":
         help="GPU KV cache block size (vLLM block_size)",
     )
     parser.add_argument(
-        "--fs-block-size",
+        "--storage-block-size",
         type=int,
         default=256,
-        help="fs_connector offloaded block_size (tokens per file)",
+        help="Storage tier offloaded block_size (tokens per file)",
     )
     parser.add_argument(
         "--cpu-block-size",
         type=int,
         default=48,
-        help="CPU offload block_size (for cpu / multi-cpu-fs backends)",
+        help="CPU offload block_size (for cpu / multi-cpu-storage tiers)",
     )
     parser.add_argument(
         "--threads-per-gpu",
         type=int,
         default=24,
-        help="I/O worker threads per GPU for fs backend (default 24)",
+        help="I/O worker threads per GPU for storage tier (default 24)",
+    )
+    parser.add_argument(
+        "--storage-type",
+        type=str,
+        default="fs",
+        choices=STORAGE_TYPES,
+        help=(
+            f"Storage implementation flavor (one of {STORAGE_TYPES}). "
+            "Only meaningful for --backend=storage / multi-cpu-storage."
+        ),
+    )
+    parser.add_argument(
+        "--with-gpu-prefix-cache",
+        action="store_true",
+        help=(
+            "Enable GPU prefix cache alongside the offload backend. "
+            "Ignored for 'gpu' (always on) and 'base' (always off)."
+        ),
     )
     parser.add_argument(
         "--log-level",
         type=str,
         default="info",
         choices=LOG_LEVELS,
-        help=f"Set STORAGE_LOG_LEVEL for fs_connector (one of {LOG_LEVELS})",
+        help=f"Set STORAGE_LOG_LEVEL for storage tier (one of {LOG_LEVELS})",
     )
     args = parser.parse_args()
 
@@ -444,9 +474,11 @@ if __name__ == "__main__":
             tensor_parallel_size=args.tp_size,
             storage_log_level=args.log_level,
             gpu_block_size=args.gpu_block_size,
-            fs_block_size=args.fs_block_size,
+            storage_block_size=args.storage_block_size,
             cpu_block_size=args.cpu_block_size,
             threads_per_gpu=args.threads_per_gpu,
+            with_gpu_prefix_cache=args.with_gpu_prefix_cache,
+            storage_type=args.storage_type,
         )
     finally:
         cleanup_storage_dir(args.storage_path)

--- a/kv_connectors/llmd_fs_backend/tests/performance/test_throughput.py
+++ b/kv_connectors/llmd_fs_backend/tests/performance/test_throughput.py
@@ -224,6 +224,11 @@ def test_throughput(
 # ---------------- standalone CLI ----------------
 
 if __name__ == "__main__":
+    # Example manual runs (see --help for the full flag list):
+    #   # Storage tier - default fs (use CPU staging)
+    #   python -m tests.performance.test_throughput --backend=storage
+    #   # CPU-only baseline
+    #   python -m tests.performance.test_throughput --backend=cpu
     parser = argparse.ArgumentParser(
         description="Run KV-offload throughput test (cold/hot/steady)."
     )

--- a/kv_connectors/llmd_fs_backend/tests/performance/test_throughput.py
+++ b/kv_connectors/llmd_fs_backend/tests/performance/test_throughput.py
@@ -1,0 +1,286 @@
+# Copyright 2026 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Performance test: KV-offloading backend sustained throughput
+(cold -> hot -> steady-state), mirroring vllm-offloading-tests/test_cold_hot_req.py.
+
+Measures:
+  - Cold latency (req 1): FS / CPU populate + full prefill
+  - Hot average    (req 2..N): reload from offload backend
+  - Last-10 avg:   steady-state latency
+  - Throughput (GB/s): KV-cache bytes / avg_time for the chosen model
+
+Backends (configurable via --backend CLI / @pytest.parametrize):
+  - "base":         No offloading at all
+  - "gpu":          GPU prefix cache only
+  - "cpu":          CPU offloading only
+  - "fs":           Storage offloading only
+  - "multi-cpu-fs": MultiConnector chaining CPU + FS
+"""
+
+import argparse
+import time
+
+import pytest
+from vllm import LLM, SamplingParams
+
+from .utils import (
+    BACKENDS,
+    LOG_LEVELS,
+    build_tokens_prompt,
+    calculate_throughput_gb_s,
+    cleanup_storage_dir,
+    del_llm_and_cleanup,
+    get_kv_transfer_config,
+    quiet_vllm_logs,
+    set_storage_log_level,
+    warmup_req,
+)
+
+
+def run_throughput_test(
+    model_name: str,
+    backend: str,
+    gpu_memory_utilization: float,
+    storage_path: str,
+    num_requests: int = 40,
+    num_tokens: int = 10000,
+    seed: int = 42,
+    tensor_parallel_size: int = 1,
+    storage_log_level: str | None = None,
+    gpu_block_size: int = 16,
+    fs_block_size: int = 256,
+    cpu_block_size: int = 48,
+    threads_per_gpu: int = 24,
+) -> tuple[float, float, float, float, float]:
+    """
+    Run sustained throughput test: cold -> hot -> steady-state.
+
+    Returns:
+        (cold_time, hot_avg, last_10_avg, total_time, throughput_gb_s)
+    """
+    print(f"\n===== Throughput Test: backend={backend} model={model_name} =====")
+    print(f"Requests: {num_requests}, Tokens/req: {num_tokens}")
+
+    # -------- Phase 1: Setup (config, LLM, warmup) --------
+    if storage_log_level:
+        set_storage_log_level(storage_log_level)
+
+    kv_transfer_config = get_kv_transfer_config(
+        backend=backend,
+        storage_path=storage_path,
+        fs_block_size=fs_block_size,
+        cpu_block_size=cpu_block_size,
+        threads_per_gpu=threads_per_gpu,
+    )
+
+    llm = LLM(
+        model=model_name,
+        gpu_memory_utilization=gpu_memory_utilization,
+        kv_transfer_config=kv_transfer_config,
+        max_model_len=num_tokens + 1000,
+        seed=seed,
+        # "gpu" baseline uses GPU prefix cache; offload backends bypass it
+        # so every request is forced through the offload path.
+        enable_prefix_caching=(backend == "gpu"),
+        tensor_parallel_size=tensor_parallel_size,
+        block_size=gpu_block_size,
+    )
+
+    quiet_vllm_logs()
+
+    sampling_params = SamplingParams(
+        detokenize=False,
+        ignore_eos=True,
+        seed=seed,
+        max_tokens=1,
+    )
+
+    prompt = build_tokens_prompt(num_tokens)
+
+    warmup_req(llm, sampling_params)
+
+    # -------- Phase 2: Run cold -> hot test --------
+    times = []
+    print(f"[INFO] Running {num_requests} requests...")
+    for i in range(num_requests):
+        t0 = time.perf_counter()
+        outputs = llm.generate([prompt], sampling_params, use_tqdm=False)
+        dt = time.perf_counter() - t0
+        times.append(dt)
+        print(f"  [{i + 1:3d}] {dt:.3f}s")
+
+    # -------- Phase 3: Print results --------
+    cold_time = times[0]
+    hot_avg = sum(times[1:]) / (len(times) - 1) if len(times) > 1 else 0.0
+    total_time = sum(times)
+    last_10 = times[-10:] if len(times) >= 10 else times
+    last_10_avg = sum(last_10) / len(last_10)
+
+    # Throughput (GB/s) based on KV bytes per token of the chosen model.
+    # Computed against the steady-state avg (last-10) for a representative value.
+    throughput_gb_s = calculate_throughput_gb_s(model_name, num_tokens, last_10_avg)
+
+    # Print the summary block: cold / hot / steady-state latencies + KV GB/s.
+    input_tokens = len(outputs[0].prompt_token_ids)
+    print(f"\n[RESULTS] backend={backend}  model={model_name}")
+    print(f"  Input tokens: {input_tokens}")
+    print(f"  Cold (req 1):          {cold_time:.3f}s")
+    print(f"  Hot avg (req 2..{num_requests}):   {hot_avg:.3f}s")
+    print(f"  Last-10 avg:           {last_10_avg:.3f}s")
+    print(f"  Total ({num_requests} reqs):       {total_time:.3f}s")
+    if throughput_gb_s > 0:
+        print(f"  Throughput (KV):       {throughput_gb_s:.2f} GB/s")
+    else:
+        print(f"  Throughput (KV):       NA (unknown model '{model_name}')")
+
+    # Warn if steady-state (last-10) is >10% slower than hot_avg — signals
+    # possible memory leak, FS fragmentation, or page-cache churn.
+    degradation_pct = (last_10_avg - hot_avg) / hot_avg * 100 if hot_avg > 0 else 0
+    if degradation_pct > 10:
+        print(f"  [WARN] Steady-state degradation: {degradation_pct:.1f}%")
+
+    del_llm_and_cleanup(llm)
+    return cold_time, hot_avg, last_10_avg, total_time, throughput_gb_s
+
+
+# ---------------- pytest entry points ----------------
+
+
+# Default parameterization: fs backend only (primary target of these tests).
+# Run other backends by passing --backend via CLI (see __main__) or by
+# extending the parametrize list below.
+@pytest.mark.parametrize("backend", ["fs"])
+@pytest.mark.parametrize("num_requests", [40])
+# (model_name, num_tokens) pairs - num_tokens sized to each model's max context.
+@pytest.mark.parametrize(
+    "model_name,num_tokens",
+    [
+        ("Qwen/Qwen3-0.6B", 31000),  # ~32K ctx
+        ("meta-llama/Llama-3.2-1B-Instruct", 31000),  # 128K ctx (keep small for speed)
+        ("Qwen/Qwen2.5-7B-Instruct", 31000),  # 32K ctx
+        ("meta-llama/Meta-Llama-3.1-8B-Instruct", 128000),  # 128K ctx
+    ],
+    ids=["qwen3-0.6b", "llama-3.2-1b", "qwen2.5-7b", "llama-3.1-8b"],
+)
+def test_throughput(
+    storage_path: str,
+    backend: str,
+    model_name: str,
+    num_requests: int,
+    num_tokens: int,
+):
+    """
+    Sustained throughput test for the selected backend.
+
+    Verifies:
+      - Hot (reload) is faster than cold (populate)
+      - Steady-state does not degrade by >20% vs hot avg
+    """
+    cold, hot_avg, last_10_avg, _total, _tput = run_throughput_test(
+        model_name=model_name,
+        backend=backend,
+        gpu_memory_utilization=0.5,
+        storage_path=storage_path,
+        num_requests=num_requests,
+        num_tokens=num_tokens,
+    )
+
+    assert hot_avg < cold, (
+        f"Hot latency ({hot_avg:.3f}s) should be faster than cold ({cold:.3f}s). "
+        "Offload reload path did not help vs cold populate."
+    )
+
+    degradation = (last_10_avg - hot_avg) / hot_avg if hot_avg > 0 else 0
+    assert degradation < 0.20, (
+        f"Steady-state degradation too high: {degradation * 100:.1f}% "
+        "(possible memory leak or fragmentation)."
+    )
+
+
+# ---------------- standalone CLI ----------------
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Run KV-offload throughput test (cold/hot/steady)."
+    )
+    parser.add_argument(
+        "--backend",
+        type=str,
+        default="fs",
+        choices=BACKENDS,
+        help=f"Backend to benchmark (one of {BACKENDS})",
+    )
+    parser.add_argument(
+        "--storage-path",
+        type=str,
+        default="/tmp/fs_connector_perf",
+        help="Storage path for fs / multi-fs-cpu backends",
+    )
+    parser.add_argument("--model", type=str, default="Qwen/Qwen2.5-7B-Instruct")
+    parser.add_argument("--num-requests", type=int, default=40)
+    parser.add_argument("--num-tokens", type=int, default=31000)
+    parser.add_argument("--gpu-mem-util", type=float, default=0.85)
+    parser.add_argument("--tp-size", type=int, default=1, help="Tensor parallel size")
+    parser.add_argument(
+        "--gpu-block-size",
+        type=int,
+        default=16,
+        help="GPU KV cache block size (vLLM block_size)",
+    )
+    parser.add_argument(
+        "--fs-block-size",
+        type=int,
+        default=256,
+        help="fs_connector offloaded block_size (tokens per file)",
+    )
+    parser.add_argument(
+        "--cpu-block-size",
+        type=int,
+        default=48,
+        help="CPU offload block_size (for cpu / multi-fs-cpu backends)",
+    )
+    parser.add_argument(
+        "--threads-per-gpu",
+        type=int,
+        default=64,
+        help="I/O worker threads per GPU for fs backend (default 24)",
+    )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="info",
+        choices=LOG_LEVELS,
+        help=f"Set STORAGE_LOG_LEVEL for fs_connector (one of {LOG_LEVELS})",
+    )
+    args = parser.parse_args()
+
+    try:
+        run_throughput_test(
+            model_name=args.model,
+            backend=args.backend,
+            gpu_memory_utilization=args.gpu_mem_util,
+            storage_path=args.storage_path,
+            num_requests=args.num_requests,
+            num_tokens=args.num_tokens,
+            tensor_parallel_size=args.tp_size,
+            storage_log_level=args.log_level,
+            gpu_block_size=args.gpu_block_size,
+            fs_block_size=args.fs_block_size,
+            cpu_block_size=args.cpu_block_size,
+            threads_per_gpu=args.threads_per_gpu,
+        )
+    finally:
+        cleanup_storage_dir(args.storage_path)

--- a/kv_connectors/llmd_fs_backend/tests/performance/test_throughput.py
+++ b/kv_connectors/llmd_fs_backend/tests/performance/test_throughput.py
@@ -23,11 +23,15 @@ Measures:
   - Throughput (GB/s): KV-cache bytes / avg_time for the chosen model
 
 Backends (configurable via --backend CLI / @pytest.parametrize):
-  - "base":         No offloading at all
-  - "gpu":          GPU prefix cache only
-  - "cpu":          CPU offloading only
-  - "fs":           Storage offloading only
-  - "multi-cpu-fs": MultiConnector chaining CPU + FS
+  - "base":              No offloading at all
+  - "gpu":               GPU prefix cache only
+  - "cpu":               CPU offloading only
+  - "storage":           Storage offloading only
+  - "multi-cpu-storage": MultiConnector chaining CPU + storage
+
+Storage implementation flavor (for "storage" / "multi-cpu-storage"):
+  - --storage-type fs (default, CPU staging)
+  - --storage-type gds (full read/write GPUDirect Storage)
 """
 
 import argparse
@@ -39,6 +43,7 @@ from vllm import LLM, SamplingParams
 from .utils import (
     BACKENDS,
     LOG_LEVELS,
+    STORAGE_TYPES,
     build_tokens_prompt,
     calculate_throughput_gb_s,
     cleanup_storage_dir,
@@ -46,6 +51,7 @@ from .utils import (
     get_kv_transfer_config,
     quiet_vllm_logs,
     set_storage_log_level,
+    should_enable_prefix_caching,
     warmup_req,
 )
 
@@ -61,9 +67,11 @@ def run_throughput_test(
     tensor_parallel_size: int = 1,
     storage_log_level: str | None = None,
     gpu_block_size: int = 16,
-    fs_block_size: int = 256,
+    storage_block_size: int = 256,
     cpu_block_size: int = 48,
     threads_per_gpu: int = 24,
+    with_gpu_prefix_cache: bool = False,
+    storage_type: str = "fs",
 ) -> tuple[float, float, float, float, float]:
     """
     Run sustained throughput test: cold -> hot -> steady-state.
@@ -81,9 +89,10 @@ def run_throughput_test(
     kv_transfer_config = get_kv_transfer_config(
         backend=backend,
         storage_path=storage_path,
-        fs_block_size=fs_block_size,
+        storage_block_size=storage_block_size,
         cpu_block_size=cpu_block_size,
         threads_per_gpu=threads_per_gpu,
+        storage_type=storage_type,
     )
 
     llm = LLM(
@@ -92,9 +101,11 @@ def run_throughput_test(
         kv_transfer_config=kv_transfer_config,
         max_model_len=num_tokens + 1000,
         seed=seed,
-        # "gpu" baseline uses GPU prefix cache; offload backends bypass it
-        # so every request is forced through the offload path.
-        enable_prefix_caching=(backend == "gpu"),
+        # "gpu" always on, "base" always off, offload backends opt-in
+        # via --with-gpu-prefix-cache. See should_enable_prefix_caching().
+        enable_prefix_caching=should_enable_prefix_caching(
+            backend, with_gpu_prefix_cache
+        ),
         tensor_parallel_size=tensor_parallel_size,
         block_size=gpu_block_size,
     )
@@ -159,10 +170,10 @@ def run_throughput_test(
 # ---------------- pytest entry points ----------------
 
 
-# Default parameterization: fs backend only (primary target of these tests).
+# Default parameterization: storage tier only (primary target of these tests).
 # Run other backends by passing --backend via CLI (see __main__) or by
 # extending the parametrize list below.
-@pytest.mark.parametrize("backend", ["fs"])
+@pytest.mark.parametrize("backend", ["storage"])
 @pytest.mark.parametrize("num_requests", [40])
 # (model_name, num_tokens) pairs - num_tokens sized to each model's max context.
 @pytest.mark.parametrize(
@@ -219,7 +230,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--backend",
         type=str,
-        default="fs",
+        default="storage",
         choices=BACKENDS,
         help=f"Backend to benchmark (one of {BACKENDS})",
     )
@@ -227,7 +238,7 @@ if __name__ == "__main__":
         "--storage-path",
         type=str,
         default="/tmp/fs_connector_perf",
-        help="Storage path for fs / multi-fs-cpu backends",
+        help="Storage path for storage / multi-cpu-storage tiers",
     )
     parser.add_argument("--model", type=str, default="Qwen/Qwen2.5-7B-Instruct")
     parser.add_argument("--num-requests", type=int, default=40)
@@ -241,29 +252,47 @@ if __name__ == "__main__":
         help="GPU KV cache block size (vLLM block_size)",
     )
     parser.add_argument(
-        "--fs-block-size",
+        "--storage-block-size",
         type=int,
         default=256,
-        help="fs_connector offloaded block_size (tokens per file)",
+        help="Storage tier offloaded block_size (tokens per file)",
     )
     parser.add_argument(
         "--cpu-block-size",
         type=int,
         default=48,
-        help="CPU offload block_size (for cpu / multi-fs-cpu backends)",
+        help="CPU offload block_size (for cpu / multi-cpu-storage tiers)",
     )
     parser.add_argument(
         "--threads-per-gpu",
         type=int,
         default=64,
-        help="I/O worker threads per GPU for fs backend (default 24)",
+        help="I/O worker threads per GPU for storage tier (default 24)",
+    )
+    parser.add_argument(
+        "--storage-type",
+        type=str,
+        default="fs",
+        choices=STORAGE_TYPES,
+        help=(
+            f"Storage implementation flavor (one of {STORAGE_TYPES}). "
+            "Only meaningful for --backend=storage / multi-cpu-storage."
+        ),
+    )
+    parser.add_argument(
+        "--with-gpu-prefix-cache",
+        action="store_true",
+        help=(
+            "Enable GPU prefix cache alongside the offload backend. "
+            "Ignored for 'gpu' (always on) and 'base' (always off)."
+        ),
     )
     parser.add_argument(
         "--log-level",
         type=str,
         default="info",
         choices=LOG_LEVELS,
-        help=f"Set STORAGE_LOG_LEVEL for fs_connector (one of {LOG_LEVELS})",
+        help=f"Set STORAGE_LOG_LEVEL for storage tier (one of {LOG_LEVELS})",
     )
     args = parser.parse_args()
 
@@ -278,9 +307,11 @@ if __name__ == "__main__":
             tensor_parallel_size=args.tp_size,
             storage_log_level=args.log_level,
             gpu_block_size=args.gpu_block_size,
-            fs_block_size=args.fs_block_size,
+            storage_block_size=args.storage_block_size,
             cpu_block_size=args.cpu_block_size,
             threads_per_gpu=args.threads_per_gpu,
+            with_gpu_prefix_cache=args.with_gpu_prefix_cache,
+            storage_type=args.storage_type,
         )
     finally:
         cleanup_storage_dir(args.storage_path)

--- a/kv_connectors/llmd_fs_backend/tests/performance/utils.py
+++ b/kv_connectors/llmd_fs_backend/tests/performance/utils.py
@@ -46,7 +46,10 @@ def set_storage_log_level(level: str) -> None:
 
 
 # Supported backend choices for parameterized tests / CLI runs.
-BACKENDS = ("base", "gpu", "cpu", "fs", "multi-cpu-fs")
+BACKENDS = ("base", "gpu", "cpu", "storage", "multi-cpu-storage")
+
+# Storage implementation flavors (only used by "storage" / "multi-cpu-storage").
+STORAGE_TYPES = ("fs", "gds")
 
 # Per-token KV cache size (bytes) for known models. Used to compute GB/s.
 # Formula: layers × kv_heads × head_dim × 2 (K+V) × dtype_bytes (bf16 = 2)
@@ -83,29 +86,30 @@ def get_kv_transfer_config(
     backend: str,
     storage_path: str | None = None,
     cpu_bytes_to_use: int = 4 << 30,  # 4 GiB CPU cache
-    fs_block_size: int = 256,
+    storage_block_size: int = 256,
     cpu_block_size: int = 48,
     threads_per_gpu: int = 24,
     max_staging_memory_gb: int = 150,
-    gds_mode: str = "disabled",
+    storage_type: str = "fs",
 ) -> KVTransferConfig | None:
     """
     Build a KVTransferConfig for the specified backend.
 
     Args:
         backend: One of BACKENDS:
-                   - "base":         No offloading at all
-                   - "gpu":          GPU prefix cache only
-                   - "cpu":          CPU offloading only
-                   - "fs":           Storage offloading only
-                   - "multi-cpu-fs": MultiConnector chaining CPU + FS
-        storage_path: Filesystem path for "fs" / "multi-cpu-fs" backends.
-        cpu_bytes_to_use: CPU cache size in bytes for "cpu" / "multi-cpu-fs".
-        fs_block_size: Block size for fs backend.
+                   - "base":              No offloading at all
+                   - "gpu":               GPU prefix cache only
+                   - "cpu":               CPU offloading only
+                   - "storage":           Storage offloading only
+                   - "multi-cpu-storage": MultiConnector chaining CPU + storage
+        storage_path: Filesystem path for "storage" / "multi-cpu-storage".
+        cpu_bytes_to_use: CPU cache size in bytes for "cpu" / "multi-cpu-storage".
+        storage_block_size: Block size for the storage tier.
         cpu_block_size: Block size for cpu backend.
-        threads_per_gpu: I/O worker count for fs backend.
-        max_staging_memory_gb: Max CPU staging buffer for fs backend.
-        gds_mode: GDS mode for fs backend (disabled / read_only / ...).
+        threads_per_gpu: I/O worker count for the storage tier.
+        max_staging_memory_gb: Max CPU staging buffer for the storage tier.
+        storage_type: Storage implementation flavor — "fs" (default, CPU
+            staging) or "gds" (full read/write GPUDirect Storage).
 
     Returns:
         A KVTransferConfig, or None if backend is "base" or "gpu".
@@ -118,9 +122,11 @@ def get_kv_transfer_config(
     if backend in ("base", "gpu"):
         return None
 
-    if backend == "fs":
+    gds_mode = "read_write" if storage_type == "gds" else "disabled"
+
+    if backend == "storage":
         if storage_path is None:
-            raise ValueError("backend='fs' requires storage_path")
+            raise ValueError("backend='storage' requires storage_path")
         return KVTransferConfig(
             kv_connector="OffloadingConnector",
             kv_role="kv_both",
@@ -129,7 +135,7 @@ def get_kv_transfer_config(
                 "spec_module_path": "llmd_fs_backend.spec",
                 "shared_storage_path": storage_path,
                 "threads_per_gpu": threads_per_gpu,
-                "block_size": fs_block_size,
+                "block_size": storage_block_size,
                 "max_staging_memory_gb": max_staging_memory_gb,
                 "gds_mode": gds_mode,
                 "read_preferring_ratio": 0.75,
@@ -146,9 +152,9 @@ def get_kv_transfer_config(
             },
         )
 
-    if backend == "multi-cpu-fs":
+    if backend == "multi-cpu-storage":
         if storage_path is None:
-            raise ValueError("backend='multi-cpu-fs' requires storage_path")
+            raise ValueError("backend='multi-cpu-storage' requires storage_path")
         return KVTransferConfig(
             kv_connector="MultiConnector",
             kv_role="kv_both",
@@ -170,7 +176,7 @@ def get_kv_transfer_config(
                             "spec_module_path": "llmd_fs_backend.spec",
                             "shared_storage_path": storage_path,
                             "threads_per_gpu": threads_per_gpu,
-                            "block_size": fs_block_size,
+                            "block_size": storage_block_size,
                             "max_staging_memory_gb": max_staging_memory_gb,
                             "gds_mode": gds_mode,
                         },
@@ -180,6 +186,23 @@ def get_kv_transfer_config(
         )
 
     raise ValueError(f"Unknown backend '{backend}'. Expected one of {BACKENDS}.")
+
+
+def should_enable_prefix_caching(backend: str, with_gpu_prefix_cache: bool) -> bool:
+    """
+    Decide whether vLLM's GPU prefix caching should be enabled.
+
+    - "gpu"  -> always True  (the whole point of this baseline)
+    - "base" -> always False (no caching at all, by definition)
+    - offload backends (cpu/storage/multi-cpu-storage) -> opt-in via flag
+      (useful to benchmark GPU-cache + offload together, e.g. to check
+       whether the connector steals too much GPU memory from the cache).
+    """
+    if backend == "gpu":
+        return True
+    if backend == "base":
+        return False
+    return with_gpu_prefix_cache
 
 
 def calculate_throughput_gb_s(

--- a/kv_connectors/llmd_fs_backend/tests/performance/utils.py
+++ b/kv_connectors/llmd_fs_backend/tests/performance/utils.py
@@ -1,0 +1,271 @@
+# Copyright 2025 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Shared helpers for the fs_connector performance/stress tests:
+prompt construction, backend KVTransferConfig builder, KV-throughput math,
+storage log-level setup, and LLM/storage cleanup.
+"""
+
+import gc
+import logging
+import os
+import shutil
+
+from vllm import TokensPrompt
+from vllm.config import KVTransferConfig
+
+# Valid STORAGE_LOG_LEVEL values (applies to both C++ and Python sides).
+LOG_LEVELS = ("trace", "debug", "info", "warn", "error")
+
+
+def set_storage_log_level(level: str) -> None:
+    """
+    Set the fs_connector storage log level via STORAGE_LOG_LEVEL env var.
+    Must be called BEFORE LLM() / connector import so the C++ side reads it.
+    """
+    level = level.lower()
+    if level not in LOG_LEVELS:
+        raise ValueError(f"Unknown log level '{level}'. Expected one of {LOG_LEVELS}.")
+    os.environ["STORAGE_LOG_LEVEL"] = level
+    print(f"[INFO] STORAGE_LOG_LEVEL={level}")
+    # Legacy flag: some code paths still check STORAGE_CONNECTOR_DEBUG.
+    if level in ("trace", "debug"):
+        os.environ["STORAGE_CONNECTOR_DEBUG"] = "1"
+
+
+# Supported backend choices for parameterized tests / CLI runs.
+BACKENDS = ("base", "gpu", "cpu", "fs", "multi-cpu-fs")
+
+# Per-token KV cache size (bytes) for known models. Used to compute GB/s.
+# Formula: layers × kv_heads × head_dim × 2 (K+V) × dtype_bytes (bf16 = 2)
+KV_BYTES_PER_TOKEN = {
+    "Qwen/Qwen3-0.6B": 28 * 8 * 128 * 2 * 2,  # 114,688
+    "Qwen/Qwen2.5-1.5B-Instruct": 28 * 2 * 128 * 2 * 2,  # 28,672
+    "Qwen/Qwen2.5-3B-Instruct": 36 * 2 * 128 * 2 * 2,  # 36,864
+    "Qwen/Qwen2.5-7B-Instruct": 28 * 4 * 128 * 2 * 2,  # 57,344
+    "meta-llama/Meta-Llama-3.1-8B-Instruct": 32 * 8 * 128 * 2 * 2,  # 131,072
+    "meta-llama/Llama-3.2-1B-Instruct": 16 * 8 * 64 * 2 * 2,  # 32,768
+    "meta-llama/Meta-Llama-3.1-70B": 80 * 8 * 128 * 2 * 2,  # 327,680
+}
+
+
+def build_tokens_prompt(
+    num_tokens: int, prefix_id: int = 1, fill_id: int = 2
+) -> TokensPrompt:
+    """
+    Build a TokensPrompt directly from token IDs without using a tokenizer.
+
+    Args:
+        num_tokens: Total number of tokens in the prompt.
+        prefix_id: Token ID for the first token (default: 1).
+        fill_id:   Token ID used for the rest of the prompt (default: 2).
+
+    Returns:
+        TokensPrompt with the specified token IDs.
+    """
+    prompt_token_ids = [prefix_id] + [fill_id] * (num_tokens - 1)
+    return TokensPrompt(prompt_token_ids=prompt_token_ids)
+
+
+def get_kv_transfer_config(
+    backend: str,
+    storage_path: str | None = None,
+    cpu_bytes_to_use: int = 4 << 30,  # 4 GiB CPU cache
+    fs_block_size: int = 256,
+    cpu_block_size: int = 48,
+    threads_per_gpu: int = 24,
+    max_staging_memory_gb: int = 150,
+    gds_mode: str = "disabled",
+) -> KVTransferConfig | None:
+    """
+    Build a KVTransferConfig for the specified backend.
+
+    Args:
+        backend: One of BACKENDS:
+                   - "base":         No offloading at all
+                   - "gpu":          GPU prefix cache only
+                   - "cpu":          CPU offloading only
+                   - "fs":           Storage offloading only
+                   - "multi-cpu-fs": MultiConnector chaining CPU + FS
+        storage_path: Filesystem path for "fs" / "multi-cpu-fs" backends.
+        cpu_bytes_to_use: CPU cache size in bytes for "cpu" / "multi-cpu-fs".
+        fs_block_size: Block size for fs backend.
+        cpu_block_size: Block size for cpu backend.
+        threads_per_gpu: I/O worker count for fs backend.
+        max_staging_memory_gb: Max CPU staging buffer for fs backend.
+        gds_mode: GDS mode for fs backend (disabled / read_only / ...).
+
+    Returns:
+        A KVTransferConfig, or None if backend is "base" or "gpu".
+
+    Raises:
+        ValueError: on an unknown backend.
+    """
+    # "base" (no offload, no prefix cache) and "gpu" (no offload, GPU prefix
+    # cache enabled in the caller) both skip the KVTransferConfig entirely.
+    if backend in ("base", "gpu"):
+        return None
+
+    if backend == "fs":
+        if storage_path is None:
+            raise ValueError("backend='fs' requires storage_path")
+        return KVTransferConfig(
+            kv_connector="OffloadingConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={
+                "spec_name": "SharedStorageOffloadingSpec",
+                "spec_module_path": "llmd_fs_backend.spec",
+                "shared_storage_path": storage_path,
+                "threads_per_gpu": threads_per_gpu,
+                "block_size": fs_block_size,
+                "max_staging_memory_gb": max_staging_memory_gb,
+                "gds_mode": gds_mode,
+                "read_preferring_ratio": 0.75,
+            },
+        )
+
+    if backend == "cpu":
+        return KVTransferConfig(
+            kv_connector="OffloadingConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={
+                "cpu_bytes_to_use": cpu_bytes_to_use,
+                "block_size": cpu_block_size,
+            },
+        )
+
+    if backend == "multi-cpu-fs":
+        if storage_path is None:
+            raise ValueError("backend='multi-cpu-fs' requires storage_path")
+        return KVTransferConfig(
+            kv_connector="MultiConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={
+                "connectors": [
+                    {
+                        "kv_connector": "OffloadingConnector",
+                        "kv_role": "kv_both",
+                        "kv_connector_extra_config": {
+                            "cpu_bytes_to_use": cpu_bytes_to_use,
+                            "block_size": cpu_block_size,
+                        },
+                    },
+                    {
+                        "kv_connector": "OffloadingConnector",
+                        "kv_role": "kv_both",
+                        "kv_connector_extra_config": {
+                            "spec_name": "SharedStorageOffloadingSpec",
+                            "spec_module_path": "llmd_fs_backend.spec",
+                            "shared_storage_path": storage_path,
+                            "threads_per_gpu": threads_per_gpu,
+                            "block_size": fs_block_size,
+                            "max_staging_memory_gb": max_staging_memory_gb,
+                            "gds_mode": gds_mode,
+                        },
+                    },
+                ],
+            },
+        )
+
+    raise ValueError(f"Unknown backend '{backend}'. Expected one of {BACKENDS}.")
+
+
+def calculate_throughput_gb_s(
+    model_name: str, num_tokens: int, avg_time: float
+) -> float:
+    """
+    Compute KV-cache throughput in GB/s.
+
+    Throughput = (num_tokens × kv_bytes_per_token) / avg_time.
+    For unknown models returns 0.0 (caller should print NA).
+
+    Args:
+        model_name: HF model identifier.
+        num_tokens: Tokens transferred per request.
+        avg_time:   Average time per request (seconds).
+
+    Returns:
+        Throughput in GiB/s, or 0.0 if the model is unknown.
+    """
+    if avg_time <= 0:
+        return 0.0
+    bytes_per_token = KV_BYTES_PER_TOKEN.get(model_name, 0)
+    if bytes_per_token == 0:
+        return 0.0
+    total_bytes = num_tokens * bytes_per_token
+    return (total_bytes / avg_time) / (1 << 30)  # GiB/s
+
+
+def del_llm_and_cleanup(llm) -> None:
+    """
+    Release the LLM, collect garbage, empty CUDA cache and tear down the
+    torch.distributed process group if initialized.
+
+    Mirrors vllm-offloading-tests/tests/test_utils.py:del_llm_and_cleanup so
+    multiple LLM runs in the same process don't leak GPU memory.
+    """
+    try:
+        del llm
+        gc.collect()
+
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+                torch.cuda.synchronize()
+
+            import torch.distributed as dist
+
+            if dist.is_initialized():
+                dist.destroy_process_group()
+                print("[INFO] torch.distributed process group destroyed.")
+        except ImportError:
+            pass
+    except Exception as e:
+        print(f"[WARN] Cleanup failed: {e}")
+
+
+def cleanup_storage_dir(path: str | None) -> None:
+    """Remove a storage directory if it exists (CLI cleanup helper)."""
+    if not path:
+        return
+    if os.path.exists(path):
+        try:
+            shutil.rmtree(path)
+            print(f"[CLEANUP] Finish Removed {path}")
+        except Exception as e:
+            print(f"[CLEANUP] Failed to remove {path}: {e}")
+
+
+def quiet_vllm_logs() -> None:
+    """
+    Silence vLLM's INFO-level inference-loop logs so per-iteration test
+    output stays readable. Model-load / init logs still show.
+    """
+    logging.getLogger("vllm").setLevel(logging.WARNING)
+    logging.getLogger("vllm.engine").setLevel(logging.WARNING)
+
+
+def warmup_req(llm, sampling_params) -> None:
+    """
+    Run a tiny 10-token prompt so model/compile paths are warm but the
+    offload backend is NOT populated with any of the test prompts.
+    Uses distinct prefix/fill token IDs (999 / 998) to avoid any hash
+    overlap with the real test prompts.
+    """
+    warmup_prompt = build_tokens_prompt(10, prefix_id=999, fill_id=998)
+    print("[INFO] Warming up model (10-token prompt)...")
+    llm.generate([warmup_prompt], sampling_params, use_tqdm=False)


### PR DESCRIPTION
## Summary

Adds a `tests/performance/` suite for benchmarking the fs_connector and
comparing against the other KV-offload backends (base / gpu / cpu / fs /
multi-cpu-fs). Two complementary entry points share a small `utils.py`.

## Tests

### `test_throughput.py` — sustained cold → hot → steady-state
Runs N sequential requests of a fixed prompt through the chosen backend
and reports:
- **Cold (req 1):** full prefill + backend populate
- **Hot avg (req 2..N):** reload from offload backend
- **Last-10 avg:** steady-state latency
- **Throughput (KV GB/s):** `(num_tokens × KV_bytes_per_token) / last_10_avg`

### `test_stress.py` — batched hot/cold ratio sweep
Each `llm.generate()` call submits `batch_size` prompts mixed by
`hot_ratio`:
- `ratio = 0.0` → all cold (pure write stress)
- `ratio = 1.0` → all hot (pure read stress)
- in between → mix exercising the scheduler's `read_preferring_ratio`

Default sweep: `hot_ratios = [0.0, 0.1, ..., 1.0]` × 5 iters each. Set
`--num-repeats=N>=2` to repeat the full sweep against a growing FS pool
to surface drift / fragmentation.

Reports per `(repeat, ratio)`: mean / p50 / p99 latency, tokens/s, KV GB/s.

## Configuration

Both tests accept the same knobs (CLI flags + pytest `conftest.py` options):

| Flag | Default | Notes |
|------|---------|-------|
| `--backend` | `fs` | `base` / `gpu` / `cpu` / `fs` / `multi-cpu-fs` |
| `--model` | `Qwen/Qwen2.5-7B-Instruct` | HF model id |
| `--num-tokens` | 31000 / 10000 | per-request token count |
| `--num-requests` / `--num-iterations` | 40 / 5 | sequential (throughput) / per-ratio (stress) |
| `--tp-size` | 1 | tensor parallel |
| `--gpu-block-size` / `--fs-block-size` / `--cpu-block-size` | 16 / 256 / 48 | |
| `--threads-per-gpu` | 24 | fs I/O workers |
| `--log-level` | `info` | `STORAGE_LOG_LEVEL` |
| `--storage-root` / `\$FS_CONNECTOR_STORAGE_ROOT` | `/tmp` | pytest option |
| `--hot-ratios` / `--num-repeats` | sweep / 1 | stress-only |

## Makefile

- `make test` — unit tests (excludes `./tests/performance`)
- `make test-performance` — new: runs the throughput + stress pytest suite

## Test plan

- [x] `make test-performance` passes on an 80GB H100 node (3m19s)
  - throughput across Qwen3-0.6B, Llama-3.2-1B, Qwen2.5-7B @ 31K tokens,
    Llama-3.1-8B @ 128K tokens — all assertions pass (hot < cold, steady
    degradation < 20%, p99 < 10s, tail < 5s)
  - stress sweep on Qwen2.5-7B (batch=32, 3 ratios, 2 iters)
- [x] Sanity: all 5 backends (`base`, `gpu`, `cpu`, `fs`, `multi-cpu-fs`)
  work for both tests on Qwen3-0.6B — no deadlocks, no duplicated
  Prometheus registrations, clean `[CLEANUP]` output