### PR TITLE
add group_id tracking for HMA model support

### DIFF
--- a/pkg/kvcache/backend.go
+++ b/pkg/kvcache/backend.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package kvcache
 
+import "sync"
+
 type KVCacheBackendConfig struct {
 	// Name is the identifier for this medium (e.g., "gpu", "cpu", "disk")
 	Name string `json:"name"`
@@ -28,4 +30,185 @@ func DefaultKVCacheBackendConfig() []*KVCacheBackendConfig {
 		{Name: "gpu", Weight: 1.0},
 		{Name: "cpu", Weight: 0.8},
 	}
+}
+
+// AttentionType defines the type of attention mechanism used by an attention group.
+type AttentionType string
+
+const (
+	// AttentionTypeFull represents full/global attention (attends to all previous tokens).
+	AttentionTypeFull AttentionType = "full"
+	// AttentionTypeSlidingWindow represents sliding window attention (attends to last N tokens).
+	AttentionTypeSlidingWindow AttentionType = "sliding_window"
+	// AttentionTypeLocal represents local attention (attends to nearby tokens only).
+	AttentionTypeLocal AttentionType = "local"
+)
+
+// AttentionGroupConfig holds configuration for a single attention group in HMA models.
+type AttentionGroupConfig struct {
+	// GroupID is the attention group identifier (e.g., 0 for full attention, 1 for sliding window)
+	GroupID int `json:"groupId"`
+	// AttentionType specifies the type of attention mechanism
+	AttentionType AttentionType `json:"attentionType"`
+	// BlockSize is the number of tokens per KV-cache block for this group
+	BlockSize int `json:"blockSize"`
+	// SlidingWindowSize is the window size for sliding window attention (0 or omitted for full attention)
+	SlidingWindowSize int `json:"slidingWindowSize,omitempty"`
+}
+
+// ModelConfig holds the configuration for a specific model.
+type ModelConfig struct {
+	// Name is the model identifier (e.g., "Qwen/Qwen3-8B", "DeepSeek-V3")
+	Name string `json:"name"`
+	// IsHMA indicates whether this model uses Hybrid Multi-head Attention.
+	// When true, StoredGroups tracking is enabled for cache entries (non-zero bitmask).
+	// When false, StoredGroups is left 0 to save memory.
+	IsHMA bool `json:"isHMA"`
+	// AttentionGroups defines the attention group configuration for HMA models.
+	// Only used when IsHMA is true.
+	// Example for DeepSeek-V3:
+	//   [{GroupID: 0, BlockSize: 64, SlidingWindowSize: 0},       // Full attention
+	//    {GroupID: 1, BlockSize: 64, SlidingWindowSize: 4096}]    // Sliding window
+	AttentionGroups []AttentionGroupConfig `json:"attentionGroups,omitempty"`
+}
+
+// ModelAttentionInfo holds precomputed attention group metadata for scoring.
+type ModelAttentionInfo struct {
+	FullGroupID     int
+	SWAGroupIDs     []int
+	SWAWindowBlocks []int
+}
+
+func cdiv(a, b int) int {
+	return (a + b - 1) / b
+}
+
+func buildAttentionInfo(config *ModelConfig) *ModelAttentionInfo {
+	if !config.IsHMA {
+		return nil
+	}
+	info := &ModelAttentionInfo{FullGroupID: -1}
+	for _, group := range config.AttentionGroups {
+		switch group.AttentionType {
+		case AttentionTypeFull:
+			info.FullGroupID = group.GroupID
+		case AttentionTypeSlidingWindow:
+			if group.BlockSize > 0 && group.SlidingWindowSize > 0 {
+				info.SWAGroupIDs = append(info.SWAGroupIDs, group.GroupID)
+				info.SWAWindowBlocks = append(info.SWAWindowBlocks, cdiv(group.SlidingWindowSize-1, group.BlockSize))
+			}
+		}
+	}
+	if info.FullGroupID < 0 || len(info.SWAWindowBlocks) == 0 {
+		return nil
+	}
+	return info
+}
+
+// ModelRegistry manages model configurations.
+// It provides thread-safe access to model metadata needed for event processing.
+type ModelRegistry struct {
+	mu            sync.RWMutex
+	configs       map[string]*ModelConfig
+	attentionInfo map[string]*ModelAttentionInfo
+}
+
+// NewModelRegistry creates a new ModelRegistry with optional initial configs.
+func NewModelRegistry(initialConfigs []*ModelConfig) *ModelRegistry {
+	registry := &ModelRegistry{
+		configs:       make(map[string]*ModelConfig),
+		attentionInfo: make(map[string]*ModelAttentionInfo),
+	}
+
+	for _, config := range initialConfigs {
+		registry.configs[config.Name] = config
+		if info := buildAttentionInfo(config); info != nil {
+			registry.attentionInfo[config.Name] = info
+		}
+	}
+
+	return registry
+}
+
+// GetModelConfig retrieves the configuration for a given model name.
+// If the model is not registered, it returns a default non-HMA config.
+func (r *ModelRegistry) GetModelConfig(modelName string) *ModelConfig {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if config, exists := r.configs[modelName]; exists {
+		return config
+	}
+
+	// Default: treat unknown models as non-HMA for memory efficiency
+	return &ModelConfig{
+		Name:  modelName,
+		IsHMA: false,
+	}
+}
+
+// RegisterModel adds or updates a model configuration.
+func (r *ModelRegistry) RegisterModel(config *ModelConfig) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.configs[config.Name] = config
+	if info := buildAttentionInfo(config); info != nil {
+		r.attentionInfo[config.Name] = info
+	} else {
+		delete(r.attentionInfo, config.Name)
+	}
+}
+
+// GetAttentionInfo returns precomputed attention info for HMA scoring.
+// Returns nil for non-HMA models or models without valid full+SWA groups.
+func (r *ModelRegistry) GetAttentionInfo(modelName string) *ModelAttentionInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.attentionInfo[modelName]
+}
+
+// IsHMA checks if a model uses Hybrid Multi-head Attention.
+// Returns false for unknown models.
+func (r *ModelRegistry) IsHMA(modelName string) bool {
+	return r.GetModelConfig(modelName).IsHMA
+}
+
+// GetAttentionGroups returns the attention group configuration for a model.
+// Returns nil for simple (non-HMA) models or unknown models.
+func (r *ModelRegistry) GetAttentionGroups(modelName string) []AttentionGroupConfig {
+	config := r.GetModelConfig(modelName)
+	if !config.IsHMA {
+		return nil
+	}
+	return config.AttentionGroups
+}
+
+// GetGroupBlockSize returns the block size for a specific attention group.
+// Returns 0 if the model or group is not found.
+func (r *ModelRegistry) GetGroupBlockSize(modelName string, groupID int) int {
+	groups := r.GetAttentionGroups(modelName)
+	for _, group := range groups {
+		if group.GroupID == groupID {
+			return group.BlockSize
+		}
+	}
+	return 0
+}
+
+// GetGroupSlidingWindow returns the sliding window size for a specific attention group.
+// Returns 0 for full attention groups or if not found.
+func (r *ModelRegistry) GetGroupSlidingWindow(modelName string, groupID int) int {
+	groups := r.GetAttentionGroups(modelName)
+	for _, group := range groups {
+		if group.GroupID == groupID {
+			return group.SlidingWindowSize
+		}
+	}
+	return 0
+}
+
+// NewDefaultModelRegistry creates a ModelRegistry with common defaults.
+// By default, all models are treated as non-HMA for memory efficiency.
+func NewDefaultModelRegistry() *ModelRegistry {
+	return NewModelRegistry(nil)
 }

--- a/pkg/kvcache/backend_test.go
+++ b/pkg/kvcache/backend_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvcache_test
+
+import (
+	"testing"
+
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModelRegistryAttentionInfo(t *testing.T) {
+	tests := []struct {
+		name         string
+		modelConfig  *kvcache.ModelConfig
+		expectNil    bool
+		expectedInfo *kvcache.ModelAttentionInfo
+	}{
+		{
+			name: "HMA_FullAndSWA",
+			modelConfig: &kvcache.ModelConfig{
+				Name:  "DeepSeek-V3",
+				IsHMA: true,
+				AttentionGroups: []kvcache.AttentionGroupConfig{
+					{GroupID: 0, AttentionType: kvcache.AttentionTypeFull, BlockSize: 64},
+					{GroupID: 1, AttentionType: kvcache.AttentionTypeSlidingWindow, BlockSize: 64, SlidingWindowSize: 4096},
+				},
+			},
+			expectNil: false,
+			expectedInfo: &kvcache.ModelAttentionInfo{
+				FullGroupID:     0,
+				SWAGroupIDs:     []int{1},
+				SWAWindowBlocks: []int{64},
+			},
+		},
+		{
+			name: "NonHMA_ReturnsNil",
+			modelConfig: &kvcache.ModelConfig{
+				Name:  "Qwen3-8B",
+				IsHMA: false,
+			},
+			expectNil: true,
+		},
+		{
+			name: "HMA_FullOnly_ReturnsNil",
+			modelConfig: &kvcache.ModelConfig{
+				Name:  "TestModel",
+				IsHMA: true,
+				AttentionGroups: []kvcache.AttentionGroupConfig{
+					{GroupID: 0, AttentionType: kvcache.AttentionTypeFull, BlockSize: 64},
+				},
+			},
+			expectNil: true,
+		},
+		{
+			name: "HMA_SWAOnly_ReturnsNil",
+			modelConfig: &kvcache.ModelConfig{
+				Name:  "TestModel",
+				IsHMA: true,
+				AttentionGroups: []kvcache.AttentionGroupConfig{
+					{GroupID: 1, AttentionType: kvcache.AttentionTypeSlidingWindow, BlockSize: 64, SlidingWindowSize: 129},
+				},
+			},
+			expectNil: true,
+		},
+		{
+			name: "HMA_NonStandardGroupIDs",
+			modelConfig: &kvcache.ModelConfig{
+				Name:  "TestModel",
+				IsHMA: true,
+				AttentionGroups: []kvcache.AttentionGroupConfig{
+					{GroupID: 5, AttentionType: kvcache.AttentionTypeFull, BlockSize: 64},
+					{GroupID: 3, AttentionType: kvcache.AttentionTypeSlidingWindow, BlockSize: 64, SlidingWindowSize: 129},
+				},
+			},
+			expectNil: false,
+			expectedInfo: &kvcache.ModelAttentionInfo{
+				FullGroupID:     5,
+				SWAGroupIDs:     []int{3},
+				SWAWindowBlocks: []int{2},
+			},
+		},
+		{
+			name: "HMA_MultipleSWAGroups",
+			modelConfig: &kvcache.ModelConfig{
+				Name:  "TestModel",
+				IsHMA: true,
+				AttentionGroups: []kvcache.AttentionGroupConfig{
+					{GroupID: 0, AttentionType: kvcache.AttentionTypeFull, BlockSize: 64},
+					{GroupID: 1, AttentionType: kvcache.AttentionTypeSlidingWindow, BlockSize: 64, SlidingWindowSize: 129},
+					{GroupID: 2, AttentionType: kvcache.AttentionTypeSlidingWindow, BlockSize: 32, SlidingWindowSize: 97},
+				},
+			},
+			expectNil: false,
+			expectedInfo: &kvcache.ModelAttentionInfo{
+				FullGroupID:     0,
+				SWAGroupIDs:     []int{1, 2},
+				SWAWindowBlocks: []int{2, 3}, // cdiv(128,64)=2, cdiv(96,32)=3
+			},
+		},
+		{
+			name: "HMA_ZeroBlockSize_Ignored",
+			modelConfig: &kvcache.ModelConfig{
+				Name:  "TestModel",
+				IsHMA: true,
+				AttentionGroups: []kvcache.AttentionGroupConfig{
+					{GroupID: 0, AttentionType: kvcache.AttentionTypeFull, BlockSize: 64},
+					{GroupID: 1, AttentionType: kvcache.AttentionTypeSlidingWindow, BlockSize: 0, SlidingWindowSize: 129},
+				},
+			},
+			expectNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := kvcache.NewModelRegistry([]*kvcache.ModelConfig{tt.modelConfig})
+			info := registry.GetAttentionInfo(tt.modelConfig.Name)
+			if tt.expectNil {
+				assert.Nil(t, info)
+			} else {
+				assert.NotNil(t, info)
+				assert.Equal(t, tt.expectedInfo.FullGroupID, info.FullGroupID)
+				assert.Equal(t, tt.expectedInfo.SWAGroupIDs, info.SWAGroupIDs)
+				assert.Equal(t, tt.expectedInfo.SWAWindowBlocks, info.SWAWindowBlocks)
+			}
+		})
+	}
+}
+
+func TestModelRegistryRegisterModelUpdatesCache(t *testing.T) {
+	registry := kvcache.NewDefaultModelRegistry()
+
+	assert.Nil(t, registry.GetAttentionInfo("test-model"))
+
+	registry.RegisterModel(&kvcache.ModelConfig{
+		Name:  "test-model",
+		IsHMA: true,
+		AttentionGroups: []kvcache.AttentionGroupConfig{
+			{GroupID: 0, AttentionType: kvcache.AttentionTypeFull, BlockSize: 64},
+			{GroupID: 1, AttentionType: kvcache.AttentionTypeSlidingWindow, BlockSize: 64, SlidingWindowSize: 129},
+		},
+	})
+
+	info := registry.GetAttentionInfo("test-model")
+	assert.NotNil(t, info)
+	assert.Equal(t, 0, info.FullGroupID)
+	assert.Equal(t, []int{1}, info.SWAGroupIDs)
+	assert.Equal(t, []int{2}, info.SWAWindowBlocks)
+
+	registry.RegisterModel(&kvcache.ModelConfig{
+		Name:  "test-model",
+		IsHMA: false,
+	})
+	assert.Nil(t, registry.GetAttentionInfo("test-model"))
+}
+
+func TestModelRegistryUnknownModel(t *testing.T) {
+	registry := kvcache.NewDefaultModelRegistry()
+	assert.Nil(t, registry.GetAttentionInfo("unknown-model"))
+}

--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -42,6 +42,7 @@ type Config struct {
 	KVBlockScorerConfig  *KVBlockScorerConfig    // not exported
 	TokenizersPoolConfig *tokenization.Config    `json:"tokenizersPoolConfig"`
 	BackendConfigs       []*KVCacheBackendConfig `json:"kvCacheBackendConfigs"`
+	ModelConfigs         []*ModelConfig          `json:"modelConfigs,omitempty"`
 }
 
 // NewDefaultConfig returns a default configuration for the Indexer module.
@@ -66,6 +67,7 @@ type Indexer struct {
 	tokenProcessor kvblock.TokenProcessor // turns tokens to kv block keys
 	kvBlockIndex   kvblock.Index          // looks up pods for block keys
 	kvBlockScorer  KVBlockScorer          // scores pods based on block hits
+	modelRegistry  *ModelRegistry         // manages model-specific configurations
 
 	tokenizersPool TokenizersPool
 }
@@ -88,6 +90,20 @@ func NewKVCacheIndexer(ctx context.Context, config *Config, tokenProcessor kvblo
 	// When tracing is not configured, otel.Tracer() returns a no-op implementation.
 	kvBlockIndex = kvblock.NewTracedIndex(kvBlockIndex)
 
+	// Create model registry from config first (needed for scorer selection)
+	var modelRegistry *ModelRegistry
+	if len(config.ModelConfigs) > 0 {
+		modelRegistry = NewModelRegistry(config.ModelConfigs)
+	} else {
+		// Use default registry (all models treated as non-HMA)
+		modelRegistry = NewDefaultModelRegistry()
+	}
+
+	// Auto-select scoring strategy based on model registry:
+	// - If any model is HMA → use HybridPrefixMatch scorer
+	// - Otherwise → use LongestPrefixMatch scorer
+	config.KVBlockScorerConfig.ScoringStrategy = LongestPrefixMatch
+
 	// override backend configs with the ones from the config, if the defaults are not used.
 	config.KVBlockScorerConfig.BackendConfigs = config.BackendConfigs
 	scorer, err := NewKVBlockScorer(config.KVBlockScorerConfig)
@@ -109,6 +125,7 @@ func NewKVCacheIndexer(ctx context.Context, config *Config, tokenProcessor kvblo
 		tokenProcessor: tokenProcessor,
 		kvBlockIndex:   kvBlockIndex,
 		kvBlockScorer:  scorer,
+		modelRegistry:  modelRegistry,
 		tokenizersPool: tokenizersPool,
 	}, nil
 }
@@ -121,6 +138,11 @@ func (k *Indexer) Run(ctx context.Context) {
 // KVBlockIndex returns the kvblock.Index used by the Indexer.
 func (k *Indexer) KVBlockIndex() kvblock.Index {
 	return k.kvBlockIndex
+}
+
+// ModelRegistry returns the ModelRegistry used by the Indexer.
+func (k *Indexer) ModelRegistry() *ModelRegistry {
+	return k.modelRegistry
 }
 
 // ComputeBlockKeys computes the KV-block keys for a given prompt and model name.
@@ -292,4 +314,17 @@ func (k *Indexer) SetTokenizer(tokenizer tokenization.Tokenizer, modelName strin
 // blockSize returns the block size from the injected token processor.
 func (k *Indexer) blockSize() int {
 	return k.tokenProcessor.BlockSize()
+}
+
+// hasHMAModels checks if any model in the registry uses HMA.
+func hasHMAModels(registry *ModelRegistry) bool {
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
+
+	for _, config := range registry.configs {
+		if config.IsHMA {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/kvcache/kvblock/cost_aware_memory.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory.go
@@ -104,23 +104,77 @@ func (m *CostAwareMemoryIndex) MaxCost() int64 {
 
 // CostPodCache wraps a sync.Map of PodEntry and provides cost calculation for memory usage estimation.
 type CostPodCache struct {
-	cache sync.Map // map[PodEntry]struct{}
+	cache sync.Map // map[string]*PodEntry (key: "podID@tier")
 	// size tracks the number of entries in cache for O(1) Len().
 	size atomic.Int64
 }
 
-// Add adds a PodEntry to the cache.
+// Add adds a PodEntry to the cache, merging StoredGroups if the pod already exists.
 func (c *CostPodCache) Add(entry PodEntry) {
-	if _, loaded := c.cache.LoadOrStore(entry, struct{}{}); !loaded {
-		c.size.Add(1)
+	key := entry.String() // Consider using a custom struct key if possible to avoid string allocation
+
+	// 1. Use LoadOrStore to handle the "check-then-set" race condition in one call
+	ep := &entry
+	actual, loaded := c.cache.LoadOrStore(key, ep)
+
+	if loaded {
+		// 2. If it exists, update the bitmask.
+		// We cast to the pointer to modify the existing entry in-place.
+		if entry.StoredGroups != 0 {
+			if existing, ok := actual.(*PodEntry); ok {
+				// Use atomic if multiple goroutines might update the same key simultaneously
+				// atomic.Uint64 or similar is safer here depending on your concurrency model
+				existing.StoredGroups |= entry.StoredGroups
+			}
+		}
+		return
 	}
+
+	// 3. Only increment size if we actually stored a new entry
+	c.size.Add(1)
 }
 
 // Delete removes a PodEntry from the cache.
+// For HMA models (StoredGroups != 0): clears specific group bits via pointer mutation,
+// removes entry only when all groups are cleared.
+// For simple models (StoredGroups == 0): removes the entire entry.
 func (c *CostPodCache) Delete(entry PodEntry) {
-	if _, loaded := c.cache.LoadAndDelete(entry); loaded {
-		c.size.Add(-1)
+	key := entry.String()
+
+	// 1. If StoredGroups is 0, we treat it as a full deletion immediately.
+	// This avoids loading the object if we know we're nuking the key anyway.
+	if entry.StoredGroups == 0 {
+		if _, loaded := c.cache.LoadAndDelete(key); loaded {
+			c.size.Add(-1)
+		}
+		return
 	}
+
+	// 2. Load the existing entry to check the bitmask
+	val, loaded := c.cache.Load(key)
+	if !loaded {
+		return
+	}
+
+	existing, ok := val.(*PodEntry)
+	if !ok {
+		return
+	}
+
+	// 3. Bitmask Logic:
+	// If the resulting mask after clearing bits is 0, delete the entry.
+	// Use atomic operations if concurrent updates to the same key are expected.
+	remaining := existing.StoredGroups &^ entry.StoredGroups
+	if remaining == 0 {
+		// Use LoadAndDelete to ensure we only decrement size if WE were the ones to delete it
+		if _, deleted := c.cache.LoadAndDelete(key); deleted {
+			c.size.Add(-1)
+		}
+		return
+	}
+
+	// 4. Otherwise, just update the bitmask in place
+	existing.StoredGroups = remaining
 }
 
 // Len returns the number of entries in the cache.
@@ -141,17 +195,26 @@ func (c *CostPodCache) CalculateByteSize(keyStr string) int64 {
 	totalBytes += 64 // approximate sync.Map overhead
 
 	// Count entries and calculate their size
-	c.cache.Range(func(key, value interface{}) bool {
-		entry, ok := key.(PodEntry)
+	c.cache.Range(func(k, value interface{}) bool {
+		entry, ok := value.(*PodEntry)
+		if !ok {
+			return true
+		}
+
+		keyStr, ok := k.(string)
 		if !ok {
 			return true
 		}
 
 		entryCount++
+		totalBytes += int64(len(keyStr))              // map key string content ("podID@tier")
+		totalBytes += 16                              // map key string header
 		totalBytes += int64(len(entry.PodIdentifier)) // PodIdentifier string content
 		totalBytes += int64(len(entry.DeviceTier))    // DeviceTier string content
 		totalBytes += 32                              // string headers (16 bytes each for 2 strings)
 		totalBytes += 8                               // struct padding/alignment
+		totalBytes += 4                               // StoredGroups uint32
+		totalBytes += 8                               // pointer overhead
 		return true
 	})
 
@@ -246,18 +309,18 @@ func (m *CostAwareMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHa
 
 			if podIdentifierSet.Len() == 0 {
 				// If no pod identifiers are provided, return all pods
-				pods.cache.Range(func(k, value interface{}) bool {
-					if pod, ok := k.(PodEntry); ok {
-						podsPerKey[key] = append(podsPerKey[key], pod)
+				pods.cache.Range(func(_, value interface{}) bool {
+					if pod, ok := value.(*PodEntry); ok {
+						podsPerKey[key] = append(podsPerKey[key], *pod)
 					}
 					return true
 				})
 			} else {
 				// Filter pods based on the provided pod identifiers
-				pods.cache.Range(func(k, value interface{}) bool {
-					if pod, ok := k.(PodEntry); ok {
+				pods.cache.Range(func(_, value interface{}) bool {
+					if pod, ok := value.(*PodEntry); ok {
 						if podIdentifierSet.Has(pod.PodIdentifier) {
-							podsPerKey[key] = append(podsPerKey[key], pod)
+							podsPerKey[key] = append(podsPerKey[key], *pod)
 						}
 					}
 					return true

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -89,9 +89,8 @@ var _ Index = &InMemoryIndex{}
 
 // PodCache represents a cache for pod entries.
 type PodCache struct {
-	// cache is an LRU cache that maps PodEntry to their last access time.
-	// thread-safe.
-	cache *lru.Cache[PodEntry, struct{}]
+	// cache is an LRU cache keyed by "podID@tier[speculative]" string, value is *PodEntry.
+	cache *lru.Cache[string, *PodEntry]
 	// mu protects the cache from concurrent access during check-and-set operations.
 	mu sync.Mutex
 }
@@ -127,12 +126,14 @@ func (m *InMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 
 			if podIdentifierSet.Len() == 0 {
 				// If no pod identifiers are provided, return all pods
-				podsPerKey[requestKey] = pods.cache.Keys()
+				for _, pod := range pods.cache.Values() {
+					podsPerKey[requestKey] = append(podsPerKey[requestKey], *pod)
+				}
 			} else {
 				// Filter pods based on the provided pod identifiers
-				for _, pod := range pods.cache.Keys() {
+				for _, pod := range pods.cache.Values() {
 					if podIdentifierSet.Has(pod.PodIdentifier) {
-						podsPerKey[requestKey] = append(podsPerKey[requestKey], pod)
+						podsPerKey[requestKey] = append(podsPerKey[requestKey], *pod)
 					}
 				}
 			}
@@ -186,7 +187,7 @@ func (m *InMemoryIndex) Add(ctx context.Context, engineKeys, requestKeys []Block
 		//nolint:nestif // double-checked locking pattern
 		if !found {
 			// Create new cache
-			cache, err := lru.New[PodEntry, struct{}](m.podCacheSize)
+			cache, err := lru.New[string, *PodEntry](m.podCacheSize)
 			if err != nil {
 				return fmt.Errorf("failed to create pod cache for key %s: %w", requestKey.String(), err)
 			}
@@ -213,7 +214,15 @@ func (m *InMemoryIndex) Add(ctx context.Context, engineKeys, requestKeys []Block
 
 		podCache.mu.Lock()
 		for _, entry := range entries {
-			podCache.cache.Add(entry, struct{}{})
+			key := entry.String()
+			if existing, ok := podCache.cache.Get(key); ok {
+				if entry.StoredGroups != 0 {
+					existing.StoredGroups |= entry.StoredGroups
+				}
+			} else {
+				ep := entry
+				podCache.cache.Add(key, &ep)
+			}
 		}
 		podCache.mu.Unlock()
 
@@ -265,7 +274,14 @@ func (m *InMemoryIndex) evictPodsFromRequestKey(requestKey, engineKey BlockHash,
 
 	podCache.mu.Lock()
 	for _, entry := range entries {
-		podCache.cache.Remove(entry)
+		key := entry.String()
+		if existing, ok := podCache.cache.Get(key); ok {
+			if entry.StoredGroups == 0 || (existing.StoredGroups&^entry.StoredGroups) == 0 {
+				podCache.cache.Remove(key)
+			} else {
+				existing.StoredGroups &^= entry.StoredGroups
+			}
+		}
 	}
 
 	isEmpty := podCache.cache.Len() == 0

--- a/pkg/kvcache/kvblock/index.go
+++ b/pkg/kvcache/kvblock/index.go
@@ -180,6 +180,11 @@ type PodEntry struct {
 	DeviceTier string
 	// Speculative indicates the entry was added predictively before a KV event confirmed it.
 	Speculative bool
+	// StoredGroups tracks the group IDs that have stored this block (for HMA models) as a bitmask.
+	// - 0: Simple (non-HMA) model - no group tracking, saves memory
+	// - non-zero: HMA model - bit N set if group N has cached this block
+	// Group N → bit N: set with |= (1 << N), clear with &^= (1 << N), check with & (1 << N) != 0
+	StoredGroups uint32
 }
 
 // String returns a string representation of the PodEntry.

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -153,6 +153,48 @@ var pruneRequestKeyScript = redis.NewScript(`
 	return 0
 `)
 
+// mergeGroupsLua atomically merges StoredGroups bitmask for a pod entry.
+// If the field exists with HMA groups, ORs the new groups with existing; otherwise creates it.
+const mergeGroupsLua = `
+	local cur = redis.call('HGET', KEYS[1], ARGV[1])
+	local new = tonumber(ARGV[2])
+	if cur then
+		local existing = tonumber(cur)
+		if existing and new and new > 0 and existing > 0 then
+			redis.call('HSET', KEYS[1], ARGV[1], tostring(bit.bor(existing, new)))
+		else
+			redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
+		end
+	else
+		redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
+	end
+	return 1
+`
+
+// evictGroupsLua atomically clears StoredGroups bits for a pod entry.
+// Deletes the field if no groups remain or if StoredGroups is 0 (non-HMA).
+const evictGroupsLua = `
+	local cur = redis.call('HGET', KEYS[1], ARGV[1])
+	if not cur then return 0 end
+	local groups = tonumber(ARGV[2])
+	if not groups or groups == 0 then
+		redis.call('HDEL', KEYS[1], ARGV[1])
+		return 1
+	end
+	local curGroups = tonumber(cur)
+	if not curGroups or curGroups == 0 then
+		redis.call('HDEL', KEYS[1], ARGV[1])
+		return 1
+	end
+	local remaining = curGroups - bit.band(curGroups, groups)
+	if remaining == 0 then
+		redis.call('HDEL', KEYS[1], ARGV[1])
+	else
+		redis.call('HSET', KEYS[1], ARGV[1], tostring(remaining))
+	end
+	return 1
+`
+
 // Lookup receives a list of keys and a set of pod identifiers,
 // and retrieves the filtered pods associated with those keys.
 // The filtering is done based on the pod identifiers provided.
@@ -173,12 +215,11 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 
 	// pipeline for single RTT
 	pipe := r.RedisClient.Pipeline()
-	results := make([]*redis.StringSliceCmd, len(requestKeys))
+	results := make([]*redis.MapStringStringCmd, len(requestKeys))
 
-	// queue an HKeys command for each key in the pipeline
+	// queue an HGetAll command for each key in the pipeline
 	for i, key := range requestKeys {
-		// HKeys gets all field names
-		results[i] = pipe.HKeys(ctx, key.String())
+		results[i] = pipe.HGetAll(ctx, key.String())
 	}
 
 	_, execErr := pipe.Exec(ctx)
@@ -191,8 +232,7 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 	for idx, cmd := range results {
 		key := requestKeys[idx]
 
-		// cmd.Result() returns the slice of strings (pod IDs) which is the first layer in the mapping
-		pods, cmdErr := cmd.Result()
+		podMap, cmdErr := cmd.Result()
 		if cmdErr != nil {
 			if !errors.Is(cmdErr, redis.Nil) {
 				logger.Error(cmdErr, "failed to get pods for key", "key", key)
@@ -201,18 +241,32 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 			return podsPerKey, nil // early stop since prefix-chain breaks here
 		}
 
+		if len(podMap) == 0 {
+			logger.Info("no pods found for key, cutting search", "key", key)
+			return podsPerKey, nil // early stop since prefix-chain breaks here
+		}
+
 		var filteredPods []PodEntry
-		for _, p := range pods {
-			ip := strings.SplitN(p, "@", 2)[0]
+		for field, val := range podMap {
+			ip := strings.SplitN(field, "@", 2)[0]
 			if !filterPods || podIdentifierSet.Has(ip) {
-				tier := strings.SplitN(p, "@", 2)[1]
+				tier := strings.SplitN(field, "@", 2)[1]
 				speculative := false
 				// Strip annotation suffix e.g. "gpu[speculative]" -> "gpu"
 				if idx := strings.Index(tier, "["); idx != -1 {
 					speculative = strings.Contains(tier[idx:], "speculative")
 					tier = tier[:idx]
 				}
-				filteredPods = append(filteredPods, PodEntry{PodIdentifier: ip, DeviceTier: tier, Speculative: speculative})
+				var storedGroups uint32
+				if n, err := strconv.ParseUint(val, 10, 32); err == nil {
+					storedGroups = uint32(n)
+				}
+				filteredPods = append(filteredPods, PodEntry{
+					PodIdentifier: ip,
+					DeviceTier:    tier,
+					Speculative:   speculative,
+					StoredGroups:  storedGroups,
+				})
 			}
 		}
 
@@ -253,10 +307,11 @@ func (r *RedisIndex) Add(ctx context.Context, engineKeys, requestKeys []BlockHas
 	}
 
 	// Store requestKey -> PodEntry mappings for all request keys.
+	// Uses Lua script to atomically merge StoredGroups bitmask for HMA models.
 	for _, requestKey := range requestKeys {
 		redisKey := requestKey.String()
 		for _, entry := range entries {
-			pipe.HSet(ctx, redisKey, entry.String(), "")
+			pipe.Eval(ctx, mergeGroupsLua, []string{redisKey}, entry.String(), entry.StoredGroups)
 		}
 	}
 
@@ -306,7 +361,7 @@ func (r *RedisIndex) evictPodsFromRequestKey(ctx context.Context, requestKey Blo
 	pipe := r.RedisClient.Pipeline()
 
 	for _, entry := range entries {
-		pipe.HDel(ctx, redisKey, entry.String())
+		pipe.Eval(ctx, evictGroupsLua, []string{redisKey}, entry.String(), entry.StoredGroups)
 	}
 
 	if _, err := pipe.Exec(ctx); err != nil {

--- a/pkg/kvcache/model_registry_test.go
+++ b/pkg/kvcache/model_registry_test.go
@@ -1,0 +1,207 @@
+// Copyright 2025 The llm-d Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvcache //nolint:testpackage // Tests internal model registry implementation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestModelRegistryDefaultBehavior verifies model registry default behavior.
+// 1. If modelConfigs is not present (nil/empty) → all models are non-HMA
+// 2. If modelConfigs is present but model not in list → non-HMA (default).
+func TestModelRegistryDefaultBehavior(t *testing.T) {
+	t.Run("NoConfig_AllModelsNonHMA", func(t *testing.T) {
+		for _, configs := range [][]*ModelConfig{nil, {}} {
+			registry := NewModelRegistry(configs)
+
+			assert.False(t, registry.IsHMA("DeepSeek-V3"), "Unknown model should be non-HMA")
+			assert.False(t, registry.IsHMA("Qwen/Qwen3-8B"), "Unknown model should be non-HMA")
+
+			config := registry.GetModelConfig("unknown-model")
+			require.NotNil(t, config)
+			assert.Equal(t, "unknown-model", config.Name)
+			assert.False(t, config.IsHMA)
+			assert.Nil(t, config.AttentionGroups)
+		}
+	})
+
+	t.Run("ModelNotInList_NonHMA", func(t *testing.T) {
+		registry := NewModelRegistry([]*ModelConfig{
+			{
+				Name:  "DeepSeek-V3",
+				IsHMA: true,
+				AttentionGroups: []AttentionGroupConfig{
+					{GroupID: 0, AttentionType: AttentionTypeFull, BlockSize: 64},
+					{GroupID: 1, AttentionType: AttentionTypeSlidingWindow, BlockSize: 64, SlidingWindowSize: 4096},
+				},
+			},
+		})
+
+		assert.True(t, registry.IsHMA("DeepSeek-V3"), "Configured HMA model should be HMA")
+		assert.False(t, registry.IsHMA("Qwen/Qwen3-8B"), "Model not in config should be non-HMA")
+		assert.False(t, registry.IsHMA("unknown-model"), "Model not in config should be non-HMA")
+
+		config := registry.GetModelConfig("Qwen/Qwen3-8B")
+		require.NotNil(t, config)
+		assert.Equal(t, "Qwen/Qwen3-8B", config.Name)
+		assert.False(t, config.IsHMA)
+	})
+
+	t.Run("ModelInList_UseIsHMAFlag_False", func(t *testing.T) {
+		registry := NewModelRegistry([]*ModelConfig{
+			{
+				Name:  "Qwen/Qwen3-8B",
+				IsHMA: false,
+			},
+		})
+
+		assert.False(t, registry.IsHMA("Qwen/Qwen3-8B"), "Should use IsHMA=false from config")
+
+		config := registry.GetModelConfig("Qwen/Qwen3-8B")
+		require.NotNil(t, config)
+		assert.Equal(t, "Qwen/Qwen3-8B", config.Name)
+		assert.False(t, config.IsHMA)
+		assert.Nil(t, config.AttentionGroups)
+	})
+
+	t.Run("MixedConfig_CorrectBehavior", func(t *testing.T) {
+		registry := NewModelRegistry([]*ModelConfig{
+			{
+				Name:  "DeepSeek-V3",
+				IsHMA: true,
+				AttentionGroups: []AttentionGroupConfig{
+					{GroupID: 0, AttentionType: AttentionTypeFull, BlockSize: 64},
+					{GroupID: 1, AttentionType: AttentionTypeSlidingWindow, BlockSize: 64, SlidingWindowSize: 4096},
+				},
+			},
+			{
+				Name:  "Qwen/Qwen3-8B",
+				IsHMA: false,
+			},
+			{
+				Name:  "meta-llama/Llama-3.1-8B",
+				IsHMA: false,
+			},
+		})
+
+		assert.True(t, registry.IsHMA("DeepSeek-V3"), "DeepSeek-V3 should be HMA")
+		assert.False(t, registry.IsHMA("Qwen/Qwen3-8B"), "Qwen should be non-HMA")
+		assert.False(t, registry.IsHMA("meta-llama/Llama-3.1-8B"), "Llama should be non-HMA")
+		assert.False(t, registry.IsHMA("mistralai/Mistral-7B-v0.1"), "Unknown model should be non-HMA")
+	})
+}
+
+func TestModelRegistryAttentionGroups(t *testing.T) {
+	t.Run("NonHMAModel_NoAttentionGroups", func(t *testing.T) {
+		registry := NewModelRegistry([]*ModelConfig{
+			{Name: "Qwen/Qwen3-8B", IsHMA: false},
+		})
+
+		groups := registry.GetAttentionGroups("Qwen/Qwen3-8B")
+		assert.Nil(t, groups, "Non-HMA model should have no attention groups")
+
+		blockSize := registry.GetGroupBlockSize("Qwen/Qwen3-8B", 0)
+		assert.Equal(t, 0, blockSize, "Non-HMA model should return 0 for block size")
+
+		windowSize := registry.GetGroupSlidingWindow("Qwen/Qwen3-8B", 0)
+		assert.Equal(t, 0, windowSize, "Non-HMA model should return 0 for window size")
+	})
+
+	t.Run("HMAModel_HasAttentionGroups", func(t *testing.T) {
+		registry := NewModelRegistry([]*ModelConfig{
+			{
+				Name:  "DeepSeek-V3",
+				IsHMA: true,
+				AttentionGroups: []AttentionGroupConfig{
+					{
+						GroupID:       0,
+						AttentionType: AttentionTypeFull,
+						BlockSize:     64,
+					},
+					{
+						GroupID:           1,
+						AttentionType:     AttentionTypeSlidingWindow,
+						BlockSize:         64,
+						SlidingWindowSize: 4096,
+					},
+				},
+			},
+		})
+
+		groups := registry.GetAttentionGroups("DeepSeek-V3")
+		require.NotNil(t, groups)
+		assert.Len(t, groups, 2)
+
+		// Group 0: Full attention
+		assert.Equal(t, 64, registry.GetGroupBlockSize("DeepSeek-V3", 0))
+		assert.Equal(t, 0, registry.GetGroupSlidingWindow("DeepSeek-V3", 0))
+
+		// Group 1: Sliding window
+		assert.Equal(t, 64, registry.GetGroupBlockSize("DeepSeek-V3", 1))
+		assert.Equal(t, 4096, registry.GetGroupSlidingWindow("DeepSeek-V3", 1))
+
+		// Non-existent group
+		assert.Equal(t, 0, registry.GetGroupBlockSize("DeepSeek-V3", 99))
+	})
+
+	t.Run("UnknownModel_NoAttentionGroups", func(t *testing.T) {
+		registry := NewModelRegistry([]*ModelConfig{
+			{Name: "DeepSeek-V3", IsHMA: true},
+		})
+
+		groups := registry.GetAttentionGroups("unknown-model")
+		assert.Nil(t, groups, "Unknown model should have no attention groups")
+	})
+}
+
+func TestModelRegistryRegisterModel(t *testing.T) {
+	t.Run("RegisterNewModel", func(t *testing.T) {
+		registry := NewModelRegistry(nil)
+
+		assert.False(t, registry.IsHMA("new-model"))
+
+		registry.RegisterModel(&ModelConfig{
+			Name:  "new-model",
+			IsHMA: true,
+			AttentionGroups: []AttentionGroupConfig{
+				{GroupID: 0, AttentionType: AttentionTypeFull, BlockSize: 32},
+			},
+		})
+
+		assert.True(t, registry.IsHMA("new-model"))
+		assert.Equal(t, 32, registry.GetGroupBlockSize("new-model", 0))
+	})
+
+	t.Run("UpdateExistingModel", func(t *testing.T) {
+		registry := NewModelRegistry([]*ModelConfig{
+			{Name: "test-model", IsHMA: false},
+		})
+
+		assert.False(t, registry.IsHMA("test-model"))
+
+		registry.RegisterModel(&ModelConfig{
+			Name:  "test-model",
+			IsHMA: true,
+			AttentionGroups: []AttentionGroupConfig{
+				{GroupID: 0, AttentionType: AttentionTypeFull, BlockSize: 64},
+			},
+		})
+
+		assert.True(t, registry.IsHMA("test-model"))
+	})
+}

--- a/pkg/kvevents/engineadapter/vllm_adapter.go
+++ b/pkg/kvevents/engineadapter/vllm_adapter.go
@@ -141,6 +141,7 @@ func fieldAt(fields []any, i int) any {
 //	[6] medium        string|nil        (optional, omit_defaults)
 //	[7] lora_name     string|nil        (optional, omit_defaults)
 //	[8] extra_keys    [][]any|nil       (optional, omit_defaults)
+//	[9] group_idx     int|nil           (optional, omit_defaults)
 //
 // Trailing fields may be absent in older vLLM versions. Extra trailing fields
 // from newer vLLM versions are silently ignored.
@@ -221,6 +222,16 @@ func (v *VLLMAdapter) convertBlockStoredEvent(fields []any) (kvevents.GenericEve
 		}
 	}
 
+	// [9] group_idx (optional)
+	var groupIdx int
+	if raw := fieldAt(fields, 9); raw != nil {
+		idx, err := toInt(raw)
+		if err == nil {
+			groupIdx = idx
+		}
+		// Silently ignore field if it's not an int (forward compatibility)
+	}
+
 	return &kvevents.BlockStoredEvent{
 		BlockHashes: blockHashes,
 		Tokens:      tokens,
@@ -229,6 +240,7 @@ func (v *VLLMAdapter) convertBlockStoredEvent(fields []any) (kvevents.GenericEve
 		LoraID:      loraID,
 		LoraName:    loraName,
 		ExtraKeys:   extraKeys,
+		GroupIdx:    groupIdx,
 	}, nil
 }
 
@@ -238,6 +250,7 @@ func (v *VLLMAdapter) convertBlockStoredEvent(fields []any) (kvevents.GenericEve
 //	[0] tag           string
 //	[1] block_hashes  []hash
 //	[2] medium        string|nil      (optional, omit_defaults)
+//	[3] group_idx     int|nil          (optional, omit_defaults)
 func (v *VLLMAdapter) convertBlockRemovedEvent(fields []any) (kvevents.GenericEvent, error) {
 	if len(fields) < 2 {
 		return nil, fmt.Errorf("BlockRemoved: need at least 2 fields, got %d", len(fields))
@@ -261,9 +274,20 @@ func (v *VLLMAdapter) convertBlockRemovedEvent(fields []any) (kvevents.GenericEv
 		deviceTier = s
 	}
 
+	// [3] group_idx (optional)
+	var groupIdx int
+	if raw := fieldAt(fields, 3); raw != nil {
+		idx, err := toInt(raw)
+		if err == nil {
+			groupIdx = idx
+		}
+		// Silently ignore field if it's not an int (forward compatibility)
+	}
+
 	return &kvevents.BlockRemovedEvent{
 		BlockHashes: blockHashes,
 		DeviceTier:  deviceTier,
+		GroupIdx:    groupIdx,
 	}, nil
 }
 

--- a/pkg/kvevents/events.go
+++ b/pkg/kvevents/events.go
@@ -72,6 +72,7 @@ type BlockStoredEvent struct {
 	LoraID      *int
 	LoraName    *string
 	ExtraKeys   [][]any
+	GroupIdx    int // Attention group ID
 }
 
 // Type returns the event type.
@@ -83,6 +84,7 @@ func (e *BlockStoredEvent) Type() EventType {
 type BlockRemovedEvent struct {
 	BlockHashes []uint64
 	DeviceTier  string
+	GroupIdx    int // Attention group ID being evicted
 }
 
 // Type returns the event type.

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -302,7 +302,21 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 			}
 
 			// Create PodEntry for this specific event's device tier
-			podEntries := []kvblock.PodEntry{{PodIdentifier: podIdentifier, DeviceTier: deviceTier}}
+			// Check once if model uses HMA to avoid repeated lookups
+			isHMA := p.modelRegistry.IsHMA(effectiveModelName)
+
+			// Only populate StoredGroups for HMA models to save CPU and memory
+			// For simple models: skip group processing entirely (0 StoredGroups)
+			var storedGroups uint32
+			if isHMA {
+				storedGroups = 1 << ev.GroupIdx
+			}
+
+			podEntries := []kvblock.PodEntry{{
+				PodIdentifier: podIdentifier,
+				DeviceTier:    deviceTier,
+				StoredGroups:  storedGroups,
+			}}
 
 			engineKeys := make([]kvblock.BlockHash, len(ev.BlockHashes))
 			for i, hash := range ev.BlockHashes {
@@ -399,7 +413,21 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 			}
 
 			// Create PodEntry for this specific event's device tier
-			podEntries := []kvblock.PodEntry{{PodIdentifier: podIdentifier, DeviceTier: deviceTier}}
+			// Check once if model uses HMA to avoid repeated lookups
+			isHMA := p.modelRegistry.IsHMA(modelName)
+
+			// Only populate StoredGroups for HMA models to save CPU and memory
+			// For simple models: 0 StoredGroups → evict entire entry immediately
+			var storedGroups uint32
+			if isHMA {
+				storedGroups = 1 << ev.GroupIdx
+			}
+
+			podEntries := []kvblock.PodEntry{{
+				PodIdentifier: podIdentifier,
+				DeviceTier:    deviceTier,
+				StoredGroups:  storedGroups,
+			}}
 
 			// Iterate over the hashes and evict each key.
 			// The Index handles engine->request key resolution internally for both

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -51,6 +51,9 @@ type Config struct {
 	// PodDiscoveryConfig holds the configuration for pod discovery.
 	// Only used when DiscoverPods is true.
 	PodDiscoveryConfig *PodDiscoveryConfig `json:"podDiscoveryConfig,omitempty"`
+	// ModelRegistry provides model configuration for HMA vs simple model handling.
+	// If nil, NewDefaultModelRegistry() is used.
+	ModelRegistry ModelRegistry `json:"-"`
 }
 
 // PodDiscoveryConfig holds configuration for the Kubernetes pod reconciler.
@@ -94,7 +97,24 @@ type Pool struct {
 	index          kvblock.Index
 	tokenProcessor kvblock.TokenProcessor
 	adapter        EngineAdapter
+	modelRegistry  ModelRegistry
 	wg             sync.WaitGroup
+}
+
+// ModelRegistry interface defines methods for retrieving model configurations.
+type ModelRegistry interface {
+	IsHMA(modelName string) bool
+}
+
+// defaultModelRegistry is a simple implementation that treats all models as non-HMA.
+type defaultModelRegistry struct{}
+
+func newDefaultModelRegistry() ModelRegistry {
+	return &defaultModelRegistry{}
+}
+
+func (r *defaultModelRegistry) IsHMA(modelName string) bool {
+	return false
 }
 
 // NewPool creates a Pool with a sharded worker setup.
@@ -107,12 +127,20 @@ func NewPool(cfg *Config, index kvblock.Index, tokenProcessor kvblock.TokenProce
 		cfg = DefaultConfig()
 	}
 
+	// Use provided model registry or default
+	modelRegistry := cfg.ModelRegistry
+	if modelRegistry == nil {
+		// Import required - will add at top of file
+		modelRegistry = newDefaultModelRegistry()
+	}
+
 	p := &Pool{
 		queues:         make([]workqueue.TypedRateLimitingInterface[*RawMessage], cfg.Concurrency),
 		concurrency:    cfg.Concurrency,
 		index:          index,
 		tokenProcessor: tokenProcessor,
 		adapter:        adapter,
+		modelRegistry:  modelRegistry,
 	}
 
 	for i := 0; i < p.concurrency; i++ {


### PR DESCRIPTION
  Summary         

  - Model Registry: Added ModelConfig and ModelRegistry to configure HMA (Hybrid Multi-head Attention) models with per-group attention settings (full vs sliding window, block size,
   window size)
  - Event pipeline: Extended BlockStoredEvent / BlockRemovedEvent with GroupIdx field, parsed from vLLM msgpack events. Pool converts GroupIdx to a StoredGroups bitmask (1 <<      
  GroupIdx) for HMA models; non-HMA models keep StoredGroups = 0 to save memory                                                                                                     
  - Index backends: Reworked all three index implementations (InMemoryIndex, CostAwareMemoryIndex, RedisIndex) to use string-keyed pod caches ("podID@tier" → *PodEntry) instead of
  PodEntry-as-key, enabling in-place StoredGroups bitmask merging on Add and partial group eviction on Evict                                                                        
  - Redis: Added Lua scripts (mergeGroupsLua, evictGroupsLua) for atomic bitmask merge/clear operations; switched Lookup from HKeys to HGetAll to persist and retrieve StoredGroups
                                                                                                                                                                                    
  Key design decisions
                                                                                                                                                                                    
  - Bitmask over slice: StoredGroups uint32 supports up to 32 attention groups with O(1) merge/clear via bitwise ops, zero allocation overhead                                      
  - String key with pointer value: Allows same pod+tier entries with different groups to merge rather than duplicate. Pointer enables in-place mutation without cache re-insertion
  (except Redis which uses Lua)                                                                                                                                                     
  - Non-HMA short-circuit: StoredGroups == 0 triggers full entry removal on evict, preserving existing behavior for simple models with zero overhead