### PR TITLE
build(fs-connector): enable pip install via PEP 503 Pages index

### DIFF
--- a/.github/scripts/generate-pip-index.sh
+++ b/.github/scripts/generate-pip-index.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Copyright 2025 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generates a PEP 503 simple package index whose links point directly at
+# GitHub Release asset download URLs, splitting CUDA variants across
+# separate index paths based on the wheel's PEP 440 local-version segment.
+#
+# Layout:
+#   <output-dir>/simple/<pkg>/index.html              wheels with NO local segment (default, e.g. cu12)
+#   <output-dir>/simple/<local>/<pkg>/index.html      wheels stamped X.Y+<local>  (e.g. simple/cu130/llmd-fs-connector/)
+#   <output-dir>/simple/index.html                    root listing of buckets
+#
+# Wheels are NOT copied into the index; pip downloads bytes straight from Releases.
+#
+# Usage: generate-pip-index.sh <repo> <output-dir>
+
+set -euo pipefail
+
+REPO="${1:?Usage: $0 <repo> <output-dir>}"
+OUTPUT_DIR="${2:?Usage: $0 <repo> <output-dir>}"
+SIMPLE_DIR="${OUTPUT_DIR}/simple"
+mkdir -p "$SIMPLE_DIR"
+
+mapfile -t entries < <(
+  gh api --paginate "/repos/${REPO}/releases?per_page=100" \
+    --jq '.[] | .assets[] | select(.name|endswith(".whl")) | "\(.name) \(.browser_download_url)"'
+)
+
+if [ ${#entries[@]} -eq 0 ]; then
+    echo "ERROR: No .whl assets found across releases of ${REPO}" >&2
+    exit 1
+fi
+
+# Split filename into (normalized_pkg, local_segment_or_empty).
+# Wheel: {name}-{version}(-{build})?-{python}-{abi}-{platform}.whl
+# Version may include +<local> (PEP 440). We extract local from the version field.
+parse_wheel() {
+    local filename="$1"
+    local stem="${filename%.whl}"
+    local raw_name="${stem%%-[0-9]*}"
+    local rest="${stem#${raw_name}-}"
+    local version="${rest%%-*}"
+    local local_seg=""
+    if [[ "$version" == *"+"* ]]; then
+        local_seg="${version#*+}"
+    fi
+    local pkg
+    pkg="$(echo "$raw_name" | tr '[:upper:]' '[:lower:]' | sed -E 's/[-_.]+/-/g')"
+    echo "${pkg}|${local_seg}"
+}
+
+declare -A BUCKET_PACKAGES
+declare -a ROUTED
+
+for line in "${entries[@]}"; do
+    filename="${line%% *}"
+    url="${line#* }"
+    parsed="$(parse_wheel "$filename")"
+    pkg="${parsed%|*}"
+    local_seg="${parsed#*|}"
+    bucket="${local_seg:-_default}"
+    BUCKET_PACKAGES["${bucket}/${pkg}"]=1
+    ROUTED+=("${bucket}|${pkg}|${filename}|${url}")
+done
+
+# Per-bucket per-package index files
+for key in "${!BUCKET_PACKAGES[@]}"; do
+    bucket="${key%%/*}"
+    pkg="${key#*/}"
+    if [ "$bucket" = "_default" ]; then
+        pkg_dir="${SIMPLE_DIR}/${pkg}"
+    else
+        pkg_dir="${SIMPLE_DIR}/${bucket}/${pkg}"
+    fi
+    mkdir -p "$pkg_dir"
+    {
+        echo '<!DOCTYPE html>'
+        echo "<html><head><meta charset=\"utf-8\"><title>Links for ${pkg}</title></head>"
+        echo '<body>'
+        echo "<h1>Links for ${pkg}</h1>"
+        declare -A SEEN=()
+        for entry in "${ROUTED[@]}"; do
+            IFS='|' read -r e_bucket e_pkg e_filename e_url <<< "$entry"
+            [ "$e_bucket" = "$bucket" ] && [ "$e_pkg" = "$pkg" ] || continue
+            if [ -n "${SEEN[$e_filename]:-}" ]; then
+                echo "WARN: duplicate filename ${e_filename} in bucket ${bucket} - keeping first" >&2
+                continue
+            fi
+            SEEN["$e_filename"]=1
+            echo "  <a href=\"${e_url}\">${e_filename}</a><br/>"
+        done
+        unset SEEN
+        echo '</body></html>'
+    } > "${pkg_dir}/index.html"
+done
+
+# Root index listing default packages and any CUDA buckets
+{
+    echo '<!DOCTYPE html>'
+    echo '<html><head><meta charset="utf-8"><title>Simple Package Index</title></head>'
+    echo '<body>'
+    echo '<h1>Simple Package Index</h1>'
+    declare -A SEEN_DIRS=()
+    for key in $(printf '%s\n' "${!BUCKET_PACKAGES[@]}" | sort); do
+        bucket="${key%%/*}"
+        pkg="${key#*/}"
+        if [ "$bucket" = "_default" ]; then
+            href="${pkg}/"
+        else
+            href="${bucket}/${pkg}/"
+        fi
+        [ -z "${SEEN_DIRS[$href]:-}" ] || continue
+        SEEN_DIRS["$href"]=1
+        echo "  <a href=\"${href}\">${href}</a><br/>"
+    done
+    echo '</body></html>'
+} > "${SIMPLE_DIR}/index.html"
+
+echo "Generated PEP 503 index at ${SIMPLE_DIR}/"
+echo "Buckets/packages: ${!BUCKET_PACKAGES[*]}"
+echo "Wheel links: ${#ROUTED[@]}"

--- a/.github/workflows/ci-pages-index.yaml
+++ b/.github/workflows/ci-pages-index.yaml
@@ -1,0 +1,55 @@
+# Builds a PEP 503 simple index from the wheel assets attached to GitHub
+# Releases and publishes it via GitHub Pages. Consumers install with:
+#   pip install <pkg> --extra-index-url https://<owner>.github.io/<repo>/simple/
+#
+# The HTML links directly at Release asset URLs - no wheel bytes are copied
+# into Pages. CUDA variants are split by PEP 440 local-version segment;
+# see .github/scripts/generate-pip-index.sh for the routing logic.
+
+name: CI - Publish PyPI Pages Index
+
+on:
+  release:
+    types: [published, edited, deleted, released]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  # Generate the simple-index HTML from Release assets and upload it as a Pages artifact.
+  build-index:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Generate PEP 503 simple index
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x .github/scripts/generate-pip-index.sh
+          .github/scripts/generate-pip-index.sh "${{ github.repository }}" _site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  # Publish the artifact to the live github.io URL.
+  deploy:
+    needs: build-index
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -77,3 +77,10 @@ graph TD
   A reference implementation of how to integrate the `kvcache.Indexer` into a scheduler like the `llm-d-inference-scheduler`
 * [**KV-Events**](examples/kv_events/README.md):
  Demonstrates how the KV-Cache libraries handles KV-Events through both an offline example with a dummy ZMQ publisher and an online example using a vLLM Helm chart.
+
+## Connectors & Utilities
+
+* [**llmd-fs-backend**](kv_connectors/llmd_fs_backend/README.md):
+  Storage backend for vLLM's `OffloadingConnector` — moves KV-cache blocks between GPU and shared storage (local disk, shared filesystem, or object store). Pre-built wheels are published via the project's pip index; see the connector README for install instructions and configuration.
+* [**PVC Evictor**](kv_connectors/pvc_evictor/README.md):
+  Kubernetes-side utility that automatically manages disk space for the offloading connector's KV-cache storage on PVCs.

--- a/kv_connectors/llmd_fs_backend/README.md
+++ b/kv_connectors/llmd_fs_backend/README.md
@@ -20,24 +20,37 @@ For simple setups, see the **Storage Cleanup** section.
 
 ## System Requirements
 
-- vLLM version 0.19.x. Previous versions are supported via their matching wheels in the [wheels](./wheels) folder or the corresponding llm-d-kv-cache release assets.
+- vLLM version 0.19.x. Previous vLLM lines are supported via matching wheel versions on the pip index — vLLM 0.X.x uses `llmd-fs-connector==0.X` (see [Installation](#installation)).
 
 ## Installation
 
-### 1. Install from a pre-built wheel (Recommended)
+### 1. Install from the pip index (Recommended)
+
+The connector is published as a PEP 503 simple index hosted on GitHub Pages. The index points at wheel assets attached to GitHub Releases — `pip` auto-selects amd64 vs arm64 from your platform.
+
+CUDA 12 (default):
 
 ```bash
-pip install https://raw.githubusercontent.com/llm-d/llm-d-kv-cache/main/kv_connectors/llmd_fs_backend/wheels/llmd_fs_connector-0.19-cp312-cp312-linux_x86_64.whl
+pip install 'llmd-fs-connector==0.19' \
+  --extra-index-url https://llm-d.github.io/llm-d-kv-cache/simple/
 ```
 
-This installs:
+CUDA 13:
 
-* Python module `llmd_fs_backend`
-* CUDA extension `storage_offload.so`
+```bash
+pip install 'llmd-fs-connector==0.19' \
+  --extra-index-url https://llm-d.github.io/llm-d-kv-cache/simple/cu130/
+```
 
-Each llm-d release is aligned with the appropriate `vLLM` and `llm-d-kv-cache` versions.
-You can download the matching wheel from the release assets and install it manually from:
-https://github.com/llm-d/llm-d-kv-cache/releases/latest
+For an older vLLM release, match the pin to your vLLM line — vLLM 0.X.x uses `==0.X` (e.g. vLLM 0.18.x):
+
+```bash
+pip install 'llmd-fs-connector==0.18' \
+  --extra-index-url https://llm-d.github.io/llm-d-kv-cache/simple/
+```
+
+Or download a wheel manually from the release assets at <https://github.com/llm-d/llm-d-kv-cache/releases>.
+
 ### 2. Build from source (compile yourself)
 
 Requires CUDA toolkit and system dependencies.

--- a/kv_connectors/llmd_fs_backend/docs/deployment/vllm-storage.yaml
+++ b/kv_connectors/llmd_fs_backend/docs/deployment/vllm-storage.yaml
@@ -39,7 +39,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
         - |
-          pip install https://raw.githubusercontent.com/llm-d/llm-d-kv-cache/main/kv_connectors/llmd_fs_backend/wheels/llmd_fs_connector-0.19-cp312-cp312-linux_x86_64.whl
+          pip install 'llmd-fs-connector==0.19' --extra-index-url https://llm-d.github.io/llm-d-kv-cache/simple/
           vllm serve Qwen/Qwen3-32B \
           --tensor-parallel-size 2 \
           --trust-remote-code \


### PR DESCRIPTION
## Summary

Makes `llmd-fs-connector` pip-installable from a stable index URL instead of users hard-coding raw GitHub wheel URLs. The index HTML is served by GitHub Pages and links directly at Release asset URLs — wheels stay in Releases, no duplication.

CUDA variants are split by PEP 440 local-version segment (works out of the box with #542's wheel-stamping):

```
/simple/llmd-fs-connector/         cu12 (default - wheels with no local segment)
/simple/cu130/llmd-fs-connector/   wheels stamped X.Y+cu130
```

Index is rebuilt on every release lifecycle event (`published`, `edited`, `deleted`, `released`) and on `workflow_dispatch`.

## Consumer install

```bash
# CUDA 12 (default)
pip install 'llmd-fs-connector==0.19' \
  --extra-index-url https://llm-d.github.io/llm-d-kv-cache/simple/

# CUDA 13
pip install 'llmd-fs-connector==0.19' \
  --extra-index-url https://llm-d.github.io/llm-d-kv-cache/simple/cu130/
```

`pip` auto-selects amd64 vs arm64 from the platform tag.

## Test plan

- [x] Local dry-run against current releases produces correct HTML (verified: 6 unique wheel links, 20 KB output, `pip download --index-url file://...` resolves and downloads from Releases CDN).
- [ ] After merge: enable Pages and run workflow manually; verify `https://llm-d.github.io/llm-d-kv-cache/simple/llmd-fs-connector/` lists existing cu12 wheels.
- [ ] Cut a tagged release with cu130 wheels (post-#542) and verify `simple/cu130/` populates and `pip install` against that URL works.