### PR TITLE
build(fs_backend): make -static-libstdc++ opt-in via FS_PORTABLE_WHEEL

### DIFF
--- a/kv_connectors/llmd_fs_backend/Dockerfile.wheel
+++ b/kv_connectors/llmd_fs_backend/Dockerfile.wheel
@@ -40,6 +40,8 @@ ENV PATH=${CUDA_HOME}/bin:${PATH}
 ENV LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
 ENV TORCH_CUDA_ARCH_LIST=${torch_cuda_arch_list}
 ENV MAX_JOBS=${max_jobs}
+# Enable -static-libstdc++ for the redistributable wheel (read by setup.py).
+ENV FS_PORTABLE_WHEEL=1
 
 # Python build deps
 RUN python -m pip install --upgrade pip setuptools wheel ninja numpy

--- a/kv_connectors/llmd_fs_backend/Makefile
+++ b/kv_connectors/llmd_fs_backend/Makefile
@@ -19,8 +19,9 @@ check-gds:
 	fi
 
 # Build wheel into dist/ and copy .whl into wheels/
+# FS_PORTABLE_WHEEL=1 enables -static-libstdc++ for the redistributable wheel.
 wheel: deps
-	$(PYTHON) -m pip wheel . -w $(DIST_DIR)
+	FS_PORTABLE_WHEEL=1 $(PYTHON) -m pip wheel . -w $(DIST_DIR)
 	cp $(DIST_DIR)/llmd_fs_connector-$(VERSION)-*.whl $(WHEEL_DIR)/
 	@echo ""
 	@echo "Wheel created in $(WHEEL_DIR):"

--- a/kv_connectors/llmd_fs_backend/setup.py
+++ b/kv_connectors/llmd_fs_backend/setup.py
@@ -50,6 +50,12 @@ nvcc_args = [
     "-fopenmp",
 ]
 
+# -static-libstdc++ is opt-in via FS_PORTABLE_WHEEL=1 (set by
+# Dockerfile.wheel and `make wheel`); off otherwise to avoid two
+# libstdc++ copies in editable installs, which can segfault.
+_portable_wheel = os.environ.get("FS_PORTABLE_WHEEL", "").lower() in ("1", "true")
+extra_link_args = ["-static-libstdc++"] if _portable_wheel else []
+
 setup(
     name="llmd_fs_connector",
     packages=find_packages(),
@@ -60,7 +66,7 @@ setup(
             include_dirs=include_dirs,
             libraries=libraries,
             extra_compile_args={"cxx": cxx_args, "nvcc": nvcc_args},
-            extra_link_args=["-static-libstdc++"],
+            extra_link_args=extra_link_args,
         ),
     ],
     cmdclass={"build_ext": BuildExtension},


### PR DESCRIPTION
## Problem

`-static-libstdc++` (added in #498 for wheel portability) causes a `std::codecvt` segfault when the connector is used in editable installs or pytest. The static-linked `.so` plus the system `libstdc++.so.6` already loaded by torch / gRPC / etc. results in two libstdc++ copies in the same Python process, which can mismatch on identity-based checks for shared C++ runtime state.

vLLM production runs are unaffected (engine is constructed in a worker subprocess); the crash surfaces in pytest or direct-construction scripts.

## Fix

Make `-static-libstdc++` opt-in via `FS_PORTABLE_WHEEL=1`, set by `Dockerfile.wheel` and the `make wheel` target — so the redistributable wheel is unchanged. The development build (`pip install -e .` / `make build`) is **without** the flag, so libstdc++ is dynamically linked and the bug doesn't trigger.

## Test plan
- [x ] `make build && make test` in `kv_connectors/llmd_fs_backend/` — no segfault
- [x] `make wheel` produces a `.so` with `-static-libstdc++` (`ldd` shows no `libstdc++.so.6`)


Refs: #498