### PR TITLE
build: Move fs-connector to use vllm v0.19.1

### DIFF
--- a/kv_connectors/llmd_fs_backend/Dockerfile.dev
+++ b/kv_connectors/llmd_fs_backend/Dockerfile.dev
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Use the vLLM base image
-FROM vllm/vllm-openai:v0.18.0
+FROM vllm/vllm-openai:v0.19.1
 
 # 1. Install system dependencies
 # We need the CUDA toolkit headers to compile the C++ extension. Install the 12.9 toolkit

--- a/kv_connectors/llmd_fs_backend/README.md
+++ b/kv_connectors/llmd_fs_backend/README.md
@@ -20,14 +20,14 @@ For simple setups, see the **Storage Cleanup** section.
 
 ## System Requirements
 
-- vLLM version 0.18.x. Previous versions are supported via their matching wheels in the [wheels](./wheels) folder or the corresponding llm-d-kv-cache release assets.
+- vLLM version 0.19.x. Previous versions are supported via their matching wheels in the [wheels](./wheels) folder or the corresponding llm-d-kv-cache release assets.
 
 ## Installation
 
 ### 1. Install from a pre-built wheel (Recommended)
 
 ```bash
-pip install https://raw.githubusercontent.com/llm-d/llm-d-kv-cache/main/kv_connectors/llmd_fs_backend/wheels/llmd_fs_connector-0.18-cp312-cp312-linux_x86_64.whl
+pip install https://raw.githubusercontent.com/llm-d/llm-d-kv-cache/main/kv_connectors/llmd_fs_backend/wheels/llmd_fs_connector-0.19-cp312-cp312-linux_x86_64.whl
 ```
 
 This installs:

--- a/kv_connectors/llmd_fs_backend/csrc/storage/backends/fs_gds/gds_file_io.cpp
+++ b/kv_connectors/llmd_fs_backend/csrc/storage/backends/fs_gds/gds_file_io.cpp
@@ -60,16 +60,18 @@ GdsFileIO::GdsFileIO(const std::vector<std::pair<void*, size_t>>& gpu_buffers,
 
     // Register GPU buffers with optional per-block registration
     size_t total_bytes = 0;
+    size_t success_count = 0;
     for (const auto& [ptr, size] : gpu_buffers) {
       if (!register_gpu_buffer(ptr, size, block_size)) {
         FS_LOG_WARN("GdsFileIO: Failed to register buffer " << ptr);
       } else {
         total_bytes += size;
+        ++success_count;
       }
     }
-    FS_LOG_INFO("GdsFileIO: Registered " << gpu_buffers.size() << " buffers ("
-                                         << (total_bytes / (1024.0 * 1024.0))
-                                         << " MB total)");
+    FS_LOG_INFO("GdsFileIO: Registered "
+                << success_count << "/" << gpu_buffers.size() << " buffers ("
+                << (total_bytes / (1024.0 * 1024.0)) << " MB total)");
   } else {
     FS_LOG_WARN("GdsFileIO: GDS initialization failed");
   }

--- a/kv_connectors/llmd_fs_backend/docs/deployment/vllm-storage.yaml
+++ b/kv_connectors/llmd_fs_backend/docs/deployment/vllm-storage.yaml
@@ -34,12 +34,12 @@ spec:
         fsGroup: 1001060000
       containers:
       - name: vllm
-        image: vllm/vllm-openai:v0.18.1
+        image: vllm/vllm-openai:v0.19.1
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "-c"]
         args:
         - |
-          pip install https://raw.githubusercontent.com/llm-d/llm-d-kv-cache/main/kv_connectors/llmd_fs_backend/wheels/llmd_fs_connector-0.18-cp312-cp312-linux_x86_64.whl
+          pip install https://raw.githubusercontent.com/llm-d/llm-d-kv-cache/main/kv_connectors/llmd_fs_backend/wheels/llmd_fs_connector-0.19-cp312-cp312-linux_x86_64.whl
           vllm serve Qwen/Qwen3-32B \
           --tensor-parallel-size 2 \
           --trust-remote-code \

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
@@ -14,13 +14,11 @@
 
 from collections.abc import Iterator
 
-import torch
 from vllm.config import VllmConfig
-from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.kv_offload.abstract import LoadStoreSpec, OffloadingManager
 from vllm.v1.kv_offload.mediums import GPULoadStoreSpec
-from vllm.v1.kv_offload.spec import OffloadingSpec
+from vllm.v1.kv_offload.spec import CanonicalKVCaches, OffloadingSpec
 from vllm.v1.kv_offload.worker.worker import OffloadingHandler
 
 from llmd_fs_backend.file_mapper import FileMapper
@@ -110,15 +108,13 @@ class SharedStorageOffloadingSpec(OffloadingSpec):
 
     def get_handlers(
         self,
-        kv_caches: dict[str, torch.Tensor],
-        attn_backends: dict[str, type[AttentionBackend]],
+        kv_caches: CanonicalKVCaches,
     ) -> Iterator[tuple[type[LoadStoreSpec], type[LoadStoreSpec], OffloadingHandler]]:
         if not self._handlers:
             self._handlers = StorageOffloadingHandlers(
                 file_mapper=self.file_mapper,
                 gpu_blocks_per_file=self.gpu_blocks_per_file,
                 gpu_block_size=self.gpu_block_size[0],
-                attn_backends=attn_backends,
                 kv_caches=kv_caches,
                 threads_per_gpu=self.threads_per_gpu,
                 max_staging_memory_gb=self.max_staging_memory_gb,

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/worker.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/worker.py
@@ -18,8 +18,8 @@ import time
 
 import storage_offload
 import torch
-from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.kv_offload.mediums import GPULoadStoreSpec
+from vllm.v1.kv_offload.spec import CanonicalKVCaches
 from vllm.v1.kv_offload.worker.worker import (
     OffloadingHandler,
     TransferResult,
@@ -244,8 +244,7 @@ class StorageOffloadingHandlers:
 
     def __init__(
         self,
-        kv_caches: dict[str, torch.Tensor],
-        attn_backends: dict[str, type[AttentionBackend]],
+        kv_caches: CanonicalKVCaches,
         file_mapper: FileMapper,
         gpu_block_size: int,
         gpu_blocks_per_file: int,
@@ -255,13 +254,8 @@ class StorageOffloadingHandlers:
         read_preferring_ratio: float = DEFAULT_READ_PREFERRING_WORKERS_RATIO,
     ):
         threads_per_gpu = min(threads_per_gpu, int(os.cpu_count()))
-        tensors, kernel_block_size = StorageOffloadingHandlers._get_tensors(
-            kv_caches, attn_backends
-        )
+        tensors = [t.tensor for t in kv_caches.tensors]
         assert tensors
-        assert gpu_block_size % kernel_block_size == 0
-
-        kernel_blocks_per_gpu_block = gpu_block_size // kernel_block_size
 
         # Validate GDS mode
         valid_gds_modes = [
@@ -281,9 +275,7 @@ class StorageOffloadingHandlers:
             gds_mode = "disabled"
 
         # Compute staging memory buffer size
-        buffer_size_mb = self._compute_buffer_size_mb(
-            tensors, gpu_blocks_per_file, kernel_blocks_per_gpu_block
-        )
+        buffer_size_mb = self._compute_buffer_size_mb(tensors, gpu_blocks_per_file)
 
         # Adjust threads_per_gpu if exceeding max_staging_memory_gb.
         # Skip for full-GDS modes — CPU staging buffer is not used.
@@ -313,9 +305,8 @@ class StorageOffloadingHandlers:
             gds_mode=gds_mode,
         )
 
-        # Compute per-GPU-block size in bytes for metrics across all layers.
-        kernel_block_bytes = sum(t.stride(0) * t.element_size() for t in tensors)
-        per_block_bytes = kernel_block_bytes * kernel_blocks_per_gpu_block
+        # Compute per-GPU-block size in bytes for metrics across all tensors.
+        per_block_bytes = sum(t.stride(0) * t.element_size() for t in tensors)
         logger.info(
             f"StorageOffloadingHandlers: "
             f"threads_per_gpu={threads_per_gpu}, "
@@ -351,102 +342,20 @@ class StorageOffloadingHandlers:
         self,
         tensors: list[torch.Tensor],
         gpu_blocks_per_file: int,
-        kernel_blocks_per_gpu_block: int,
     ):
         """
-        Estimate staging memory size in MB, applying min/max limits.
+        Estimate staging memory size in MB.
 
         Args:
-            tensors: List of KV-cache tensors used to infer per-block memory usage.
+            tensors: List of canonical KV-cache tensors (num_blocks, page_size_bytes).
             gpu_blocks_per_file: Number of GPU blocks grouped into a single file.
-            kernel_blocks_per_gpu_block: Number of kernel blocks grouped into
-                                         a single GPU block.
 
         Returns:
             Estimated staging buffer size in megabytes.
         """
-        kernel_block_size_in_bytes = 0
-        for tensor in tensors:
-            kernel_block_size_in_bytes += tensor.stride(0) * tensor.element_size()
-        kernel_blocks_per_file = kernel_blocks_per_gpu_block * gpu_blocks_per_file
-        file_size_in_bytes = kernel_block_size_in_bytes * kernel_blocks_per_file
+        bytes_per_gpu_block = sum(
+            tensor.stride(0) * tensor.element_size() for tensor in tensors
+        )
+        file_size_in_bytes = bytes_per_gpu_block * gpu_blocks_per_file
         file_size_mb = math.ceil(file_size_in_bytes / (1 << 20))
         return file_size_mb
-
-    @staticmethod
-    def _get_tensors(
-        kv_caches: dict[str, torch.Tensor],
-        attn_backends: dict[str, type[AttentionBackend]],
-    ) -> tuple[list[torch.Tensor], int]:
-        """
-        Splits the given KV caches to tensors such that
-            each tensor shape is (num_blocks, ...).
-
-        Returns:
-            (list_of_kv_cache_tensors, kernel_block_size)
-        """
-        tensors: list[torch.Tensor] = []
-        kernel_block_size: int | None = None
-
-        for layer_name, gpu_tensor in kv_caches.items():
-            gpu_shape = gpu_tensor.shape
-            attn_backend = attn_backends[layer_name]
-
-            # Generate a reference KV-cache shape using known parameters.
-            # We compare gpu_shape with this synthetic shape to infer the layout.
-            test_shape = attn_backend.get_kv_cache_shape(
-                num_blocks=1234, block_size=16, num_kv_heads=8, head_size=256
-            )
-
-            split_k_and_v = False
-            has_layers_dim = False
-            if len(gpu_shape) != len(test_shape):
-                # Case 1: Cross-layer tensor - an extra layer dimension exists.
-                # In this case, num_blocks is the leading dimension.
-                assert len(gpu_shape) == len(test_shape) + 1
-                has_layers_dim = True
-                # prepend a dummy num_layers=80 to test_shape
-                test_shape = (80,) + test_shape
-            elif test_shape[0] == 1234:
-                # Case 2: Standard layout - each element represents a single layer with
-                # tensor shaped as (num_blocks, ...).
-                # The first dimension matches num_blocks.
-                pass
-            else:
-                # Case 3: (2, num_blocks, ...) - standard layout but with KV first:
-                # (2, num_blocks, heads, block_size, head_size).
-                assert test_shape[0] == 2
-                assert test_shape[1] == 1234
-                assert gpu_shape[0] == 2
-                split_k_and_v = True
-
-            if split_k_and_v:
-                # split tensor to k-tensor and v-tensor
-                for sub_tensor in gpu_tensor:
-                    tensors.append(sub_tensor)
-            else:
-                tensors.append(gpu_tensor)
-
-            try:
-                kv_cache_stride_order = attn_backend.get_kv_cache_stride_order(
-                    include_num_layers_dimension=has_layers_dim
-                )
-                assert len(kv_cache_stride_order) == len(gpu_shape)
-            except (AttributeError, NotImplementedError):
-                kv_cache_stride_order = tuple(range(len(gpu_shape)))
-
-            # permute test_shape according to stride_order
-            test_shape = tuple(test_shape[i] for i in kv_cache_stride_order)
-
-            # find block_size (16) dimension index
-            block_size_idx = test_shape.index(16)
-            if kernel_block_size is not None:
-                assert kernel_block_size == gpu_shape[block_size_idx]
-            else:
-                kernel_block_size = gpu_shape[block_size_idx]
-
-        assert len({t.stride(0) for t in tensors}) == 1, (
-            "All KV-cache tensors must have the same block element stride."
-        )
-        assert kernel_block_size
-        return tensors, kernel_block_size

--- a/kv_connectors/llmd_fs_backend/pyproject.toml
+++ b/kv_connectors/llmd_fs_backend/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llmd_fs_connector"
-version = "0.18"
+version = "0.19"
 description = "Standalone llm-d fs storage connector"
 readme = "README.md"
 authors = [
@@ -36,7 +36,7 @@ llmd_fs_metric_patch = "llmd_fs_backend.metrics:install_offload_metric_suffix_pa
 
 [project.optional-dependencies]
 dev = [
-    "vllm==0.18.1",
+    "vllm==0.19.1",
     "pytest",
     "black",
     "ruff",

--- a/kv_connectors/llmd_fs_backend/tests/test_fs_backend.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_fs_backend.py
@@ -23,9 +23,13 @@ from collections.abc import Iterable
 
 import pytest
 import torch
-from vllm.v1.attention.backends.flash_attn import FlashAttentionBackend
 from vllm.v1.core.kv_cache_utils import BlockHash
 from vllm.v1.kv_offload.mediums import GPULoadStoreSpec
+from vllm.v1.kv_offload.spec import (
+    CanonicalKVCacheRef,
+    CanonicalKVCaches,
+    CanonicalKVCacheTensor,
+)
 
 from llmd_fs_backend.file_mapper import FileMapper
 from llmd_fs_backend.mediums import SharedStorageLoadStoreSpec
@@ -54,6 +58,45 @@ def create_dummy_kv_tensors(
     return [torch.rand(shape, dtype=dtype, device="cuda") for _ in range(num_layers)]
 
 
+def make_canonical_kv_caches(
+    kv_tensors: list[torch.Tensor],
+) -> CanonicalKVCaches:
+    """Build a CanonicalKVCaches aliasing the storage of test KV tensors.
+
+    Test-side equivalent of vLLM's upstream canonicalization for FlashAttention.
+    Each layer tensor has shape (2, num_blocks, block_size, num_heads, head_size)
+    in fp16; canonical form wants (num_blocks, page_size_bytes) int8, with K and V
+    as separate tensors. We build those views zero-copy so that writes through the
+    canonical tensors hit the same storage the test later inspects.
+    """
+    canonical_tensors: list[CanonicalKVCacheTensor] = []
+    for layer_tensor in kv_tensors:
+        assert layer_tensor.shape[0] == 2  # dim 0 is K/V, dim 1 is num_blocks
+        num_blocks = layer_tensor.shape[1]
+        # Bytes per block for K (or V) alone — full page is K+V, so "half".
+        half_page_bytes = layer_tensor.stride(1) * layer_tensor.element_size()
+
+        # Reinterpret the same storage as int8 (element_size=1 → shape values are
+        # byte counts; dtype-agnostic byte-level view). Zero copy.
+        raw = (
+            torch.tensor([], dtype=torch.int8, device=layer_tensor.device)
+            .set_(layer_tensor.untyped_storage())
+            .view(2, num_blocks, half_page_bytes)
+        )
+        # Split into K-view and V-view, each (num_blocks, half_page_bytes) int8.
+        for sub in raw.unbind(0):
+            canonical_tensors.append(
+                CanonicalKVCacheTensor(tensor=sub, page_size_bytes=half_page_bytes)
+            )
+
+    # Single KV cache group: all tensors belong to group 0.
+    group_refs = [
+        CanonicalKVCacheRef(tensor_idx=i, page_size_bytes=t.page_size_bytes)
+        for i, t in enumerate(canonical_tensors)
+    ]
+    return CanonicalKVCaches(tensors=canonical_tensors, group_data_refs=[group_refs])
+
+
 def get_prefix_hash(token_ids: Iterable[int]) -> BlockHash:
     """Generate a stable 64-bit hash for a list of token IDs
     by packing each as uint32."""
@@ -66,8 +109,8 @@ def get_prefix_hash(token_ids: Iterable[int]) -> BlockHash:
 
 
 def make_gpu_specs(block_ids: list[int]) -> GPULoadStoreSpec:
-    """Create GPULoadStoreSpec objects for the given block IDs."""
-    return GPULoadStoreSpec(block_ids)
+    """Create GPULoadStoreSpec objects for the given block IDs (single KV group)."""
+    return GPULoadStoreSpec(block_ids, group_sizes=[len(block_ids)])
 
 
 def make_storage_specs(
@@ -227,20 +270,14 @@ def roundtrip_once(
     put_storage_specs, block_hashes = make_storage_specs(put_num_files)
     cleanup_files(file_mapper, block_hashes)
 
-    # set names for layers
-    attn_backends = {f"layer_{i}": FlashAttentionBackend for i in range(num_layers)}
-    kv_caches_original = {f"layer_{i}": original[i] for i in range(num_layers)}
-    kv_caches_restored = {f"layer_{i}": restored[i] for i in range(num_layers)}
-
     # PUT phase
     kv_caches_original_handler = StorageOffloadingHandlers(
         file_mapper=file_mapper,
         gds_mode=gds_mode,
-        kv_caches=kv_caches_original,
+        kv_caches=make_canonical_kv_caches(original),
         gpu_blocks_per_file=gpu_blocks_per_file,
         gpu_block_size=gpu_block_size,
         threads_per_gpu=threads_per_gpu,
-        attn_backends=attn_backends,
     )
     put_handler = kv_caches_original_handler.gpu_to_storage_handler
     start_put = time.time()
@@ -262,11 +299,10 @@ def roundtrip_once(
     # GET phase
     kv_caches_restored_handler = StorageOffloadingHandlers(
         file_mapper=file_mapper,
-        kv_caches=kv_caches_restored,
+        kv_caches=make_canonical_kv_caches(restored),
         gpu_blocks_per_file=gpu_blocks_per_file,
         threads_per_gpu=threads_per_gpu,
         gpu_block_size=gpu_block_size,
-        attn_backends=attn_backends,
         gds_mode=gds_mode,
     )
     get_handler = kv_caches_restored_handler.storage_to_gpu_handler

--- a/kv_connectors/llmd_fs_backend/tests/test_priority_queue.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_priority_queue.py
@@ -12,7 +12,6 @@
 import time
 
 import torch
-from vllm.v1.attention.backends.flash_attn import FlashAttentionBackend
 
 from llmd_fs_backend.file_mapper import FileMapper
 from llmd_fs_backend.mediums import SharedStorageLoadStoreSpec
@@ -21,6 +20,7 @@ from tests.test_fs_backend import (
     TMP_DIR,
     cleanup_files,
     create_dummy_kv_tensors,
+    make_canonical_kv_caches,
     make_gpu_specs,
     make_storage_specs,
     wait_for,
@@ -68,22 +68,16 @@ def create_test_handler(
         config["dtype"],
     )
 
-    attn_backends = {
-        f"layer_{i}": FlashAttentionBackend for i in range(config["num_layers"])
-    }
-    kv_dict = {f"layer_{i}": kv_cache[i] for i in range(config["num_layers"])}
-
     handler = StorageOffloadingHandlers(
         file_mapper=file_mapper,
-        kv_caches=kv_dict,
+        kv_caches=make_canonical_kv_caches(kv_cache),
         gpu_blocks_per_file=config["gpu_blocks_per_file"],
         gpu_block_size=config["gpu_block_size"],
         threads_per_gpu=threads_per_gpu,
-        attn_backends=attn_backends,
         gds_mode="disabled",
     )
 
-    return handler, {"file_mapper": file_mapper, "kv_dict": kv_dict}
+    return handler, {"file_mapper": file_mapper, "kv_cache": kv_cache}
 
 
 def test_priority_completion_order(default_vllm_config):


### PR DESCRIPTION
## Summary

- Port `fs_backend` to vLLM v0.19's `OffloadingSpec.get_handlers(kv_caches: CanonicalKVCaches)` API (vLLM v0.19 canonicalizes each KV tensor to `(num_blocks, page_size_bytes)` int8 upstream, so connectors no longer do per-backend layout analysis — drops the ~80-line `_get_tensors()` helper and the `kernel_block_size` concept).
- Adapt hand-rolled test `GPULoadStoreSpec` calls to the new `group_sizes=` requirement; add `make_canonical_kv_caches` helper that mirrors vLLM's FlashAttention canonicalization (int8 reinterpret + unbind) with storage aliasing preserved.
- Fix misleading `GdsFileIO` log that reported requested buffer count instead of success count (`Registered N buffers (0 MB total)` → `Registered M/N buffers (X MB total)`).
- Bump `pyproject.toml` dev dep, `Dockerfile.dev` base image, `README.md`, and `docs/deployment/vllm-storage.yaml` to v0.19.1; add matching v0.19 wheel.

## Test plan

- [x] `make test` (full pytest suite) — **20 passed** on v0.19.1
- [x] E2E test with `meta-llama/Meta-Llama-3.1-8B`
- [ ] E2E test with `Qwen/Qwen3-4B`