### PR TITLE
[1/3] deprecating internal tokenization on the lookup path

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -101,6 +101,12 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    rules:
+      # Examples and UDS e2e tests intentionally exercise the deprecated
+      # internal-tokenization path during the deprecation window of #517.
+      - path: '^(examples/|tests/e2e/uds_tokenizer/)'
+        linters: [staticcheck]
+        text: '^SA1019'
     paths:
       - third_party$
       - builtin$

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,7 @@ The indexer is built from several modules with separated concerns:
 |:---|:---|:---|
 | `kvcache.Indexer` | Orchestrator — coordinates block-key computation, index lookup, and scoring. | — |
 | `kvblock.TokenProcessor` | Converts a token sequence into a deterministic list of block keys. Reproduces each engine's chained FNV-64a over CBOR content-addressing scheme. | — |
-| `tokenization.Pool` | Worker pool for rendering and tokenizing prompts. Sources tokenizers from a UDS sidecar, from local files, or from HuggingFace Hub. | — |
+| `tokenization.Pool` | Deprecated in-process worker pool backing the prompt-string APIs. New integrations tokenize externally and call `ScoreTokens` directly. | — |
 | `kvblock.Scorer` | Computes per-pod scores from block keys and lookup results. | Longest consecutive prefix match, weighted by device tier. |
 | `kvblock.Index` | The block index itself. Pluggable interface storing `requestKey → []PodEntry` plus the auxiliary `engineKey → requestKey` map. | Two-level in-memory LRU. |
 | `kvevents.Pool` | Sharded worker pool that consumes ZMQ messages, orders them per-pod (FNV-1a on pod ID), and applies them to the index. | — |
@@ -26,7 +26,7 @@ flowchart LR
         direction TB
         Indexer["kvcache.Indexer<br/>(orchestrator)"]
         TP["kvblock.TokenProcessor<br/>(tokens → block keys)"]
-        Tokzr["tokenization.Pool<br/>(UDS / embedded)"]
+        Tokzr["tokenization.Pool<br/>(deprecated)"]
         BScorer["kvblock.Scorer<br/>(longest-prefix match)"]
         Index["kvblock.Index<br/>(block key → pods)"]
         Pool["kvevents.Pool<br/>(sharded ZMQ workers)"]
@@ -286,16 +286,9 @@ The library exposes the primitive; the policy (when to insert, what TTL) is deci
 > `kvcache.NewDefaultConfig()` no longer pre-populates `TokenizersPoolConfig`;
 > callers that still rely on the deprecated path must set it explicitly.
 
-Efficient tokenization matters because the Read Path computes request keys synchronously per request. Historically the indexer shipped an in-process worker pool with a composite tokenizer:
+Tokenization happens **outside the indexer**. The host (e.g. llm-d's EPP) renders prompts and feeds token IDs to `Indexer.ScoreTokens`. The indexer is agnostic to the tokenizer source as long as the resulting token IDs match what the engines emit in their KV-events.
 
-- **`tokenization.Pool`** — supports both synchronous (for scoring requests — complete results required) and asynchronous (fire-and-forget) modes.
-- **Tokenizer backends**:
-  - **`CachedLocalTokenizer`** — loads tokenizers from local files. Useful for air-gapped environments, custom tokenizers, or pre-loaded models. Supports manual mapping, auto-discovery of HuggingFace cache layouts (`models--org--model/snapshots/{hash}/tokenizer.json`), and custom directory structures.
-  - **`CachedHFTokenizer`** — downloads and caches tokenizers from HuggingFace. Wraps HF's Rust tokenizers and maintains an LRU cache of active instances.
-  - **`CompositeTokenizer`** — tries backends in order, falling back from local to HuggingFace.
-- **Caching** — all tokenizer backends maintain an LRU of loaded tokenizer instances to avoid repeated disk loads.
-
-The library can also be driven by an **external tokenizer sidecar** over a Unix domain socket. This is the path forward: it isolates tokenizer downloads and Python dependencies from the host process, and aligns with the tokens-in API direction.
+For backwards-compatibility, the indexer still ships a deprecated in-process `tokenization.Pool` backing the prompt-string APIs (`GetPodScores`, `ComputeBlockKeys`). The pool and those APIs will be removed once consumers migrate to `ScoreTokens`.
 
 -----
 
@@ -303,7 +296,6 @@ The library can also be driven by an **external tokenizer sidecar** over a Unix 
 
 The indexer relies on several external libraries:
 
-- **Tokenization** — HuggingFace Rust tokenizers via Go bindings (embedded path), or an external tokenizer sidecar over UDS (recommended for production).
 - **[go-zeromq/zmq4](https://github.com/go-zeromq/zmq4)** — pure-Go ZeroMQ implementation used by the event processing pool. Does not require `libzmq` on the host.
 
 -----

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -275,16 +275,27 @@ The library exposes the primitive; the policy (when to insert, what TTL) is deci
 
 ### Tokenization Subsystem
 
-Efficient tokenization matters because the Read Path computes request keys synchronously per request. The system uses a worker pool with a composite tokenizer:
+> [!WARNING]
+> **Internal tokenization is deprecated.** New integrations should tokenize
+> externally — in the host process or a sidecar — and feed token IDs into
+> `Indexer.ScoreTokens` (or `Indexer.ComputeBlockKeysFromTokens`) directly.
+> The prompt-string entry points (`Indexer.GetPodScores`, `Indexer.ComputeBlockKeys`)
+> and the `tokenization.Pool` they depend on are retained for
+> backwards-compatibility and will be removed in a future release.
+>
+> `kvcache.NewDefaultConfig()` no longer pre-populates `TokenizersPoolConfig`;
+> callers that still rely on the deprecated path must set it explicitly.
+
+Efficient tokenization matters because the Read Path computes request keys synchronously per request. Historically the indexer shipped an in-process worker pool with a composite tokenizer:
 
 - **`tokenization.Pool`** — supports both synchronous (for scoring requests — complete results required) and asynchronous (fire-and-forget) modes.
 - **Tokenizer backends**:
   - **`CachedLocalTokenizer`** — loads tokenizers from local files. Useful for air-gapped environments, custom tokenizers, or pre-loaded models. Supports manual mapping, auto-discovery of HuggingFace cache layouts (`models--org--model/snapshots/{hash}/tokenizer.json`), and custom directory structures.
   - **`CachedHFTokenizer`** — downloads and caches tokenizers from HuggingFace. Wraps HF's Rust tokenizers and maintains an LRU cache of active instances.
-  - **`CompositeTokenizer`** (default) — tries backends in order, falling back from local to HuggingFace. Best of both worlds: fast local access when available, remote fetching otherwise.
+  - **`CompositeTokenizer`** — tries backends in order, falling back from local to HuggingFace.
 - **Caching** — all tokenizer backends maintain an LRU of loaded tokenizer instances to avoid repeated disk loads.
 
-The library can also be driven by an **external tokenizer sidecar** over a Unix domain socket, in which case the internal `tokenization.Pool` is not used. This is the recommended setup for production deployments (isolates tokenizer downloads and Python dependencies from the host process).
+The library can also be driven by an **external tokenizer sidecar** over a Unix domain socket. This is the path forward: it isolates tokenizer downloads and Python dependencies from the host process, and aligns with the tokens-in API direction.
 
 -----
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,7 +50,7 @@ The indexer configuration structure for the KV Cache Indexer module.
 | Field | Type | Description | Default |
 |-------|------|-------------|---------|
 | `kvBlockIndexConfig` | [IndexConfig](#index-configuration-indexconfig) | Configuration for KV block indexing | See defaults |
-| `tokenizersPoolConfig` | [Config](#tokenization-pool-configuration-config) | Configuration for tokenization pool | See defaults |
+| `tokenizersPoolConfig` | [Config](#tokenization-pool-configuration-config) | **Deprecated.** Configuration for the in-process tokenization pool. Leave unset (`null`) and tokenize externally; the indexer accepts token IDs via `ScoreTokens`. | `null` |
 | `kvCacheBackendConfigs` | [KVCacheBackendConfig](#kv-cache-backend-configuration-kvcachebackendconfig) | Configuration for KV Cache Device Backends | See defaults |
 
 
@@ -183,6 +183,14 @@ Configures the Valkey-backed KV block index implementation. Valkey is a Redis-co
 **Note**: Both Redis and Valkey configurations use the same `RedisIndexConfig` structure since Valkey is API-compatible with Redis.
 
 ## Tokenization Configuration
+
+> **Deprecated.** The in-process tokenization pool described below is retained
+> only for backwards-compatibility with the prompt-string indexer APIs
+> (`GetPodScores`, `ComputeBlockKeys`). New integrations should tokenize
+> externally — in the host process or a sidecar — and feed token IDs into
+> `Indexer.ScoreTokens` (or `Indexer.ComputeBlockKeysFromTokens`) directly.
+> When `tokenizersPoolConfig` is left unset, the indexer skips pool creation
+> and the prompt-string entry points return an error.
 
 ### Tokenization Pool Configuration (`Config`)
 

--- a/examples/helper/indexer.go
+++ b/examples/helper/indexer.go
@@ -38,10 +38,29 @@ func isTCPAddr(s string) bool {
 	return err == nil && host != "" && port != ""
 }
 
-// ApplyTokenizerEndpoint reads TOKENIZER_ENDPOINT and sets UDS config on the given config.
+// ConfigureInternalTokenizer wires up the in-process tokenization pool for
+// examples that still drive the prompt-string indexer APIs.
+//
+// Deprecated: tokenize externally and call Indexer.ScoreTokens.
+func ConfigureInternalTokenizer(config *kvcache.Config, modelName string) error {
+	poolCfg, err := tokenization.DefaultConfig()
+	if err != nil {
+		return err
+	}
+	poolCfg.ModelName = modelName
+	config.TokenizersPoolConfig = poolCfg
+	ApplyTokenizerEndpoint(config)
+	return nil
+}
+
+// ApplyTokenizerEndpoint reads TOKENIZER_ENDPOINT and overrides the UDS config
+// on the given indexer config. No-op when TokenizersPoolConfig is nil.
 func ApplyTokenizerEndpoint(config *kvcache.Config) {
 	endpoint := os.Getenv(EnvTokenizerEndpoint)
 	if endpoint == "" {
+		return
+	}
+	if config.TokenizersPoolConfig == nil {
 		return
 	}
 	config.TokenizersPoolConfig.UdsTokenizerConfig = &tokenization.UdsTokenizerConfig{
@@ -56,8 +75,9 @@ func getKVCacheIndexerConfig() (*kvcache.Config, error) {
 		return nil, err
 	}
 
-	config.TokenizersPoolConfig.ModelName = testdata.ModelName
-	ApplyTokenizerEndpoint(config)
+	if err := ConfigureInternalTokenizer(config, testdata.ModelName); err != nil {
+		return nil, err
+	}
 
 	return config, nil
 }

--- a/examples/kv_cache_aware_scorer/kvcache_aware_scorer.go
+++ b/examples/kv_cache_aware_scorer/kvcache_aware_scorer.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
@@ -73,14 +72,6 @@ func PrecisePrefixCachePluginFactory(name string, rawParameters json.RawMessage,
 	parameters := PrecisePrefixCachePluginConfig{
 		IndexerConfig:  indexerConfig,
 		KVEventsConfig: kvevents.DefaultConfig(),
-	}
-
-	// read hugging face token from environment variable if set
-	if token := os.Getenv("HF_TOKEN"); token != "" &&
-		parameters.IndexerConfig != nil &&
-		parameters.IndexerConfig.TokenizersPoolConfig != nil &&
-		parameters.IndexerConfig.TokenizersPoolConfig.HFTokenizerConfig != nil {
-		parameters.IndexerConfig.TokenizersPoolConfig.HFTokenizerConfig.HuggingFaceToken = token
 	}
 
 	if rawParameters != nil {

--- a/examples/kv_cache_index/main.go
+++ b/examples/kv_cache_index/main.go
@@ -45,9 +45,9 @@ func getKVCacheIndexerConfig() (*kvcache.Config, error) {
 		return nil, err
 	}
 
-	config.TokenizersPoolConfig.ModelName = getModelName()
-
-	helper.ApplyTokenizerEndpoint(config)
+	if err := helper.ConfigureInternalTokenizer(config, getModelName()); err != nil {
+		return nil, err
+	}
 
 	redisAddr := os.Getenv(envRedisAddr)
 	if redisAddr != "" {

--- a/examples/kv_events/online/main.go
+++ b/examples/kv_events/online/main.go
@@ -138,8 +138,9 @@ func getKVCacheIndexerConfig() (*kvcache.Config, error) {
 		return nil, err
 	}
 
-	config.TokenizersPoolConfig.ModelName = testdata.ModelName
-	helper.ApplyTokenizerEndpoint(config)
+	if err := helper.ConfigureInternalTokenizer(config, testdata.ModelName); err != nil {
+		return nil, err
+	}
 
 	config.KVBlockIndexConfig.EnableMetrics = true
 	config.KVBlockIndexConfig.MetricsLoggingInterval = 30 * time.Second

--- a/examples/valkey_example/main.go
+++ b/examples/valkey_example/main.go
@@ -85,9 +85,9 @@ func createValkeyConfig() (*kvcache.Config, error) {
 		return nil, fmt.Errorf("failed to create default config: %w", err)
 	}
 
-	config.TokenizersPoolConfig.ModelName = testdata.ModelName
-
-	helper.ApplyTokenizerEndpoint(config)
+	if err := helper.ConfigureInternalTokenizer(config, testdata.ModelName); err != nil {
+		return nil, fmt.Errorf("failed to configure internal tokenizer: %w", err)
+	}
 
 	// Configure Valkey backend
 	valkeyAddr := os.Getenv(envValkeyAddr)

--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -135,7 +135,11 @@ func (k *Indexer) KVBlockIndex() kvblock.Index {
 	return k.kvBlockIndex
 }
 
-var errInternalTokenizationDisabled = fmt.Errorf(
+// ErrInternalTokenizationDisabled is returned by the deprecated prompt-string
+// entry points when the indexer was constructed without TokenizersPoolConfig.
+// Callers can inspect it via errors.Is to distinguish missing-pool from other
+// failures.
+var ErrInternalTokenizationDisabled = fmt.Errorf(
 	"internal tokenization not configured: tokenize externally and call ScoreTokens / ComputeBlockKeysFromTokens")
 
 // ComputeBlockKeys computes the KV-block keys for a given prompt and model name.
@@ -144,7 +148,7 @@ var errInternalTokenizationDisabled = fmt.Errorf(
 func (k *Indexer) ComputeBlockKeys(ctx context.Context, renderReq *types.RenderChatRequest, prompt, modelName string,
 ) ([]kvblock.BlockHash, error) {
 	if k.tokenizersPool == nil {
-		return nil, errInternalTokenizationDisabled
+		return nil, ErrInternalTokenizationDisabled
 	}
 
 	// 1. tokenize prompt
@@ -200,7 +204,7 @@ func (k *Indexer) GetPodScores(ctx context.Context, renderReq *types.RenderChatR
 	podIdentifiers []string,
 ) (map[string]float64, error) {
 	if k.tokenizersPool == nil {
-		return nil, errInternalTokenizationDisabled
+		return nil, ErrInternalTokenizationDisabled
 	}
 
 	// 1. tokenize prompt

--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -38,24 +38,26 @@ import (
 // The configuration cover the different components found in the Indexer
 // module.
 type Config struct {
-	KVBlockIndexConfig   *kvblock.IndexConfig    `json:"kvBlockIndexConfig"`
-	KVBlockScorerConfig  *KVBlockScorerConfig    // not exported
-	TokenizersPoolConfig *tokenization.Config    `json:"tokenizersPoolConfig"`
-	BackendConfigs       []*KVCacheBackendConfig `json:"kvCacheBackendConfigs"`
+	KVBlockIndexConfig  *kvblock.IndexConfig    `json:"kvBlockIndexConfig"`
+	KVBlockScorerConfig *KVBlockScorerConfig    // not exported
+	BackendConfigs      []*KVCacheBackendConfig `json:"kvCacheBackendConfigs"`
+
+	// TokenizersPoolConfig configures the in-process tokenization pool.
+	// Leaving it nil disables the pool; the prompt-string entry points then
+	// return an error.
+	//
+	// Deprecated: tokenize externally and call Indexer.ScoreTokens.
+	TokenizersPoolConfig *tokenization.Config `json:"tokenizersPoolConfig,omitempty"`
 }
 
 // NewDefaultConfig returns a default configuration for the Indexer module.
+// TokenizersPoolConfig is left nil; populate it only if the deprecated
+// prompt-string APIs are needed.
 func NewDefaultConfig() (*Config, error) {
-	tokenizerPoolConfig, err := tokenization.DefaultConfig()
-	if err != nil {
-		return &Config{}, fmt.Errorf("failed to get default tokenizer pool config: %w", err)
-	}
-
 	return &Config{
-		KVBlockIndexConfig:   kvblock.DefaultIndexConfig(),
-		KVBlockScorerConfig:  DefaultKVBlockScorerConfig(),
-		TokenizersPoolConfig: tokenizerPoolConfig,
-		BackendConfigs:       DefaultKVCacheBackendConfig(),
+		KVBlockIndexConfig:  kvblock.DefaultIndexConfig(),
+		KVBlockScorerConfig: DefaultKVBlockScorerConfig(),
+		BackendConfigs:      DefaultKVCacheBackendConfig(),
 	}, nil
 }
 
@@ -70,7 +72,9 @@ type Indexer struct {
 	tokenizersPool TokenizersPool
 }
 
-// NewKVCacheIndexer creates a KVCacheIndex given a Config.
+// NewKVCacheIndexer creates a KVCacheIndex given a Config. When
+// config.TokenizersPoolConfig is nil, the indexer accepts only the tokens-in
+// API (Indexer.ScoreTokens) and the prompt-string entry points return an error.
 func NewKVCacheIndexer(ctx context.Context, config *Config, tokenProcessor kvblock.TokenProcessor) (*Indexer, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config cannot be nil")
@@ -99,22 +103,30 @@ func NewKVCacheIndexer(ctx context.Context, config *Config, tokenProcessor kvblo
 	// When tracing is not configured, otel.Tracer() returns a no-op implementation.
 	scorer = NewTracedScorer(scorer)
 
-	tokenizersPool, err := tokenization.NewTokenizationPool(ctx, config.TokenizersPoolConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create tokenizers pool: %w", err)
-	}
-
-	return &Indexer{
+	indexer := &Indexer{
 		config:         config,
 		tokenProcessor: tokenProcessor,
 		kvBlockIndex:   kvBlockIndex,
 		kvBlockScorer:  scorer,
-		tokenizersPool: tokenizersPool,
-	}, nil
+	}
+
+	if config.TokenizersPoolConfig != nil {
+		tokenizersPool, err := tokenization.NewTokenizationPool(ctx, config.TokenizersPoolConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create tokenizers pool: %w", err)
+		}
+		indexer.tokenizersPool = tokenizersPool
+	}
+
+	return indexer, nil
 }
 
-// Run starts the indexer.
+// Run starts the indexer. Blocks until ctx is cancelled.
 func (k *Indexer) Run(ctx context.Context) {
+	if k.tokenizersPool == nil {
+		<-ctx.Done()
+		return
+	}
 	k.tokenizersPool.Run(ctx)
 }
 
@@ -123,13 +135,17 @@ func (k *Indexer) KVBlockIndex() kvblock.Index {
 	return k.kvBlockIndex
 }
 
+var errInternalTokenizationDisabled = fmt.Errorf(
+	"internal tokenization not configured: tokenize externally and call ScoreTokens / ComputeBlockKeysFromTokens")
+
 // ComputeBlockKeys computes the KV-block keys for a given prompt and model name.
-// This method extracts the tokenization and block key computation logic so that
-// callers (e.g., IGW::EPP::PrepareDataPlugin) can compute block keys once and reuse them
-// across multiple extension points without re-tokenizing.
+//
+// Deprecated: use ComputeBlockKeysFromTokens.
 func (k *Indexer) ComputeBlockKeys(ctx context.Context, renderReq *types.RenderChatRequest, prompt, modelName string,
 ) ([]kvblock.BlockHash, error) {
-	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvcache.ComputeBlockKeys")
+	if k.tokenizersPool == nil {
+		return nil, errInternalTokenizationDisabled
+	}
 
 	// 1. tokenize prompt
 	tokens, features := k.tokenizersPool.Tokenize(renderReq, prompt)
@@ -150,7 +166,17 @@ func (k *Indexer) ComputeBlockKeys(ctx context.Context, renderReq *types.RenderC
 			k.blockSize(), len(tokens))
 	}
 
-	// 4. get block keys
+	return k.ComputeBlockKeysFromTokens(ctx, tokens, modelName, extraFeatures)
+}
+
+// ComputeBlockKeysFromTokens computes the KV-block keys for a pre-tokenized
+// prompt. Callers tokenize and truncate externally. extraFeatures provides
+// per-block multimodal data that taints the hash; nil means text-only.
+func (k *Indexer) ComputeBlockKeysFromTokens(ctx context.Context, tokens []uint32, modelName string,
+	extraFeatures []*kvblock.BlockExtraFeatures,
+) ([]kvblock.BlockHash, error) {
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvcache.ComputeBlockKeysFromTokens")
+
 	blockKeys, err := k.tokenProcessor.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, modelName, extraFeatures)
 	if err != nil {
 		traceLogger.Error(err, "blockKey conversion failed")
@@ -166,15 +192,17 @@ func (k *Indexer) ComputeBlockKeys(ctx context.Context, renderReq *types.RenderC
 }
 
 // GetPodScores retrieves the pod scores for a given prompt and model name.
-// The function receives the mentioned information and a list of relevant pod
-// identifiers. A Pod identifier should be its address.
-// If the set of pod identifiers is empty, the function assumes all pods are
-// relevant.
+// A pod identifier should be its address. An empty podIdentifiers set means
+// all pods are considered.
 //
-// The function returns a map of pod identifiers to scores.
+// Deprecated: use ScoreTokens.
 func (k *Indexer) GetPodScores(ctx context.Context, renderReq *types.RenderChatRequest, prompt, modelName string,
 	podIdentifiers []string,
 ) (map[string]float64, error) {
+	if k.tokenizersPool == nil {
+		return nil, errInternalTokenizationDisabled
+	}
+
 	// 1. tokenize prompt
 	tokens, features := k.tokenizersPool.Tokenize(renderReq, prompt)
 
@@ -285,7 +313,14 @@ func podsPerKeyPrintHelper(ks map[kvblock.BlockHash][]kvblock.PodEntry) string {
 	return flattened
 }
 
+// SetTokenizer overrides the in-process tokenizer. No-op when the pool is
+// disabled.
+//
+// Deprecated: tied to the in-process tokenization pool.
 func (k *Indexer) SetTokenizer(tokenizer tokenization.Tokenizer, modelName string) {
+	if k.tokenizersPool == nil {
+		return
+	}
 	k.tokenizersPool.SetTokenizer(tokenizer, modelName)
 }
 

--- a/pkg/tokenization/pool.go
+++ b/pkg/tokenization/pool.go
@@ -45,6 +45,8 @@ type Task struct {
 }
 
 // Pool encapsulates the queue and worker pool for tokenization tasks.
+//
+// Deprecated: tokenize externally and call kvcache.Indexer.ScoreTokens.
 type Pool struct {
 	modelName string // base model name for tokenization
 	workers   int

--- a/tests/e2e/uds_tokenizer/uds_e2e_suite_test.go
+++ b/tests/e2e/uds_tokenizer/uds_e2e_suite_test.go
@@ -108,12 +108,14 @@ func (s *UDSTokenizerSuite) SetupTest() {
 	s.config, err = kvcache.NewDefaultConfig()
 	s.Require().NoError(err)
 
-	// Configure UDS tokenizer to use TCP for testing
-	s.config.TokenizersPoolConfig.ModelName = defaultModelName
-	s.config.TokenizersPoolConfig.UdsTokenizerConfig = &tokenization.UdsTokenizerConfig{
+	tokenizerPoolConfig, err := tokenization.DefaultConfig()
+	s.Require().NoError(err)
+	tokenizerPoolConfig.ModelName = defaultModelName
+	tokenizerPoolConfig.UdsTokenizerConfig = &tokenization.UdsTokenizerConfig{
 		SocketFile: s.grpcAddress,
 		UseTCP:     true,
 	}
+	s.config.TokenizersPoolConfig = tokenizerPoolConfig
 
 	s.tokenProcessorConfig = kvblock.DefaultTokenProcessorConfig()
 	s.tokenProcessorConfig.BlockSize = 4


### PR DESCRIPTION
## Summary

Surface-level changes that signal the deprecation of the in-process tokenization pool and let new integrations skip it entirely. Behavior for existing callers is preserved as long as they configure `TokenizersPoolConfig` explicitly.

## What changed

- **`kvcache.Config.TokenizersPoolConfig`** — marked `Deprecated`, made optional (`omitempty`).
- **`kvcache.NewDefaultConfig`** — no longer auto-populates `TokenizersPoolConfig`. New integrations are tokenizer-pool-free by default.
- **`kvcache.NewKVCacheIndexer`** — skips pool construction when config is nil. `Indexer.Run` becomes a `<-ctx.Done()` no-op in that mode.
- **Deprecated APIs** — `Indexer.GetPodScores` (prompt-string), `Indexer.ComputeBlockKeys` (prompt-string), `Indexer.SetTokenizer`, and `tokenization.Pool` carry `Deprecated:` godoc tags. Prompt-string calls return an explicit error when the pool is absent, redirecting callers to `ScoreTokens`.
- **`Indexer.ComputeBlockKeysFromTokens`** — added as the tokens-in counterpart of `ComputeBlockKeys`.
- **Examples and e2e suites** — flows that still demonstrate the prompt-string path opt in explicitly via a new `helper.ConfigureInternalTokenizer`. `helper.ApplyTokenizerEndpoint` is now nil-safe.
- **Docs** — `docs/architecture.md` and `docs/configuration.md` carry deprecation callouts pointing at `ScoreTokens` / `ComputeBlockKeysFromTokens`.

## Migration

Existing consumers that still need the prompt-string flow:

```go
cfg, _ := kvcache.NewDefaultConfig()
poolCfg, _ := tokenization.DefaultConfig()
poolCfg.ModelName = "your-model"
cfg.TokenizersPoolConfig = poolCfg
```

New integrations: tokenize externally and call `Indexer.ScoreTokens` directly. No tokenizer pool config required.

## Related issues
- #517 

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/... ./tests/integration/...`
- [ ] `make e2e-test-uds` (requires `UDS_TOKENIZER_IMAGE`)
- [ ] `make e2e-test` with `embedded_tokenizers` build tag (requires `Python.h` toolchain)