### PR TITLE
Support multiple gpu blocks in a single object store block

### DIFF
--- a/kv_connectors/llmd_fs_backend/docs/object_store.md
+++ b/kv_connectors/llmd_fs_backend/docs/object_store.md
@@ -37,7 +37,3 @@ Add the object store configuration and specify the object store backend in  `kv_
   }
 }'
 ```
-
-## Limitations
-
-Note that currently the gpu block size (set as block_size in vllm) must match the object store blocksize (set as block_size in kv_connector_extra_config).

--- a/kv_connectors/llmd_fs_backend/llmd_nixl/nixl_offload.py
+++ b/kv_connectors/llmd_fs_backend/llmd_nixl/nixl_offload.py
@@ -116,16 +116,15 @@ class StorageOffloadEngine(ABC):
         """Open files; return fd_list (ints for file backends, strings for OBJ)."""
 
     @abstractmethod
-    def _build_nixl_file_entry(
-        self, fd_list: list, file_idx: int, intra_offset: int
-    ) -> tuple:
-        """Return one NIXL file descriptor tuple for a block.
+    def _build_nixl_file_entries(
+        self, fd_list: list, file_idx: int, block_list: list
+    ) -> list[tuple]:
+        """Return NIXL file descriptor tuples for one file.
 
         Args:
-            fd_list:      file descriptors / S3 keys, one per file.
-            file_idx:     index into fd_list identifying the file.
-            intra_offset: position of this block within the file
-                          (always 0 for OBJ since block size == GPU block size).
+            fd_list:    file descriptors / S3 keys, one per file.
+            file_idx:   index into fd_list identifying the file.
+            block_list: block ids assigned to this file.
         """
 
     @abstractmethod
@@ -163,15 +162,13 @@ class StorageOffloadEngine(ABC):
         blocks_data = self._get_blocks_data(tensors, block_ids)
         assert blocks_data
 
-        # Build one NIXL file entry per block, grouped by file.
-        # file_idx indexes fd_list; intra_offset is the block's position
-        # within that file.
+        # Build one NIXL file entry per file; OBJ packs all blocks into one
+        # contiguous S3 object, so each file produces exactly one descriptor.
         nixl_files = []
         for file_idx, block_list in enumerate(block_ids):
-            for intra_offset, _ in enumerate(block_list):
-                nixl_files.append(
-                    self._build_nixl_file_entry(fd_list, file_idx, intra_offset)
-                )
+            nixl_files.extend(
+                self._build_nixl_file_entries(fd_list, file_idx, block_list)
+            )
 
         assert len(blocks_data) == len(nixl_files)
         xfer_desc = self.agent.get_xfer_descs(blocks_data, self.nixl_source)

--- a/kv_connectors/llmd_fs_backend/llmd_nixl/nixl_offload.py
+++ b/kv_connectors/llmd_fs_backend/llmd_nixl/nixl_offload.py
@@ -100,11 +100,11 @@ class StorageOffloadEngine(ABC):
         """Return params dict for agent.create_backend()."""
 
     @abstractmethod
-    def _get_staging_and_copy(self, block_ids: list) -> tuple:
+    def _store_gpu_blocks_to_staging(self, block_ids: list) -> tuple:
         """Return (tensors, stagings) ready for a WRITE transfer."""
 
     @abstractmethod
-    def _get_staging(self, block_ids: list) -> tuple:
+    def _reserve_staging_for_load(self, block_ids: list) -> tuple:
         """Return (tensors, stagings) ready for a READ transfer."""
 
     @abstractmethod
@@ -132,7 +132,7 @@ class StorageOffloadEngine(ABC):
         """Close descriptors opened by _open_files."""
 
     @abstractmethod
-    def _complete_read(self, stagings: list, block_ids: list) -> None:
+    def _load_staging_to_gpu_blocks(self, stagings: list, block_ids: list) -> None:
         """Copy completed READ data from stagings to GPU (no-op for GDS)."""
 
     @abstractmethod
@@ -215,7 +215,7 @@ class StorageOffloadEngine(ABC):
     ) -> bool:
         """Store gpu kv cache blocks into storage (obj, posix, gds, whatever)"""
         self.logger.debug("async_store_gpu_blocks in_flight=%d", len(self._transfers))
-        tensors, stagings = self._get_staging_and_copy(block_ids)
+        tensors, stagings = self._store_gpu_blocks_to_staging(block_ids)
         assert tensors is not None, (
             "staging pool should never be empty after auto-extend"
         )
@@ -228,7 +228,7 @@ class StorageOffloadEngine(ABC):
     ) -> bool:
         """Load kv cache blocks from storage into gpu"""
         self.logger.debug("async_load_gpu_blocks in_flight=%d", len(self._transfers))
-        tensors, stagings = self._get_staging(block_ids)
+        tensors, stagings = self._reserve_staging_for_load(block_ids)
         assert tensors is not None, (
             "staging pool should never be empty after auto-extend"
         )

--- a/kv_connectors/llmd_fs_backend/llmd_nixl/obj_backend.py
+++ b/kv_connectors/llmd_fs_backend/llmd_nixl/obj_backend.py
@@ -70,10 +70,9 @@ class ObjBackend(_StagedBackend):
 
     def _get_staging_and_copy(self, block_ids: list) -> tuple:
         num_files = len(block_ids)
-        assert self._staging_pool.qsize() >= num_files, (
-            f"Staging pool exhausted: need {num_files} slots, "
-            f"have {self._staging_pool.qsize()} (pool size={self.io_threads * 8})"
-        )
+        shortfall = num_files - self._staging_pool.qsize()
+        if shortfall > 0:
+            self._extend_staging_pool(shortfall)
         stagings, tensors_out = [], []
         with torch.cuda.stream(self._d2h_stream):
             for block_list in block_ids:
@@ -93,10 +92,9 @@ class ObjBackend(_StagedBackend):
 
     def _get_staging(self, block_ids: list) -> tuple:
         num_files = len(block_ids)
-        assert self._staging_pool.qsize() >= num_files, (
-            f"Staging pool exhausted: need {num_files} slots, "
-            f"have {self._staging_pool.qsize()} (pool size={self.io_threads * 8})"
-        )
+        shortfall = num_files - self._staging_pool.qsize()
+        if shortfall > 0:
+            self._extend_staging_pool(shortfall)
         stagings, tensors_out = [], []
         for _ in block_ids:
             staging = self._staging_pool.get_nowait()

--- a/kv_connectors/llmd_fs_backend/llmd_nixl/obj_backend.py
+++ b/kv_connectors/llmd_fs_backend/llmd_nixl/obj_backend.py
@@ -36,10 +36,6 @@ class ObjBackend(_StagedBackend):
         tensors: list[torch.Tensor],
         extra_config: dict | None = None,
     ):
-        assert gpu_blocks_per_file == 1, (
-            "OBJ backend: multiple blocks per object not yet supported"
-        )
-
         cfg = extra_config or {}
         required = ["bucket", "endpoint_override", "access_key", "secret_key"]
         missing = [k for k in required if not cfg.get(k)]
@@ -69,13 +65,69 @@ class ObjBackend(_StagedBackend):
             params["ca_bundle"] = self._ca_bundle
         return params
 
+    def _staging_bytes_per_slot(self) -> int:
+        return self.gpu_blocks_per_file * len(self.tensors) * self._block_size
+
+    def _get_staging_and_copy(self, block_ids: list) -> tuple:
+        num_files = len(block_ids)
+        assert self._staging_pool.qsize() >= num_files, (
+            f"Staging pool exhausted: need {num_files} slots, "
+            f"have {self._staging_pool.qsize()} (pool size={self.io_threads * 8})"
+        )
+        stagings, tensors_out = [], []
+        with torch.cuda.stream(self._d2h_stream):
+            for block_list in block_ids:
+                staging = self._staging_pool.get_nowait()
+                buf, _ = staging
+                offset = 0
+                for block_id in block_list:
+                    for tensor in self.tensors:
+                        buf[offset : offset + self._block_size].copy_(
+                            tensor[block_id].view(torch.uint8).flatten(),
+                            non_blocking=True,
+                        )
+                        offset += self._block_size
+                stagings.append(staging)
+                tensors_out.append(buf)
+        return tensors_out, stagings
+
+    def _get_staging(self, block_ids: list) -> tuple:
+        num_files = len(block_ids)
+        assert self._staging_pool.qsize() >= num_files, (
+            f"Staging pool exhausted: need {num_files} slots, "
+            f"have {self._staging_pool.qsize()} (pool size={self.io_threads * 8})"
+        )
+        stagings, tensors_out = [], []
+        for _ in block_ids:
+            staging = self._staging_pool.get_nowait()
+            stagings.append(staging)
+            tensors_out.append(staging[0])
+        return tensors_out, stagings
+
+    def _get_blocks_data(self, tensors: list[torch.Tensor], _block_ids: list) -> list:
+        # One DRAM descriptor per file; size comes from the staging buffer itself.
+        return [(t.data_ptr(), t.numel(), 0) for t in tensors]
+
+    def _complete_read(self, stagings: list, block_ids: list) -> None:
+        with torch.cuda.stream(self._h2d_stream):
+            for (buf, _), block_list in zip(stagings, block_ids):
+                offset = 0
+                for block_id in block_list:
+                    for tensor in self.tensors:
+                        tensor[block_id].view(torch.uint8).flatten().copy_(
+                            buf[offset : offset + self._block_size],
+                            non_blocking=True,
+                        )
+                        offset += self._block_size
+        self._h2d_stream.synchronize()
+
     def _open_files(self, files: list[str]) -> list:
         return list(files)  # S3 keys - no real FDs
 
-    def _build_nixl_file_entry(self, fd_list, file_idx, _intra_offset) -> tuple:
-        # OBJ: block size == GPU block size, so intra_offset is always 0
+    def _build_nixl_file_entries(self, fd_list, file_idx, block_list) -> list[tuple]:
         key = fd_list[file_idx]
-        return (0, len(self.tensors) * self._block_size, obj_key_to_dev_id(key), key)
+        file_bytes = len(block_list) * len(self.tensors) * self._block_size
+        return [(0, file_bytes, obj_key_to_dev_id(key), key)]
 
     def _close_fds(self, *_) -> None:
         pass  # S3 keys - nothing to close

--- a/kv_connectors/llmd_fs_backend/llmd_nixl/obj_backend.py
+++ b/kv_connectors/llmd_fs_backend/llmd_nixl/obj_backend.py
@@ -104,9 +104,13 @@ class ObjBackend(_StagedBackend):
             tensors_out.append(staging[0])
         return tensors_out, stagings
 
-    def _get_blocks_data(self, tensors: list[torch.Tensor], _block_ids: list) -> list:
-        # One DRAM descriptor per file; size comes from the staging buffer itself.
-        return [(t.data_ptr(), t.numel(), 0) for t in tensors]
+    def _get_blocks_data(self, tensors: list[torch.Tensor], block_ids: list) -> list:
+        # One DRAM descriptor per file; size matches the actual transfer bytes
+        # so that partial first-file reads use a correctly-sized DRAM region.
+        return [
+            (t.data_ptr(), len(bl) * len(self.tensors) * self._block_size, 0)
+            for t, bl in zip(tensors, block_ids)
+        ]
 
     def _complete_read(self, stagings: list, block_ids: list) -> None:
         with torch.cuda.stream(self._h2d_stream):
@@ -127,7 +131,11 @@ class ObjBackend(_StagedBackend):
     def _build_nixl_file_entries(self, fd_list, file_idx, block_list) -> list[tuple]:
         key = fd_list[file_idx]
         file_bytes = len(block_list) * len(self.tensors) * self._block_size
-        return [(0, file_bytes, obj_key_to_dev_id(key), key)]
+        # For a partial first file the relevant blocks sit at the tail of the
+        # object; use a non-zero offset so NIXL issues a range read/write.
+        skip = self.gpu_blocks_per_file - len(block_list)
+        file_offset = skip * len(self.tensors) * self._block_size
+        return [(file_offset, file_bytes, obj_key_to_dev_id(key), key)]
 
     def _close_fds(self, *_) -> None:
         pass  # S3 keys - nothing to close

--- a/kv_connectors/llmd_fs_backend/llmd_nixl/obj_backend.py
+++ b/kv_connectors/llmd_fs_backend/llmd_nixl/obj_backend.py
@@ -68,7 +68,7 @@ class ObjBackend(_StagedBackend):
     def _staging_bytes_per_slot(self) -> int:
         return self.gpu_blocks_per_file * len(self.tensors) * self._block_size
 
-    def _get_staging_and_copy(self, block_ids: list) -> tuple:
+    def _store_gpu_blocks_to_staging(self, block_ids: list) -> tuple:
         num_files = len(block_ids)
         shortfall = num_files - self._staging_pool.qsize()
         if shortfall > 0:
@@ -90,7 +90,7 @@ class ObjBackend(_StagedBackend):
                 tensors_out.append(buf)
         return tensors_out, stagings
 
-    def _get_staging(self, block_ids: list) -> tuple:
+    def _reserve_staging_for_load(self, block_ids: list) -> tuple:
         num_files = len(block_ids)
         shortfall = num_files - self._staging_pool.qsize()
         if shortfall > 0:
@@ -110,7 +110,7 @@ class ObjBackend(_StagedBackend):
             for t, bl in zip(tensors, block_ids)
         ]
 
-    def _complete_read(self, stagings: list, block_ids: list) -> None:
+    def _load_staging_to_gpu_blocks(self, stagings: list, block_ids: list) -> None:
         with torch.cuda.stream(self._h2d_stream):
             for (buf, _), block_list in zip(stagings, block_ids):
                 offset = 0

--- a/kv_connectors/llmd_fs_backend/llmd_nixl/staged_backend.py
+++ b/kv_connectors/llmd_fs_backend/llmd_nixl/staged_backend.py
@@ -40,15 +40,24 @@ class _StagedBackend(StorageOffloadEngine, ABC):
         self._d2h_stream = torch.cuda.Stream()  # GPU --> CPU for WRITE staging
         self._h2d_stream = torch.cuda.Stream()  # CPU --> GPU for READ completion
         self._staging_pool: queue.Queue = queue.Queue()
-        self._staging_slot_bytes = len(tensors) * self._block_size
         num_gpu_blocks = tensors[0].shape[0]
-        self._staging_pool_size = max(io_threads * 8, num_gpu_blocks)
+        self._staging_pool_size = max(
+            io_threads * 8,
+            (num_gpu_blocks // gpu_blocks_per_file) + 1,
+        )
         for _ in range(self._staging_pool_size):
             self._staging_pool.put(self._alloc_staging_slot())
+        bytes_per_slot = self._staging_bytes_per_slot()
+        self.logger.debug(
+            "Staging pool: %d slots x %d bytes = %.1f MB",
+            self._staging_pool_size,
+            bytes_per_slot,
+            self._staging_pool_size * bytes_per_slot / (1 << 20),
+        )
 
     def _alloc_staging_slot(self) -> tuple:
         buf = torch.empty(
-            self._staging_slot_bytes, dtype=torch.uint8, device="cpu"
+            self._staging_bytes_per_slot(), dtype=torch.uint8, device="cpu"
         ).pin_memory()
         return (buf, self.agent.register_memory([buf]))
 

--- a/kv_connectors/llmd_fs_backend/llmd_nixl/staged_backend.py
+++ b/kv_connectors/llmd_fs_backend/llmd_nixl/staged_backend.py
@@ -52,6 +52,10 @@ class _StagedBackend(StorageOffloadEngine, ABC):
         ).pin_memory()
         return (buf, self.agent.register_memory([buf]))
 
+    def _staging_bytes_per_slot(self) -> int:
+        """Bytes per staging buffer slot. ObjBackend overrides for per-file size."""
+        return len(self.tensors) * self._block_size
+
     def _get_blocks_data(self, tensors: list[torch.Tensor], _block_ids: list) -> list:
         # tensors is one staging buffer per block (flattened); build one NIXL
         # descriptor per buffer

--- a/kv_connectors/llmd_fs_backend/llmd_nixl/staged_backend.py
+++ b/kv_connectors/llmd_fs_backend/llmd_nixl/staged_backend.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Staged backend mixin - CPU pinned-buffer staging for OBJ and POSIX backends."""
+"""Staged backend mixin - CPU pinned-buffer staging for OBJ backend."""
 
 import queue
 from abc import ABC
@@ -65,17 +65,6 @@ class _StagedBackend(StorageOffloadEngine, ABC):
         """Bytes per staging buffer slot. ObjBackend overrides for per-file size."""
         return len(self.tensors) * self._block_size
 
-    def _get_blocks_data(self, tensors: list[torch.Tensor], _block_ids: list) -> list:
-        # tensors is one staging buffer per block (flattened); build one NIXL
-        # descriptor per buffer
-        blocks_data = []
-        for tensor in tensors:
-            assert tensor.is_cpu
-            blocks_data.append(
-                (tensor.data_ptr(), len(self.tensors) * self._block_size, 0)
-            )
-        return blocks_data
-
     # Not thread-safe. Safe in practice because vLLM calls this from a single
     # engine-core thread.
     def _extend_staging_pool(self, shortfall: int) -> None:
@@ -91,67 +80,13 @@ class _StagedBackend(StorageOffloadEngine, ABC):
             self._staging_pool.put(self._alloc_staging_slot())
         self._staging_pool_size = new_size
 
-    def _get_staging_and_copy(self, block_ids: list) -> tuple:
-        # block_ids is a list of lists; acquire one staging slot per block
-        num_blocks = sum(len(bl) for bl in block_ids)
-        shortfall = num_blocks - self._staging_pool.qsize()
-        if shortfall > 0:
-            self._extend_staging_pool(shortfall)
-        stagings, tensors = [], []
-        with torch.cuda.stream(self._d2h_stream):
-            for block_list in block_ids:
-                for block_id in block_list:
-                    staging = self._staging_pool.get_nowait()
-                    buf, _ = staging
-                    offset = 0
-                    for tensor in self.tensors:
-                        buf[offset : offset + self._block_size].copy_(
-                            tensor[block_id].view(torch.uint8).flatten(),
-                            non_blocking=True,
-                        )
-                        offset += self._block_size
-                    stagings.append(staging)
-                    tensors.append(buf)
-        return tensors, stagings
-
-    def _get_staging(self, block_ids: list) -> tuple:
-        # block_ids is a list of lists; acquire one staging slot per block
-        num_blocks = sum(len(bl) for bl in block_ids)
-        shortfall = num_blocks - self._staging_pool.qsize()
-        if shortfall > 0:
-            self._extend_staging_pool(shortfall)
-        stagings, tensors = [], []
-        for block_list in block_ids:
-            for _ in block_list:
-                staging = self._staging_pool.get_nowait()
-                stagings.append(staging)
-                tensors.append(staging[0])
-        return tensors, stagings
-
     def _sync_before_transfer(self) -> None:
         self._d2h_stream.synchronize()
-
-    def _complete_read(self, stagings: list, block_ids: list) -> None:
-        with torch.cuda.stream(self._h2d_stream):
-            # block_ids is nested (one list per file), but stagings is flat (one
-            # entry per block), matching the order produced by _get_staging.
-            # Flatten block_ids so each staging slot pairs with its block_id.
-            # For obj backend gpu_blocks_per_file == 1, but this is not
-            # guaranteed for future backends (like nixl posix).
-            flat_block_ids = [b for block_list in block_ids for b in block_list]
-            for (buf, _), block_id in zip(stagings, flat_block_ids):
-                offset = 0
-                for tensor in self.tensors:
-                    tensor[block_id].view(torch.uint8).flatten().copy_(
-                        buf[offset : offset + self._block_size], non_blocking=True
-                    )
-                    offset += self._block_size
-        self._h2d_stream.synchronize()
 
     def _complete_transfer(self, entry) -> None:
         """Copy READ data to GPU, release NIXL resources, return staging slots."""
         if entry.read_block_ids is not None:
-            self._complete_read(entry.stagings, entry.read_block_ids)
+            self._load_staging_to_gpu_blocks(entry.stagings, entry.read_block_ids)
         super()._complete_transfer(entry)
         for s in entry.stagings:
             self._staging_pool.put(s)

--- a/kv_connectors/llmd_fs_backend/tests/test_fs_backend.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_fs_backend.py
@@ -268,6 +268,9 @@ def roundtrip_once(
     gpu_blocks_per_file: int,
     threads_per_gpu: int,
     extra_config: dict | None = None,
+    handlers_cls=StorageOffloadingHandlers,
+    wait_timeout: float = 2.0,
+    cleanup: bool = True,
 ):
     original = create_dummy_kv_tensors(
         num_layers, num_blocks, block_size, num_heads, head_size, dtype
@@ -280,7 +283,7 @@ def roundtrip_once(
     cleanup_files(file_mapper, keys)
 
     # PUT phase
-    kv_caches_original_handler = StorageOffloadingHandlers(
+    kv_caches_original_handler = handlers_cls(
         file_mapper=file_mapper,
         kv_caches=make_canonical_kv_caches(original),
         gpu_blocks_per_file=gpu_blocks_per_file,
@@ -291,7 +294,7 @@ def roundtrip_once(
     put_handler = kv_caches_original_handler.gpu_to_storage_handler
     start_put = time.time()
     put_handler.transfer_async(job_id=1, spec=(put_gpu_specs, put_storage_specs))
-    put_result = wait_for(put_handler, job_id=1, timeout=2.0)
+    put_result = wait_for(put_handler, job_id=1, timeout=wait_timeout)
     assert put_result.success, "PUT failed"
     dur_put = time.time() - start_put
 
@@ -306,7 +309,7 @@ def roundtrip_once(
         )
 
     # GET phase
-    kv_caches_restored_handler = StorageOffloadingHandlers(
+    kv_caches_restored_handler = handlers_cls(
         file_mapper=file_mapper,
         kv_caches=make_canonical_kv_caches(restored),
         gpu_blocks_per_file=gpu_blocks_per_file,
@@ -322,7 +325,7 @@ def roundtrip_once(
     get_storage_spec = SharedStorageLoadStoreSpec(put_storage_specs.keys[start_index:])
     start_get = time.time()
     get_handler.transfer_async(job_id=2, spec=(get_storage_spec, get_gpu_specs))
-    get_result = wait_for(get_handler, job_id=2, timeout=2.0)
+    get_result = wait_for(get_handler, job_id=2, timeout=wait_timeout)
     dur_get = time.time() - start_get
     assert get_result.success, "GET failed"
 
@@ -346,7 +349,7 @@ def roundtrip_once(
         f"{len(write_block_ids)} read blocks len: {len(read_block_ids)} "
         f"PUT {dur_put:.4f}s ({throughput_gbps(write_total_mb, dur_put):.2f} GB/s), "
         f"GET {dur_get:.4f}s ({throughput_gbps(read_total_mb, dur_get):.2f} GB/s), "
-        f"files={num_files}, sizes(MB)={file_size_mb:.2f} "
+        f"files={num_files}{size_info}"
     )
 
 

--- a/kv_connectors/llmd_fs_backend/tests/test_fs_backend.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_fs_backend.py
@@ -271,6 +271,7 @@ def roundtrip_once(
     handlers_cls=StorageOffloadingHandlers,
     wait_timeout: float = 2.0,
     cleanup: bool = True,
+    file_exists_fn=None,
 ):
     original = create_dummy_kv_tensors(
         num_layers, num_blocks, block_size, num_heads, head_size, dtype
@@ -302,11 +303,10 @@ def roundtrip_once(
     assert put_result.transfer_size is not None and put_result.transfer_size > 0
     assert put_result.transfer_time is not None and put_result.transfer_time > 0
     assert put_result.transfer_type == ("GPU", "SHARED_STORAGE")
+    check_exists = file_exists_fn or (lambda p: wait_for_file(p, timeout=2.0))
     for key in keys:
         file_path = file_mapper.get_file_name(key)
-        assert wait_for_file(file_path, timeout=2.0), (
-            f"missing file after PUT: {file_path}"
-        )
+        assert check_exists(file_path), f"missing file after PUT: {file_path}"
 
     # GET phase
     kv_caches_restored_handler = handlers_cls(
@@ -342,8 +342,14 @@ def roundtrip_once(
     read_total_mb = total_block_size_mb(
         num_layers, num_heads, block_size, head_size, dtype, len(read_block_ids)
     )
-    file_size_mb = os.path.getsize(file_mapper.get_file_name(keys[0])) / (1024 * 1024)
     num_files = len(keys)
+    try:
+        file_size_mb = os.path.getsize(file_mapper.get_file_name(keys[0])) / (
+            1024 * 1024
+        )
+        size_info = f" file_size={file_size_mb:.2f}MB"
+    except OSError:
+        size_info = ""
     print(
         f"[INFO] group={gpu_blocks_per_file} write blocks len: "
         f"{len(write_block_ids)} read blocks len: {len(read_block_ids)} "

--- a/kv_connectors/llmd_fs_backend/tests/test_obj_backend.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_obj_backend.py
@@ -33,7 +33,6 @@ Run:
       --obj-secret-key minioadmin
 """
 
-import math
 import os
 import time
 
@@ -41,19 +40,9 @@ import pytest
 import torch
 
 from llmd_fs_backend.file_mapper import FileMapper
-from llmd_fs_backend.mediums import SharedStorageLoadStoreSpec
 from llmd_nixl.nixl_lookup import NixlLookup
 from llmd_nixl.worker import NixlStorageOffloadingHandlers
-from tests.test_fs_backend import (
-    assert_blocks_equal,
-    create_dummy_kv_tensors,
-    make_canonical_kv_caches,
-    make_gpu_specs,
-    make_storage_specs,
-    throughput_gbps,
-    total_block_size_mb,
-    wait_for,
-)
+from tests.test_fs_backend import roundtrip_once
 
 pytestmark = pytest.mark.integration
 
@@ -102,6 +91,7 @@ def obj_config(request):
 
 
 # ---------------------------------------------------------------------------
+<<<<<<< HEAD
 # OBJ-specific roundtrip
 # ---------------------------------------------------------------------------
 
@@ -218,12 +208,16 @@ def roundtrip_once_obj(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("gpu_blocks_per_file", [1, 2, 4])
 @pytest.mark.parametrize("start_idx", [0, 3])
-def test_obj_backend_roundtrip(start_idx: int, obj_config, default_vllm_config):
+def test_obj_backend_roundtrip(
+    gpu_blocks_per_file: int, start_idx: int, obj_config, default_vllm_config
+):
     """End-to-end write/read roundtrip through the OBJ (S3/MinIO) backend.
 
-    Writes num_blocks GPU blocks to S3, then reads back a subset starting at
-    start_idx, and verifies bit-exact equality.
+    Writes num_blocks GPU blocks to S3, reads back a subset starting at
+    start_idx, and verifies bit-exact equality. Covers gpu_blocks_per_file > 1
+    to validate multi-block packing and partial reads.
     """
     num_layers = 80
     num_blocks = 8
@@ -234,11 +228,20 @@ def test_obj_backend_roundtrip(start_idx: int, obj_config, default_vllm_config):
     threads_per_gpu = 8
     gpu_block_size = 16
 
-    write_block_ids = list(range(num_blocks))
-    read_block_ids = list(range(start_idx, num_blocks))
+    file_mapper = FileMapper(
+        root_dir=f"kv-test/{int(time.time())}/gpf{gpu_blocks_per_file}",
+        model_name="test-model",
+        gpu_block_size=gpu_block_size,
+        gpu_blocks_per_file=gpu_blocks_per_file,
+        tp_size=1,
+        pp_size=1,
+        pcp_size=1,
+        rank=0,
+        dtype=str(dtype),
+    )
 
-    roundtrip_once_obj(
-        obj_config=obj_config,
+    roundtrip_once(
+        file_mapper=file_mapper,
         dtype=dtype,
         num_layers=num_layers,
         num_blocks=num_blocks,
@@ -246,7 +249,12 @@ def test_obj_backend_roundtrip(start_idx: int, obj_config, default_vllm_config):
         gpu_block_size=gpu_block_size,
         num_heads=num_heads,
         head_size=head_size,
-        write_block_ids=write_block_ids,
-        read_block_ids=read_block_ids,
+        write_block_ids=list(range(num_blocks)),
+        read_block_ids=list(range(start_idx, num_blocks)),
+        gpu_blocks_per_file=gpu_blocks_per_file,
         threads_per_gpu=threads_per_gpu,
+        extra_config=obj_config,
+        handlers_cls=NixlStorageOffloadingHandlers,
+        wait_timeout=30.0,
+        cleanup=False,
     )

--- a/kv_connectors/llmd_fs_backend/tests/test_obj_backend.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_obj_backend.py
@@ -33,6 +33,7 @@ Run:
       --obj-secret-key minioadmin
 """
 
+import math
 import os
 import time
 
@@ -40,9 +41,20 @@ import pytest
 import torch
 
 from llmd_fs_backend.file_mapper import FileMapper
+from llmd_fs_backend.mediums import SharedStorageLoadStoreSpec
 from llmd_nixl.nixl_lookup import NixlLookup
 from llmd_nixl.worker import NixlStorageOffloadingHandlers
-from tests.test_fs_backend import roundtrip_once
+from tests.test_fs_backend import (
+    assert_blocks_equal,
+    create_dummy_kv_tensors,
+    make_canonical_kv_caches,
+    make_gpu_specs,
+    make_storage_specs,
+    roundtrip_once,
+    throughput_gbps,
+    total_block_size_mb,
+    wait_for,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -91,7 +103,6 @@ def obj_config(request):
 
 
 # ---------------------------------------------------------------------------
-<<<<<<< HEAD
 # OBJ-specific roundtrip
 # ---------------------------------------------------------------------------
 
@@ -231,15 +242,17 @@ def test_obj_backend_roundtrip(
     file_mapper = FileMapper(
         root_dir=f"kv-test/{int(time.time())}/gpf{gpu_blocks_per_file}",
         model_name="test-model",
-        gpu_block_size=gpu_block_size,
+        hash_block_size=gpu_block_size,
         gpu_blocks_per_file=gpu_blocks_per_file,
         tp_size=1,
         pp_size=1,
         pcp_size=1,
+        dcp_size=1,
         rank=0,
         dtype=str(dtype),
     )
 
+    lookup = NixlLookup(obj_config)
     roundtrip_once(
         file_mapper=file_mapper,
         dtype=dtype,
@@ -257,4 +270,5 @@ def test_obj_backend_roundtrip(
         handlers_cls=NixlStorageOffloadingHandlers,
         wait_timeout=30.0,
         cleanup=False,
+        file_exists_fn=lookup.exists,
     )


### PR DESCRIPTION
This PR lifts the assert that gpu blocks per file == 1.  It does this by copying all the gpu blocks into a single staging buffer before writing it to the object store.  Reading is performed using range reads when only a subset of the blocks from a single object is requested.

The PR also updates the test_obj_backend test and makes it more inlined with the test_fs_backend test.