### PR TITLE
Added new model registry

### DIFF
--- a/pkg/kvcache/backend.go
+++ b/pkg/kvcache/backend.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package kvcache
 
+import "sync"
+
 type KVCacheBackendConfig struct {
 	// Name is the identifier for this medium (e.g., "gpu", "cpu", "disk")
 	Name string `json:"name"`
@@ -28,4 +30,185 @@ func DefaultKVCacheBackendConfig() []*KVCacheBackendConfig {
 		{Name: "gpu", Weight: 1.0},
 		{Name: "cpu", Weight: 0.8},
 	}
+}
+
+// AttentionType defines the type of attention mechanism used by an attention group.
+type AttentionType string
+
+const (
+	// AttentionTypeFull represents full/global attention (attends to all previous tokens).
+	AttentionTypeFull AttentionType = "full"
+	// AttentionTypeSlidingWindow represents sliding window attention (attends to last N tokens).
+	AttentionTypeSlidingWindow AttentionType = "sliding_window"
+	// AttentionTypeLocal represents local attention (attends to nearby tokens only).
+	AttentionTypeLocal AttentionType = "local"
+)
+
+// AttentionGroupConfig holds configuration for a single attention group in HMA models.
+type AttentionGroupConfig struct {
+	// GroupID is the attention group identifier (e.g., 0 for full attention, 1 for sliding window)
+	GroupID int `json:"groupId"`
+	// AttentionType specifies the type of attention mechanism
+	AttentionType AttentionType `json:"attentionType"`
+	// BlockSize is the number of tokens per KV-cache block for this group
+	BlockSize int `json:"blockSize"`
+	// SlidingWindowSize is the window size for sliding window attention (0 or omitted for full attention)
+	SlidingWindowSize int `json:"slidingWindowSize,omitempty"`
+}
+
+// ModelConfig holds the configuration for a specific model.
+type ModelConfig struct {
+	// Name is the model identifier (e.g., "Qwen/Qwen3-8B", "DeepSeek-V3")
+	Name string `json:"name"`
+	// IsHMA indicates whether this model uses Hybrid Multi-head Attention.
+	// When true, StoredGroups tracking is enabled for cache entries (non-zero bitmask).
+	// When false, StoredGroups is left 0 to save memory.
+	IsHMA bool `json:"isHMA"`
+	// AttentionGroups defines the attention group configuration for HMA models.
+	// Only used when IsHMA is true.
+	// Example for DeepSeek-V3:
+	//   [{GroupID: 0, BlockSize: 64, SlidingWindowSize: 0},       // Full attention
+	//    {GroupID: 1, BlockSize: 64, SlidingWindowSize: 4096}]    // Sliding window
+	AttentionGroups []AttentionGroupConfig `json:"attentionGroups,omitempty"`
+}
+
+// ModelAttentionInfo holds precomputed attention group metadata for scoring.
+type ModelAttentionInfo struct {
+	FullGroupID     int
+	SWAGroupIDs     []int
+	SWAWindowBlocks []int
+}
+
+func cdiv(a, b int) int {
+	return (a + b - 1) / b
+}
+
+func buildAttentionInfo(config *ModelConfig) *ModelAttentionInfo {
+	if !config.IsHMA {
+		return nil
+	}
+	info := &ModelAttentionInfo{FullGroupID: -1}
+	for _, group := range config.AttentionGroups {
+		switch group.AttentionType {
+		case AttentionTypeFull:
+			info.FullGroupID = group.GroupID
+		case AttentionTypeSlidingWindow:
+			if group.BlockSize > 0 && group.SlidingWindowSize > 0 {
+				info.SWAGroupIDs = append(info.SWAGroupIDs, group.GroupID)
+				info.SWAWindowBlocks = append(info.SWAWindowBlocks, cdiv(group.SlidingWindowSize-1, group.BlockSize))
+			}
+		}
+	}
+	if info.FullGroupID < 0 || len(info.SWAWindowBlocks) == 0 {
+		return nil
+	}
+	return info
+}
+
+// ModelRegistry manages model configurations.
+// It provides thread-safe access to model metadata needed for event processing.
+type ModelRegistry struct {
+	mu            sync.RWMutex
+	configs       map[string]*ModelConfig
+	attentionInfo map[string]*ModelAttentionInfo
+}
+
+// NewModelRegistry creates a new ModelRegistry with optional initial configs.
+func NewModelRegistry(initialConfigs []*ModelConfig) *ModelRegistry {
+	registry := &ModelRegistry{
+		configs:       make(map[string]*ModelConfig),
+		attentionInfo: make(map[string]*ModelAttentionInfo),
+	}
+
+	for _, config := range initialConfigs {
+		registry.configs[config.Name] = config
+		if info := buildAttentionInfo(config); info != nil {
+			registry.attentionInfo[config.Name] = info
+		}
+	}
+
+	return registry
+}
+
+// GetModelConfig retrieves the configuration for a given model name.
+// If the model is not registered, it returns a default non-HMA config.
+func (r *ModelRegistry) GetModelConfig(modelName string) *ModelConfig {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if config, exists := r.configs[modelName]; exists {
+		return config
+	}
+
+	// Default: treat unknown models as non-HMA for memory efficiency
+	return &ModelConfig{
+		Name:  modelName,
+		IsHMA: false,
+	}
+}
+
+// RegisterModel adds or updates a model configuration.
+func (r *ModelRegistry) RegisterModel(config *ModelConfig) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.configs[config.Name] = config
+	if info := buildAttentionInfo(config); info != nil {
+		r.attentionInfo[config.Name] = info
+	} else {
+		delete(r.attentionInfo, config.Name)
+	}
+}
+
+// GetAttentionInfo returns precomputed attention info for HMA scoring.
+// Returns nil for non-HMA models or models without valid full+SWA groups.
+func (r *ModelRegistry) GetAttentionInfo(modelName string) *ModelAttentionInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.attentionInfo[modelName]
+}
+
+// IsHMA checks if a model uses Hybrid Multi-head Attention.
+// Returns false for unknown models.
+func (r *ModelRegistry) IsHMA(modelName string) bool {
+	return r.GetModelConfig(modelName).IsHMA
+}
+
+// GetAttentionGroups returns the attention group configuration for a model.
+// Returns nil for simple (non-HMA) models or unknown models.
+func (r *ModelRegistry) GetAttentionGroups(modelName string) []AttentionGroupConfig {
+	config := r.GetModelConfig(modelName)
+	if !config.IsHMA {
+		return nil
+	}
+	return config.AttentionGroups
+}
+
+// GetGroupBlockSize returns the block size for a specific attention group.
+// Returns 0 if the model or group is not found.
+func (r *ModelRegistry) GetGroupBlockSize(modelName string, groupID int) int {
+	groups := r.GetAttentionGroups(modelName)
+	for _, group := range groups {
+		if group.GroupID == groupID {
+			return group.BlockSize
+		}
+	}
+	return 0
+}
+
+// GetGroupSlidingWindow returns the sliding window size for a specific attention group.
+// Returns 0 for full attention groups or if not found.
+func (r *ModelRegistry) GetGroupSlidingWindow(modelName string, groupID int) int {
+	groups := r.GetAttentionGroups(modelName)
+	for _, group := range groups {
+		if group.GroupID == groupID {
+			return group.SlidingWindowSize
+		}
+	}
+	return 0
+}
+
+// NewDefaultModelRegistry creates a ModelRegistry with common defaults.
+// By default, all models are treated as non-HMA for memory efficiency.
+func NewDefaultModelRegistry() *ModelRegistry {
+	return NewModelRegistry(nil)
 }

--- a/pkg/kvcache/backend_test.go
+++ b/pkg/kvcache/backend_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvcache_test
+
+import (
+	"testing"
+
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModelRegistryAttentionInfo(t *testing.T) {
+	tests := []struct {
+		name         string
+		modelConfig  *kvcache.ModelConfig
+		expectNil    bool
+		expectedInfo *kvcache.ModelAttentionInfo
+	}{
+		{
+			name: "HMA_FullAndSWA",
+			modelConfig: &kvcache.ModelConfig{
+				Name:  "DeepSeek-V3",
+				IsHMA: true,
+				AttentionGroups: []kvcache.AttentionGroupConfig{
+					{GroupID: 0, AttentionType: kvcache.AttentionTypeFull, BlockSize: 64},
+					{GroupID: 1, AttentionType: kvcache.AttentionTypeSlidingWindow, BlockSize: 64, SlidingWindowSize: 4096},
+				},
+			},
+			expectNil: false,
+			expectedInfo: &kvcache.ModelAttentionInfo{
+				FullGroupID:     0,
+				SWAGroupIDs:     []int{1},
+				SWAWindowBlocks: []int{64},
+			},
+		},
+		{
+			name: "NonHMA_ReturnsNil",
+			modelConfig: &kvcache.ModelConfig{
+				Name:  "Qwen3-8B",
+				IsHMA: false,
+			},
+			expectNil: true,
+		},
+		{
+			name: "HMA_FullOnly_ReturnsNil",
+			modelConfig: &kvcache.ModelConfig{
+				Name:  "TestModel",
+				IsHMA: true,
+				AttentionGroups: []kvcache.AttentionGroupConfig{
+					{GroupID: 0, AttentionType: kvcache.AttentionTypeFull, BlockSize: 64},
+				},
+			},
+			expectNil: true,
+		},
+		{
+			name: "HMA_SWAOnly_ReturnsNil",
+			modelConfig: &kvcache.ModelConfig{
+				Name:  "TestModel",
+				IsHMA: true,
+				AttentionGroups: []kvcache.AttentionGroupConfig{
+					{GroupID: 1, AttentionType: kvcache.AttentionTypeSlidingWindow, BlockSize: 64, SlidingWindowSize: 129},
+				},
+			},
+			expectNil: true,
+		},
+		{
+			name: "HMA_NonStandardGroupIDs",
+			modelConfig: &kvcache.ModelConfig{
+				Name:  "TestModel",
+				IsHMA: true,
+				AttentionGroups: []kvcache.AttentionGroupConfig{
+					{GroupID: 5, AttentionType: kvcache.AttentionTypeFull, BlockSize: 64},
+					{GroupID: 3, AttentionType: kvcache.AttentionTypeSlidingWindow, BlockSize: 64, SlidingWindowSize: 129},
+				},
+			},
+			expectNil: false,
+			expectedInfo: &kvcache.ModelAttentionInfo{
+				FullGroupID:     5,
+				SWAGroupIDs:     []int{3},
+				SWAWindowBlocks: []int{2},
+			},
+		},
+		{
+			name: "HMA_MultipleSWAGroups",
+			modelConfig: &kvcache.ModelConfig{
+				Name:  "TestModel",
+				IsHMA: true,
+				AttentionGroups: []kvcache.AttentionGroupConfig{
+					{GroupID: 0, AttentionType: kvcache.AttentionTypeFull, BlockSize: 64},
+					{GroupID: 1, AttentionType: kvcache.AttentionTypeSlidingWindow, BlockSize: 64, SlidingWindowSize: 129},
+					{GroupID: 2, AttentionType: kvcache.AttentionTypeSlidingWindow, BlockSize: 32, SlidingWindowSize: 97},
+				},
+			},
+			expectNil: false,
+			expectedInfo: &kvcache.ModelAttentionInfo{
+				FullGroupID:     0,
+				SWAGroupIDs:     []int{1, 2},
+				SWAWindowBlocks: []int{2, 3}, // cdiv(128,64)=2, cdiv(96,32)=3
+			},
+		},
+		{
+			name: "HMA_ZeroBlockSize_Ignored",
+			modelConfig: &kvcache.ModelConfig{
+				Name:  "TestModel",
+				IsHMA: true,
+				AttentionGroups: []kvcache.AttentionGroupConfig{
+					{GroupID: 0, AttentionType: kvcache.AttentionTypeFull, BlockSize: 64},
+					{GroupID: 1, AttentionType: kvcache.AttentionTypeSlidingWindow, BlockSize: 0, SlidingWindowSize: 129},
+				},
+			},
+			expectNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := kvcache.NewModelRegistry([]*kvcache.ModelConfig{tt.modelConfig})
+			info := registry.GetAttentionInfo(tt.modelConfig.Name)
+			if tt.expectNil {
+				assert.Nil(t, info)
+			} else {
+				assert.NotNil(t, info)
+				assert.Equal(t, tt.expectedInfo.FullGroupID, info.FullGroupID)
+				assert.Equal(t, tt.expectedInfo.SWAGroupIDs, info.SWAGroupIDs)
+				assert.Equal(t, tt.expectedInfo.SWAWindowBlocks, info.SWAWindowBlocks)
+			}
+		})
+	}
+}
+
+func TestModelRegistryRegisterModelUpdatesCache(t *testing.T) {
+	registry := kvcache.NewDefaultModelRegistry()
+
+	assert.Nil(t, registry.GetAttentionInfo("test-model"))
+
+	registry.RegisterModel(&kvcache.ModelConfig{
+		Name:  "test-model",
+		IsHMA: true,
+		AttentionGroups: []kvcache.AttentionGroupConfig{
+			{GroupID: 0, AttentionType: kvcache.AttentionTypeFull, BlockSize: 64},
+			{GroupID: 1, AttentionType: kvcache.AttentionTypeSlidingWindow, BlockSize: 64, SlidingWindowSize: 129},
+		},
+	})
+
+	info := registry.GetAttentionInfo("test-model")
+	assert.NotNil(t, info)
+	assert.Equal(t, 0, info.FullGroupID)
+	assert.Equal(t, []int{1}, info.SWAGroupIDs)
+	assert.Equal(t, []int{2}, info.SWAWindowBlocks)
+
+	registry.RegisterModel(&kvcache.ModelConfig{
+		Name:  "test-model",
+		IsHMA: false,
+	})
+	assert.Nil(t, registry.GetAttentionInfo("test-model"))
+}
+
+func TestModelRegistryUnknownModel(t *testing.T) {
+	registry := kvcache.NewDefaultModelRegistry()
+	assert.Nil(t, registry.GetAttentionInfo("unknown-model"))
+}

--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -42,6 +42,7 @@ type Config struct {
 	KVBlockScorerConfig  *KVBlockScorerConfig    // not exported
 	TokenizersPoolConfig *tokenization.Config    `json:"tokenizersPoolConfig"`
 	BackendConfigs       []*KVCacheBackendConfig `json:"kvCacheBackendConfigs"`
+	ModelConfigs         []*ModelConfig          `json:"modelConfigs,omitempty"`
 }
 
 // NewDefaultConfig returns a default configuration for the Indexer module.
@@ -66,6 +67,7 @@ type Indexer struct {
 	tokenProcessor kvblock.TokenProcessor // turns tokens to kv block keys
 	kvBlockIndex   kvblock.Index          // looks up pods for block keys
 	kvBlockScorer  KVBlockScorer          // scores pods based on block hits
+	modelRegistry  *ModelRegistry         // manages model-specific configurations
 
 	tokenizersPool TokenizersPool
 }
@@ -88,6 +90,20 @@ func NewKVCacheIndexer(ctx context.Context, config *Config, tokenProcessor kvblo
 	// When tracing is not configured, otel.Tracer() returns a no-op implementation.
 	kvBlockIndex = kvblock.NewTracedIndex(kvBlockIndex)
 
+	// Create model registry from config first (needed for scorer selection)
+	var modelRegistry *ModelRegistry
+	if len(config.ModelConfigs) > 0 {
+		modelRegistry = NewModelRegistry(config.ModelConfigs)
+	} else {
+		// Use default registry (all models treated as non-HMA)
+		modelRegistry = NewDefaultModelRegistry()
+	}
+
+	// Auto-select scoring strategy based on model registry:
+	// - If any model is HMA → use HybridPrefixMatch scorer
+	// - Otherwise → use LongestPrefixMatch scorer
+	config.KVBlockScorerConfig.ScoringStrategy = LongestPrefixMatch
+
 	// override backend configs with the ones from the config, if the defaults are not used.
 	config.KVBlockScorerConfig.BackendConfigs = config.BackendConfigs
 	scorer, err := NewKVBlockScorer(config.KVBlockScorerConfig)
@@ -109,6 +125,7 @@ func NewKVCacheIndexer(ctx context.Context, config *Config, tokenProcessor kvblo
 		tokenProcessor: tokenProcessor,
 		kvBlockIndex:   kvBlockIndex,
 		kvBlockScorer:  scorer,
+		modelRegistry:  modelRegistry,
 		tokenizersPool: tokenizersPool,
 	}, nil
 }
@@ -121,6 +138,11 @@ func (k *Indexer) Run(ctx context.Context) {
 // KVBlockIndex returns the kvblock.Index used by the Indexer.
 func (k *Indexer) KVBlockIndex() kvblock.Index {
 	return k.kvBlockIndex
+}
+
+// ModelRegistry returns the ModelRegistry used by the Indexer.
+func (k *Indexer) ModelRegistry() *ModelRegistry {
+	return k.modelRegistry
 }
 
 // ComputeBlockKeys computes the KV-block keys for a given prompt and model name.
@@ -292,4 +314,17 @@ func (k *Indexer) SetTokenizer(tokenizer tokenization.Tokenizer, modelName strin
 // blockSize returns the block size from the injected token processor.
 func (k *Indexer) blockSize() int {
 	return k.tokenProcessor.BlockSize()
+}
+
+// hasHMAModels checks if any model in the registry uses HMA.
+func hasHMAModels(registry *ModelRegistry) bool {
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
+
+	for _, config := range registry.configs {
+		if config.IsHMA {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/kvcache/model_registry_test.go
+++ b/pkg/kvcache/model_registry_test.go
@@ -1,0 +1,207 @@
+// Copyright 2025 The llm-d Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvcache //nolint:testpackage // Tests internal model registry implementation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestModelRegistryDefaultBehavior verifies model registry default behavior.
+// 1. If modelConfigs is not present (nil/empty) → all models are non-HMA
+// 2. If modelConfigs is present but model not in list → non-HMA (default).
+func TestModelRegistryDefaultBehavior(t *testing.T) {
+	t.Run("NoConfig_AllModelsNonHMA", func(t *testing.T) {
+		for _, configs := range [][]*ModelConfig{nil, {}} {
+			registry := NewModelRegistry(configs)
+
+			assert.False(t, registry.IsHMA("DeepSeek-V3"), "Unknown model should be non-HMA")
+			assert.False(t, registry.IsHMA("Qwen/Qwen3-8B"), "Unknown model should be non-HMA")
+
+			config := registry.GetModelConfig("unknown-model")
+			require.NotNil(t, config)
+			assert.Equal(t, "unknown-model", config.Name)
+			assert.False(t, config.IsHMA)
+			assert.Nil(t, config.AttentionGroups)
+		}
+	})
+
+	t.Run("ModelNotInList_NonHMA", func(t *testing.T) {
+		registry := NewModelRegistry([]*ModelConfig{
+			{
+				Name:  "DeepSeek-V3",
+				IsHMA: true,
+				AttentionGroups: []AttentionGroupConfig{
+					{GroupID: 0, AttentionType: AttentionTypeFull, BlockSize: 64},
+					{GroupID: 1, AttentionType: AttentionTypeSlidingWindow, BlockSize: 64, SlidingWindowSize: 4096},
+				},
+			},
+		})
+
+		assert.True(t, registry.IsHMA("DeepSeek-V3"), "Configured HMA model should be HMA")
+		assert.False(t, registry.IsHMA("Qwen/Qwen3-8B"), "Model not in config should be non-HMA")
+		assert.False(t, registry.IsHMA("unknown-model"), "Model not in config should be non-HMA")
+
+		config := registry.GetModelConfig("Qwen/Qwen3-8B")
+		require.NotNil(t, config)
+		assert.Equal(t, "Qwen/Qwen3-8B", config.Name)
+		assert.False(t, config.IsHMA)
+	})
+
+	t.Run("ModelInList_UseIsHMAFlag_False", func(t *testing.T) {
+		registry := NewModelRegistry([]*ModelConfig{
+			{
+				Name:  "Qwen/Qwen3-8B",
+				IsHMA: false,
+			},
+		})
+
+		assert.False(t, registry.IsHMA("Qwen/Qwen3-8B"), "Should use IsHMA=false from config")
+
+		config := registry.GetModelConfig("Qwen/Qwen3-8B")
+		require.NotNil(t, config)
+		assert.Equal(t, "Qwen/Qwen3-8B", config.Name)
+		assert.False(t, config.IsHMA)
+		assert.Nil(t, config.AttentionGroups)
+	})
+
+	t.Run("MixedConfig_CorrectBehavior", func(t *testing.T) {
+		registry := NewModelRegistry([]*ModelConfig{
+			{
+				Name:  "DeepSeek-V3",
+				IsHMA: true,
+				AttentionGroups: []AttentionGroupConfig{
+					{GroupID: 0, AttentionType: AttentionTypeFull, BlockSize: 64},
+					{GroupID: 1, AttentionType: AttentionTypeSlidingWindow, BlockSize: 64, SlidingWindowSize: 4096},
+				},
+			},
+			{
+				Name:  "Qwen/Qwen3-8B",
+				IsHMA: false,
+			},
+			{
+				Name:  "meta-llama/Llama-3.1-8B",
+				IsHMA: false,
+			},
+		})
+
+		assert.True(t, registry.IsHMA("DeepSeek-V3"), "DeepSeek-V3 should be HMA")
+		assert.False(t, registry.IsHMA("Qwen/Qwen3-8B"), "Qwen should be non-HMA")
+		assert.False(t, registry.IsHMA("meta-llama/Llama-3.1-8B"), "Llama should be non-HMA")
+		assert.False(t, registry.IsHMA("mistralai/Mistral-7B-v0.1"), "Unknown model should be non-HMA")
+	})
+}
+
+func TestModelRegistryAttentionGroups(t *testing.T) {
+	t.Run("NonHMAModel_NoAttentionGroups", func(t *testing.T) {
+		registry := NewModelRegistry([]*ModelConfig{
+			{Name: "Qwen/Qwen3-8B", IsHMA: false},
+		})
+
+		groups := registry.GetAttentionGroups("Qwen/Qwen3-8B")
+		assert.Nil(t, groups, "Non-HMA model should have no attention groups")
+
+		blockSize := registry.GetGroupBlockSize("Qwen/Qwen3-8B", 0)
+		assert.Equal(t, 0, blockSize, "Non-HMA model should return 0 for block size")
+
+		windowSize := registry.GetGroupSlidingWindow("Qwen/Qwen3-8B", 0)
+		assert.Equal(t, 0, windowSize, "Non-HMA model should return 0 for window size")
+	})
+
+	t.Run("HMAModel_HasAttentionGroups", func(t *testing.T) {
+		registry := NewModelRegistry([]*ModelConfig{
+			{
+				Name:  "DeepSeek-V3",
+				IsHMA: true,
+				AttentionGroups: []AttentionGroupConfig{
+					{
+						GroupID:       0,
+						AttentionType: AttentionTypeFull,
+						BlockSize:     64,
+					},
+					{
+						GroupID:           1,
+						AttentionType:     AttentionTypeSlidingWindow,
+						BlockSize:         64,
+						SlidingWindowSize: 4096,
+					},
+				},
+			},
+		})
+
+		groups := registry.GetAttentionGroups("DeepSeek-V3")
+		require.NotNil(t, groups)
+		assert.Len(t, groups, 2)
+
+		// Group 0: Full attention
+		assert.Equal(t, 64, registry.GetGroupBlockSize("DeepSeek-V3", 0))
+		assert.Equal(t, 0, registry.GetGroupSlidingWindow("DeepSeek-V3", 0))
+
+		// Group 1: Sliding window
+		assert.Equal(t, 64, registry.GetGroupBlockSize("DeepSeek-V3", 1))
+		assert.Equal(t, 4096, registry.GetGroupSlidingWindow("DeepSeek-V3", 1))
+
+		// Non-existent group
+		assert.Equal(t, 0, registry.GetGroupBlockSize("DeepSeek-V3", 99))
+	})
+
+	t.Run("UnknownModel_NoAttentionGroups", func(t *testing.T) {
+		registry := NewModelRegistry([]*ModelConfig{
+			{Name: "DeepSeek-V3", IsHMA: true},
+		})
+
+		groups := registry.GetAttentionGroups("unknown-model")
+		assert.Nil(t, groups, "Unknown model should have no attention groups")
+	})
+}
+
+func TestModelRegistryRegisterModel(t *testing.T) {
+	t.Run("RegisterNewModel", func(t *testing.T) {
+		registry := NewModelRegistry(nil)
+
+		assert.False(t, registry.IsHMA("new-model"))
+
+		registry.RegisterModel(&ModelConfig{
+			Name:  "new-model",
+			IsHMA: true,
+			AttentionGroups: []AttentionGroupConfig{
+				{GroupID: 0, AttentionType: AttentionTypeFull, BlockSize: 32},
+			},
+		})
+
+		assert.True(t, registry.IsHMA("new-model"))
+		assert.Equal(t, 32, registry.GetGroupBlockSize("new-model", 0))
+	})
+
+	t.Run("UpdateExistingModel", func(t *testing.T) {
+		registry := NewModelRegistry([]*ModelConfig{
+			{Name: "test-model", IsHMA: false},
+		})
+
+		assert.False(t, registry.IsHMA("test-model"))
+
+		registry.RegisterModel(&ModelConfig{
+			Name:  "test-model",
+			IsHMA: true,
+			AttentionGroups: []AttentionGroupConfig{
+				{GroupID: 0, AttentionType: AttentionTypeFull, BlockSize: 64},
+			},
+		})
+
+		assert.True(t, registry.IsHMA("test-model"))
+	})
+}

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -51,6 +51,9 @@ type Config struct {
 	// PodDiscoveryConfig holds the configuration for pod discovery.
 	// Only used when DiscoverPods is true.
 	PodDiscoveryConfig *PodDiscoveryConfig `json:"podDiscoveryConfig,omitempty"`
+	// ModelRegistry provides model configuration for HMA vs simple model handling.
+	// If nil, NewDefaultModelRegistry() is used.
+	ModelRegistry ModelRegistry `json:"-"`
 }
 
 // PodDiscoveryConfig holds configuration for the Kubernetes pod reconciler.
@@ -94,7 +97,24 @@ type Pool struct {
 	index          kvblock.Index
 	tokenProcessor kvblock.TokenProcessor
 	adapter        EngineAdapter
+	modelRegistry  ModelRegistry
 	wg             sync.WaitGroup
+}
+
+// ModelRegistry interface defines methods for retrieving model configurations.
+type ModelRegistry interface {
+	IsHMA(modelName string) bool
+}
+
+// defaultModelRegistry is a simple implementation that treats all models as non-HMA.
+type defaultModelRegistry struct{}
+
+func newDefaultModelRegistry() ModelRegistry {
+	return &defaultModelRegistry{}
+}
+
+func (r *defaultModelRegistry) IsHMA(modelName string) bool {
+	return false
 }
 
 // NewPool creates a Pool with a sharded worker setup.
@@ -107,12 +127,20 @@ func NewPool(cfg *Config, index kvblock.Index, tokenProcessor kvblock.TokenProce
 		cfg = DefaultConfig()
 	}
 
+	// Use provided model registry or default
+	modelRegistry := cfg.ModelRegistry
+	if modelRegistry == nil {
+		// Import required - will add at top of file
+		modelRegistry = newDefaultModelRegistry()
+	}
+
 	p := &Pool{
 		queues:         make([]workqueue.TypedRateLimitingInterface[*RawMessage], cfg.Concurrency),
 		concurrency:    cfg.Concurrency,
 		index:          index,
 		tokenProcessor: tokenProcessor,
 		adapter:        adapter,
+		modelRegistry:  modelRegistry,
 	}
 
 	for i := 0; i < p.concurrency; i++ {


### PR DESCRIPTION
  Summary                                                                                                                                                                           
                                                                                                                                                                                    
  - Adds ModelConfig and ModelRegistry to support model-aware KV-cache indexing, enabling HMA (Hybrid Multi-head Attention) vs simple model distinction                             
  - Introduces AttentionGroupConfig with per-group block size and sliding window support for HMA models like DeepSeek-V3                                                            
  - Integrates model registry into Indexer and Pool so event processing can use model-specific configuration                                                                        
  - Adds ModelAttentionInfo with precomputed attention metadata for efficient scoring lookups   
  -    
  
  **Example**  
`{
   "modelConfigs":[
      {
         "name":"DeepSeek-V3",
         "isHMA":true,
         "attentionGroups":[
            {
               "groupId":0,
               "attentionType":"full",
               "blockSize":64
            },
            {
               "groupId":1,
               "attentionType":"sliding_window",
               "blockSize":64,
               "slidingWindowSize":4096
            }
         ]
      },
      {
         "name":"Qwen/Qwen3-8B",
         "isHMA":false
      }
   ]
}`

  **Default Behavior**                                                                                                                                                                  
                  
  When no modelConfigs is provided (or the list is empty), the registry treats all models as non-HMA for memory efficiency:    