### PR TITLE
update: remove VLLM_VERSION from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ PROD_VERSION ?= 0.0.0
 IMAGE_TAG_BASE ?= ghcr.io/llm-d/$(PROJECT_NAME)
 IMG = $(IMAGE_TAG_BASE):$(DEV_VERSION)
 NAMESPACE ?= hc4ai-operator
-VLLM_VERSION := 0.18.0
 
 TARGETOS ?= $(shell go env GOOS)
 TARGETARCH ?= $(shell go env GOARCH)


### PR DESCRIPTION
# Notes
- this Env is not used anywhere in the code base and it is out of date
- GHA release for UDS is using version set in the pyproject.toml