### PR TITLE
Fix CPU offloading for precise-prefix-cache-aware

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,6 +102,9 @@ When a block is offloaded from GPU to CPU, the engine emits a `BlockStored` with
 On eviction, the indexer only removes the `engineKey → requestKey` mapping if all associated request keys have no remaining pod entries. This preserves the mapping when other tiers still hold the block.
 
 ```
+  E1 = engine key (the engine's internal content-address hash for the block)
+  R1 = request key (the indexer's own hash, computed from tokens)
+
   1. GPU BlockStored (engine_key=E1, tier=gpu, tokens=[...])
      → computes R1 from tokens, stores E1 → R1, stores R1 → {pod, gpu}
 
@@ -111,6 +114,9 @@ On eviction, the indexer only removes the `engineKey → requestKey` mapping if 
   3. GPU BlockRemoved (engine_key=E1, tier=gpu)
      → evicts R1 → {pod, gpu}, R1 still has {pod, cpu} → keeps E1 → R1
 ```
+
+> [!NOTE]
+> **Event ordering guarantee:** Events from the same pod are processed in order because the event pool shards worker queues by pod identifier (FNV-1a hash). Since both the GPU `BlockStored` and the subsequent CPU offload `BlockStored` originate from the same engine on the same pod, the GPU event (which carries tokens and establishes the `engineKey → requestKey` mapping) is always processed before the CPU event that depends on it. As a defensive measure, if a CPU offload event arrives for an engine key with no existing mapping, the indexer treats it as a graceful no-op (logs at debug level and skips).
 
 ### The Dual-Key Design
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,7 +116,7 @@ On eviction, the indexer only removes the `engineKey → requestKey` mapping if 
 ```
 
 > [!NOTE]
-> **Event ordering guarantee:** Events from the same pod are processed in order because the event pool shards worker queues by pod identifier (FNV-1a hash). Since both the GPU `BlockStored` and the subsequent CPU offload `BlockStored` originate from the same engine on the same pod, the GPU event (which carries tokens and establishes the `engineKey → requestKey` mapping) is always processed before the CPU event that depends on it. As a defensive measure, if a CPU offload event arrives for an engine key with no existing mapping, the indexer treats it as a graceful no-op (logs at debug level and skips).
+> **Event ordering guarantee:** A block must exist on GPU before it can be offloaded to CPU, so the engine always publishes the GPU `BlockStored` (with tokens) before the CPU `BlockStored` (without tokens). Both events originate from the same pod, and per-pod event ordering is preserved through the processing pipeline. As a defensive measure, if a CPU offload event arrives for an engine key with no existing mapping (e.g. due to message loss), the indexer treats it as a graceful no-op.
 
 ### The Dual-Key Design
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,7 +51,7 @@ The library has two primary data flows: the **Write Path** for ingesting cache e
 
 Model servers publish three event types over ZMQ whenever their KV-cache state changes:
 
-- **`BlockStored`** — blocks with the given content hashes have been created on a specific device tier. Payload includes the chained parent hash, the token chunk, any LoRA ID/name, and any multimodal extra keys.
+- **`BlockStored`** — blocks with the given content hashes have been created on a specific device tier. Payload includes the chained parent hash, the token chunk, any LoRA ID/name, and any multimodal extra keys. For CPU offloading, the engine may emit a `BlockStored` with engine keys and a device tier but **no tokens** — see [CPU Offloading](#cpu-offloading-precise-prefix-caching).
 - **`BlockRemoved`** — blocks with the given hashes have been evicted from a specific device tier and/or attention group.
 - **`AllBlocksCleared`** — the pod dropped its entire cache (a reset). This can occur during RL weight rollouts and other scenarios. The indexer drops all entries associated with the pod via a reverse `pod → request keys` index.
 
@@ -72,9 +72,13 @@ sequenceDiagram
     Adapter-->>Worker: podID, modelName, []Event
 
     loop For each event
-        alt BlockStored
+        alt BlockStored (with tokens)
             Worker->>Worker: Compute request keys from tokens<br/>(hashSeed, parent, extra)
             Worker->>Index: Add(engineKeys, requestKeys, podEntry)
+        else BlockStored (offloading, no tokens)
+            Worker->>Index: GetRequestKey(engineKey)
+            Index-->>Worker: resolved requestKeys
+            Worker->>Index: Add(nil, resolvedKeys, podEntry)
         else BlockRemoved
             Worker->>Index: Evict(engineKey, podEntry)
         else AllBlocksCleared
@@ -90,6 +94,45 @@ sequenceDiagram
 3. **Sharded queuing** — the `kvevents.Pool` uses `EngineAdapter.ShardingKey()` to extract the pod identifier and FNV-1a-hash it to select a worker queue. This guarantees events from the same pod are processed in order.
 4. **Engine-specific parsing** — a worker calls `EngineAdapter.ParseMessage()` to decode the engine-specific payload into a batch of generic events.
 5. **Index update** — the worker applies each event to the index.
+
+### CPU Offloading (Precise Prefix Caching)
+
+When an inference engine offloads KV-cache blocks from GPU to CPU memory, the indexer must update its records so that the scorer reflects the new device tier. This is the **precise prefix-cache-aware** approach to CPU offloading — the `precise-prefix-cache-scorer` tracks the actual per-block location reported by the engine via KV-Events. It differs from the **tiered prefix cache** approach, which uses a `cpu-prefix-cache-scorer` (an instance of the `prefix-cache-scorer` plugin with a separate LRU capacity for CPU-tier blocks) that relies on scheduling-history estimation rather than real-time engine state.
+
+The offloading lifecycle from the engine's perspective is:
+
+1. Engine stores a block on GPU → emits `BlockStored(engineKeys, DeviceTier="gpu", tokens=[...])` (standard event with tokens).
+2. Engine copies the block to CPU → emits `BlockStored(engineKeys, DeviceTier="cpu")` **with no tokens** (content is unchanged; only the location is new).
+3. Engine evicts the block from GPU → emits `BlockRemoved(engineKey, DeviceTier="gpu")`.
+
+The indexer handles this sequence as follows:
+
+**Token-less `BlockStored` resolution.** A standard `BlockStored` event carries tokens, allowing the indexer to compute request keys. An offloading event carries only engine keys and a device tier — no tokens. When the indexer encounters a `BlockStored` with engine keys but zero tokens, it resolves request keys via the existing `engineKey → requestKey` mapping (established during step 1) and adds the new pod entry (with the CPU device tier) to those request keys. This ensures the scorer sees the block's new location.
+
+**Conditional engine→request mapping removal.** On eviction (step 3), the indexer only removes the `engineKey → requestKey` mapping if **all** associated request keys have no remaining pod entries. Since the CPU entry was added in step 2, the mapping is preserved — the CPU entry still depends on it for future eviction.
+
+```
+  1. GPU BlockStored (engine_key=E1, tier=gpu, tokens=[...])
+  ┌──────────────────────────────────────────────────────────────────┐
+  │  computes:   R1 from tokens                                     │
+  │  stores:     E1 → R1 mapping                                    │
+  │  stores:     R1 → PodEntry{pod, gpu}                            │
+  └──────────────────────────────────────────────────────────────────┘
+
+  2. CPU BlockStored (engine_key=E1, tier=cpu, tokens=[])
+  ┌──────────────────────────────────────────────────────────────────┐
+  │  no tokens → cannot compute request key from content            │
+  │  resolves:  E1 → R1 (from existing mapping)                     │
+  │  adds:      R1 → PodEntry{pod, cpu}                             │
+  └──────────────────────────────────────────────────────────────────┘
+
+  3. GPU BlockRemoved (engine_key=E1, tier=gpu)
+  ┌──────────────────────────────────────────────────────────────────┐
+  │  looks up:   E1 → R1                                            │
+  │  evicts:     R1 → PodEntry{pod, gpu}                            │
+  │  checks:     R1 still has entries (cpu)? → keep E1 → R1 mapping │
+  └──────────────────────────────────────────────────────────────────┘
+```
 
 ### The Dual-Key Design
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,7 +51,7 @@ The library has two primary data flows: the **Write Path** for ingesting cache e
 
 Model servers publish three event types over ZMQ whenever their KV-cache state changes:
 
-- **`BlockStored`** — blocks with the given content hashes have been created on a specific device tier. Payload includes the chained parent hash, the token chunk, any LoRA ID/name, and any multimodal extra keys. For CPU offloading, the engine may emit a `BlockStored` with engine keys and a device tier but **no tokens** — see [CPU Offloading](#cpu-offloading-precise-prefix-caching).
+- **`BlockStored`** — blocks with the given content hashes have been created on a specific device tier. Payload includes the chained parent hash, the token chunk, any LoRA ID/name, and any multimodal extra keys. For CPU offloading, the engine may emit a `BlockStored` with engine keys and a device tier but **no tokens** — see [CPU Offloading](#cpu-offloading).
 - **`BlockRemoved`** — blocks with the given hashes have been evicted from a specific device tier and/or attention group.
 - **`AllBlocksCleared`** — the pod dropped its entire cache (a reset). This can occur during RL weight rollouts and other scenarios. The indexer drops all entries associated with the pod via a reverse `pod → request keys` index.
 
@@ -95,43 +95,21 @@ sequenceDiagram
 4. **Engine-specific parsing** — a worker calls `EngineAdapter.ParseMessage()` to decode the engine-specific payload into a batch of generic events.
 5. **Index update** — the worker applies each event to the index.
 
-### CPU Offloading (Precise Prefix Caching)
+### CPU Offloading
 
-When an inference engine offloads KV-cache blocks from GPU to CPU memory, the indexer must update its records so that the scorer reflects the new device tier. This is the **precise prefix-cache-aware** approach to CPU offloading — the `precise-prefix-cache-scorer` tracks the actual per-block location reported by the engine via KV-Events. It differs from the **tiered prefix cache** approach, which uses a `cpu-prefix-cache-scorer` (an instance of the `prefix-cache-scorer` plugin with a separate LRU capacity for CPU-tier blocks) that relies on scheduling-history estimation rather than real-time engine state.
+When a block is offloaded from GPU to CPU, the engine emits a `BlockStored` with engine keys and a device tier but **no tokens** (the content is unchanged). The indexer resolves request keys from the existing `engineKey → requestKey` mapping and adds the new pod entry with the CPU tier.
 
-The offloading lifecycle from the engine's perspective is:
-
-1. Engine stores a block on GPU → emits `BlockStored(engineKeys, DeviceTier="gpu", tokens=[...])` (standard event with tokens).
-2. Engine copies the block to CPU → emits `BlockStored(engineKeys, DeviceTier="cpu")` **with no tokens** (content is unchanged; only the location is new).
-3. Engine evicts the block from GPU → emits `BlockRemoved(engineKey, DeviceTier="gpu")`.
-
-The indexer handles this sequence as follows:
-
-**Token-less `BlockStored` resolution.** A standard `BlockStored` event carries tokens, allowing the indexer to compute request keys. An offloading event carries only engine keys and a device tier — no tokens. When the indexer encounters a `BlockStored` with engine keys but zero tokens, it resolves request keys via the existing `engineKey → requestKey` mapping (established during step 1) and adds the new pod entry (with the CPU device tier) to those request keys. This ensures the scorer sees the block's new location.
-
-**Conditional engine→request mapping removal.** On eviction (step 3), the indexer only removes the `engineKey → requestKey` mapping if **all** associated request keys have no remaining pod entries. Since the CPU entry was added in step 2, the mapping is preserved — the CPU entry still depends on it for future eviction.
+On eviction, the indexer only removes the `engineKey → requestKey` mapping if all associated request keys have no remaining pod entries. This preserves the mapping when other tiers still hold the block.
 
 ```
   1. GPU BlockStored (engine_key=E1, tier=gpu, tokens=[...])
-  ┌──────────────────────────────────────────────────────────────────┐
-  │  computes:   R1 from tokens                                     │
-  │  stores:     E1 → R1 mapping                                    │
-  │  stores:     R1 → PodEntry{pod, gpu}                            │
-  └──────────────────────────────────────────────────────────────────┘
+     → computes R1 from tokens, stores E1 → R1, stores R1 → {pod, gpu}
 
   2. CPU BlockStored (engine_key=E1, tier=cpu, tokens=[])
-  ┌──────────────────────────────────────────────────────────────────┐
-  │  no tokens → cannot compute request key from content            │
-  │  resolves:  E1 → R1 (from existing mapping)                     │
-  │  adds:      R1 → PodEntry{pod, cpu}                             │
-  └──────────────────────────────────────────────────────────────────┘
+     → resolves E1 → R1, adds R1 → {pod, cpu}
 
   3. GPU BlockRemoved (engine_key=E1, tier=gpu)
-  ┌──────────────────────────────────────────────────────────────────┐
-  │  looks up:   E1 → R1                                            │
-  │  evicts:     R1 → PodEntry{pod, gpu}                            │
-  │  checks:     R1 still has entries (cpu)? → keep E1 → R1 mapping │
-  └──────────────────────────────────────────────────────────────────┘
+     → evicts R1 → {pod, gpu}, R1 still has {pod, cpu} → keeps E1 → R1
 ```
 
 ### The Dual-Key Design

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,6 +117,8 @@ On eviction, the indexer only removes the `engineKey → requestKey` mapping if 
 
 > [!NOTE]
 > **Event ordering guarantee:** A block must exist on GPU before it can be offloaded to CPU, so the engine always publishes the GPU `BlockStored` (with tokens) before the CPU `BlockStored` (without tokens). Both events originate from the same pod, and per-pod event ordering is preserved through the processing pipeline. As a defensive measure, if a CPU offload event arrives for an engine key with no existing mapping (e.g. due to message loss), the indexer treats it as a graceful no-op.
+>
+> This ordering assumption holds for the current GPU→CPU offloading path. Tiered offloading (e.g. storage→CPU) may introduce paths where the original GPU event is no longer present in the indexer, requiring further investigation.
 
 ### The Dual-Key Design
 

--- a/pkg/kvcache/kvblock/cost_aware_memory.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory.go
@@ -297,7 +297,16 @@ func (m *CostAwareMemoryIndex) Evict(ctx context.Context, key BlockHash, keyType
 		for _, rk := range rks {
 			m.evictPodsFromRequestKey(rk, key, entries, traceLogger)
 		}
-		m.requestKeys.Remove(key)
+		allEmpty := true
+		for _, rk := range rks {
+			if pc, found := m.data.Get(rk.String()); found && pc != nil && pc.Len() > 0 {
+				allEmpty = false
+				break
+			}
+		}
+		if allEmpty {
+			m.requestKeys.Remove(key)
+		}
 		m.data.Wait()
 		return nil
 	case RequestKey:

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -77,6 +77,9 @@ func NewInMemoryIndex(cfg *InMemoryIndexConfig) (*InMemoryIndex, error) {
 
 // InMemoryIndex is an in-memory implementation of the Index interface.
 type InMemoryIndex struct {
+	// mu protects engine-key-level check-and-act operations (Evict's allEmpty
+	// check + mapping removal vs Add's pod entry insertion) to prevent TOCTOU races.
+	mu sync.Mutex
 	// data holds the mapping of requestKeys to sets of pod identifiers.
 	data *lru.Cache[BlockHash, *PodCache]
 	// engineToRequestKeys holds the mapping of engineKeys to requestKeys.
@@ -177,6 +180,11 @@ func (m *InMemoryIndex) Add(ctx context.Context, engineKeys, requestKeys []Block
 	}
 
 	// Store requestKey -> PodCache mappings for all request keys.
+	// Hold m.mu to prevent Evict from checking emptiness and removing the
+	// engine→request mapping while we are inserting pod entries.
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	for _, requestKey := range requestKeys {
 		var podCache *PodCache
 		var found bool
@@ -244,6 +252,8 @@ func (m *InMemoryIndex) Evict(ctx context.Context, key BlockHash, keyType KeyTyp
 		for _, rk := range rks {
 			m.evictPodsFromRequestKey(rk, key, entries, traceLogger)
 		}
+
+		m.mu.Lock()
 		allEmpty := true
 		for _, rk := range rks {
 			if pc, found := m.data.Get(rk); found && pc != nil && pc.cache.Len() > 0 {
@@ -254,6 +264,7 @@ func (m *InMemoryIndex) Evict(ctx context.Context, key BlockHash, keyType KeyTyp
 		if allEmpty {
 			m.engineToRequestKeys.Remove(key)
 		}
+		m.mu.Unlock()
 		return nil
 	case RequestKey:
 		m.evictPodsFromRequestKey(key, EmptyBlockHash, entries, traceLogger)

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -244,7 +244,16 @@ func (m *InMemoryIndex) Evict(ctx context.Context, key BlockHash, keyType KeyTyp
 		for _, rk := range rks {
 			m.evictPodsFromRequestKey(rk, key, entries, traceLogger)
 		}
-		m.engineToRequestKeys.Remove(key)
+		allEmpty := true
+		for _, rk := range rks {
+			if pc, found := m.data.Get(rk); found && pc != nil && pc.cache.Len() > 0 {
+				allEmpty = false
+				break
+			}
+		}
+		if allEmpty {
+			m.engineToRequestKeys.Remove(key)
+		}
 		return nil
 	case RequestKey:
 		m.evictPodsFromRequestKey(key, EmptyBlockHash, entries, traceLogger)

--- a/pkg/kvcache/kvblock/index_test.go
+++ b/pkg/kvcache/kvblock/index_test.go
@@ -113,6 +113,11 @@ func testCommonIndexBehavior(t *testing.T, indexFactory func(t *testing.T) Index
 		index := indexFactory(t)
 		testEvictOneToOne(t, ctx, index)
 	})
+
+	t.Run("EvictPreservesEngineMappingForOtherTiers", func(t *testing.T) {
+		index := indexFactory(t)
+		testEvictPreservesEngineMappingForOtherTiers(t, ctx, index)
+	})
 }
 
 // testBasicAddAndLookup tests basic Add and Lookup functionality.
@@ -732,4 +737,57 @@ func testAddWithNilEngineKeys(t *testing.T, ctx context.Context, index Index) {
 	// GetRequestKey should NOT find a mapping (no engineKey was stored)
 	_, err = index.GetRequestKey(ctx, requestKey)
 	assert.Error(t, err, "GetRequestKey should fail since no engineKey mapping was created")
+}
+
+// testEvictPreservesEngineMappingForOtherTiers verifies that evicting one device
+// tier's entries preserves the engine→request mapping when another tier still has
+// entries for the same request keys.
+func testEvictPreservesEngineMappingForOtherTiers(t *testing.T, ctx context.Context, index Index) {
+	t.Helper()
+
+	engineKey := BlockHash(88001)
+	requestKey := BlockHash(99001)
+	gpuEntry := []PodEntry{{PodIdentifier: "pod-a", DeviceTier: "gpu"}}
+	cpuEntry := []PodEntry{{PodIdentifier: "pod-a", DeviceTier: "cpu"}}
+
+	// Add GPU entry with engine→request mapping.
+	err := index.Add(ctx, []BlockHash{engineKey}, []BlockHash{requestKey}, gpuEntry)
+	require.NoError(t, err)
+
+	// Add CPU entry without engine mapping (simulates offloading path: engineKeys=nil).
+	err = index.Add(ctx, nil, []BlockHash{requestKey}, cpuEntry)
+	require.NoError(t, err)
+
+	// Both tiers present.
+	result, err := index.Lookup(ctx, []BlockHash{requestKey}, nil)
+	require.NoError(t, err)
+	require.Len(t, result[requestKey], 2)
+
+	// Evict GPU tier via engine key.
+	err = index.Evict(ctx, engineKey, EngineKey, gpuEntry)
+	require.NoError(t, err)
+
+	// CPU entry must survive.
+	result, err = index.Lookup(ctx, []BlockHash{requestKey}, nil)
+	require.NoError(t, err)
+	require.Len(t, result[requestKey], 1, "cpu entry should survive gpu eviction")
+	assert.Equal(t, "cpu", result[requestKey][0].DeviceTier)
+
+	// Engine→request mapping must still resolve (needed for CPU eviction).
+	rk, err := index.GetRequestKey(ctx, engineKey)
+	require.NoError(t, err, "engine→request mapping should be preserved")
+	assert.Equal(t, requestKey, rk)
+
+	// Evict CPU tier via engine key.
+	err = index.Evict(ctx, engineKey, EngineKey, cpuEntry)
+	require.NoError(t, err)
+
+	// Everything cleaned up.
+	result, err = index.Lookup(ctx, []BlockHash{requestKey}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, result[requestKey], "no entries should remain")
+
+	// Engine→request mapping should be gone.
+	_, err = index.GetRequestKey(ctx, engineKey)
+	assert.Error(t, err, "engine→request mapping should be removed after full eviction")
 }

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -287,9 +287,24 @@ func (r *RedisIndex) Evict(ctx context.Context, key BlockHash, keyType KeyType, 
 				return err
 			}
 		}
-		// Clean up the engine key set
-		if err := r.RedisClient.Del(ctx, redisEngineKey(key)).Err(); err != nil {
-			return fmt.Errorf("failed to delete engine key mapping: %w", err)
+		allEmpty := true
+		pipe := r.RedisClient.Pipeline()
+		hlenCmds := make([]*redis.IntCmd, len(rks))
+		for i, rk := range rks {
+			hlenCmds[i] = pipe.HLen(ctx, rk.String())
+		}
+		if _, err := pipe.Exec(ctx); err == nil {
+			for _, cmd := range hlenCmds {
+				if cmd.Val() > 0 {
+					allEmpty = false
+					break
+				}
+			}
+		}
+		if allEmpty {
+			if err := r.RedisClient.Del(ctx, redisEngineKey(key)).Err(); err != nil {
+				return fmt.Errorf("failed to delete engine key mapping: %w", err)
+			}
 		}
 		return nil
 	case RequestKey:

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -153,6 +153,20 @@ var pruneRequestKeyScript = redis.NewScript(`
 	return 0
 `)
 
+// pruneEngineKeyScript atomically deletes an engine key mapping only if all
+// associated request key hashes are empty. This prevents a TOCTOU race where a
+// concurrent Add could insert into a request key between checking and deleting.
+// KEYS[1] = engine key ("engine:<hash>"), KEYS[2..N] = request key hashes.
+var pruneEngineKeyScript = redis.NewScript(`
+	for i = 2, #KEYS do
+		if redis.call('HLEN', KEYS[i]) > 0 then
+			return 0
+		end
+	end
+	redis.call('DEL', KEYS[1])
+	return 1
+`)
+
 // Lookup receives a list of keys and a set of pod identifiers,
 // and retrieves the filtered pods associated with those keys.
 // The filtering is done based on the pod identifiers provided.
@@ -287,26 +301,13 @@ func (r *RedisIndex) Evict(ctx context.Context, key BlockHash, keyType KeyType, 
 				return err
 			}
 		}
-		allEmpty := true
-		pipe := r.RedisClient.Pipeline()
-		hlenCmds := make([]*redis.IntCmd, len(rks))
-		for i, rk := range rks {
-			hlenCmds[i] = pipe.HLen(ctx, rk.String())
+		keys := make([]string, 0, 1+len(rks))
+		keys = append(keys, redisEngineKey(key))
+		for _, rk := range rks {
+			keys = append(keys, rk.String())
 		}
-		if _, err := pipe.Exec(ctx); err == nil {
-			for _, cmd := range hlenCmds {
-				if cmd.Val() > 0 {
-					allEmpty = false
-					break
-				}
-			}
-		} else {
-			allEmpty = false
-		}
-		if allEmpty {
-			if err := r.RedisClient.Del(ctx, redisEngineKey(key)).Err(); err != nil {
-				return fmt.Errorf("failed to delete engine key mapping: %w", err)
-			}
+		if err := pruneEngineKeyScript.Run(ctx, r.RedisClient, keys).Err(); err != nil && !errors.Is(err, redis.Nil) {
+			return fmt.Errorf("failed to prune engine key mapping: %w", err)
 		}
 		return nil
 	case RequestKey:

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -300,6 +300,8 @@ func (r *RedisIndex) Evict(ctx context.Context, key BlockHash, keyType KeyType, 
 					break
 				}
 			}
+		} else {
+			allEmpty = false
 		}
 		if allEmpty {
 			if err := r.RedisClient.Del(ctx, redisEngineKey(key)).Err(); err != nil {

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -349,9 +349,35 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 			}
 
 			if len(requestKeys) == 0 {
-				debugLogger.Info("no request keys produced, skipping",
-					"podIdentifier", podIdentifier, "tokenCount", len(ev.Tokens),
-					"blockSize", p.tokenProcessor.BlockSize())
+				// Offloading/location-only event (e.g., DeviceTier=CPU with no
+				// tokens). Resolve existing request keys from the engine→request
+				// mapping and add the new PodEntry so the EPP tracks which device
+				// tiers hold each block. Only attempt resolution when tokens are
+				// truly absent; partial-block events (tokens < blockSize) should
+				// just be skipped.
+				if len(ev.Tokens) == 0 && len(engineKeys) > 0 {
+					seen := make(map[kvblock.BlockHash]struct{})
+					var resolvedKeys []kvblock.BlockHash
+					for _, ek := range engineKeys {
+						rk, err := p.index.GetRequestKey(ctx, ek)
+						if err != nil {
+							continue
+						}
+						if _, ok := seen[rk]; !ok {
+							seen[rk] = struct{}{}
+							resolvedKeys = append(resolvedKeys, rk)
+						}
+					}
+					if len(resolvedKeys) > 0 {
+						if err := p.index.Add(ctx, nil, resolvedKeys, podEntries); err != nil {
+							debugLogger.Error(err, "Failed to add device-tier update to index",
+								"podIdentifier", podIdentifier, "deviceTier", deviceTier)
+						}
+					} else {
+						debugLogger.Info("no indexed engine keys found for device-tier update, skipping",
+							"podIdentifier", podIdentifier, "engineKeyCount", len(engineKeys))
+					}
+				}
 				continue
 			}
 

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	defaultEventSourceDeviceTier = "GPU"
+	defaultEventSourceDeviceTier = "gpu"
 	defaultPodSelector           = "llm-d.ai/inference-serving=true"
 )
 

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -249,6 +249,45 @@ func realignExtraFeatures(engineFeatures []*kvblock.BlockExtraFeatures, canonica
 	return canonical
 }
 
+// handleDeviceTierUpdate handles offloading/location-only events (e.g., DeviceTier=CPU
+// with no tokens). It resolves existing request keys from the engine→request mapping and
+// adds the new PodEntry so the EPP tracks which device tiers hold each block.
+func (p *Pool) handleDeviceTierUpdate(
+	ctx context.Context, tokens []uint32, engineKeys []kvblock.BlockHash,
+	podEntries []kvblock.PodEntry, podIdentifier, deviceTier string,
+) {
+	debugLogger := log.FromContext(ctx).V(logging.DEBUG)
+
+	// Only attempt resolution when tokens are truly absent; partial-block
+	// events (tokens < blockSize) should just be skipped.
+	if len(tokens) != 0 || len(engineKeys) == 0 {
+		return
+	}
+
+	seen := make(map[kvblock.BlockHash]struct{})
+	var resolvedKeys []kvblock.BlockHash
+	for _, ek := range engineKeys {
+		rk, err := p.index.GetRequestKey(ctx, ek)
+		if err != nil {
+			continue
+		}
+		if _, ok := seen[rk]; !ok {
+			seen[rk] = struct{}{}
+			resolvedKeys = append(resolvedKeys, rk)
+		}
+	}
+
+	if len(resolvedKeys) > 0 {
+		if err := p.index.Add(ctx, nil, resolvedKeys, podEntries); err != nil {
+			debugLogger.Error(err, "Failed to add device-tier update to index",
+				"podIdentifier", podIdentifier, "deviceTier", deviceTier)
+		}
+	} else {
+		debugLogger.Info("no indexed engine keys found for device-tier update, skipping",
+			"podIdentifier", podIdentifier, "engineKeyCount", len(engineKeys))
+	}
+}
+
 // processEventBatch processes a batch of events using type switches.
 func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIdentifier, modelName string) {
 	debugLogger := log.FromContext(ctx).V(logging.DEBUG)
@@ -349,35 +388,7 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 			}
 
 			if len(requestKeys) == 0 {
-				// Offloading/location-only event (e.g., DeviceTier=CPU with no
-				// tokens). Resolve existing request keys from the engine→request
-				// mapping and add the new PodEntry so the EPP tracks which device
-				// tiers hold each block. Only attempt resolution when tokens are
-				// truly absent; partial-block events (tokens < blockSize) should
-				// just be skipped.
-				if len(ev.Tokens) == 0 && len(engineKeys) > 0 {
-					seen := make(map[kvblock.BlockHash]struct{})
-					var resolvedKeys []kvblock.BlockHash
-					for _, ek := range engineKeys {
-						rk, err := p.index.GetRequestKey(ctx, ek)
-						if err != nil {
-							continue
-						}
-						if _, ok := seen[rk]; !ok {
-							seen[rk] = struct{}{}
-							resolvedKeys = append(resolvedKeys, rk)
-						}
-					}
-					if len(resolvedKeys) > 0 {
-						if err := p.index.Add(ctx, nil, resolvedKeys, podEntries); err != nil {
-							debugLogger.Error(err, "Failed to add device-tier update to index",
-								"podIdentifier", podIdentifier, "deviceTier", deviceTier)
-						}
-					} else {
-						debugLogger.Info("no indexed engine keys found for device-tier update, skipping",
-							"podIdentifier", podIdentifier, "engineKeyCount", len(engineKeys))
-					}
-				}
+				p.handleDeviceTierUpdate(ctx, ev.Tokens, engineKeys, podEntries, podIdentifier, deviceTier)
 				continue
 			}
 

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -505,12 +505,12 @@ func TestBlockStoredEvent_OffloadingEmptyTokens(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, canonicalKeys, 4)
 
-	// Verify GPU entry exists (default tier is uppercase "GPU").
+	// Verify GPU entry exists.
 	for _, ck := range canonicalKeys {
 		result, err := idx.Lookup(ctx, []kvblock.BlockHash{ck}, nil)
 		require.NoError(t, err)
 		require.Len(t, result[ck], 1)
-		assert.Equal(t, "GPU", result[ck][0].DeviceTier)
+		assert.Equal(t, "gpu", result[ck][0].DeviceTier)
 	}
 
 	// Step 2: Process offloading event — same engine keys, empty tokens, CPU tier.
@@ -536,7 +536,7 @@ func TestBlockStoredEvent_OffloadingEmptyTokens(t *testing.T) {
 		for _, pe := range result[ck] {
 			tiers[pe.DeviceTier] = true
 		}
-		assert.True(t, tiers["GPU"], "GPU entry should be present")
+		assert.True(t, tiers["gpu"], "gpu entry should be present")
 		assert.True(t, tiers["cpu"], "cpu entry should be present")
 	}
 }

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -478,6 +478,181 @@ func TestCanonicalWritePath_ExtraKeysManyToOne(t *testing.T) {
 	}
 }
 
+// TestBlockStoredEvent_OffloadingEmptyTokens verifies that an offloading event
+// (empty Tokens, non-empty BlockHashes, DeviceTier="CPU") correctly updates
+// existing index entries with the new device tier rather than being dropped.
+func TestBlockStoredEvent_OffloadingEmptyTokens(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, idx, tp := newTestPool(t, 16)
+
+	tokens := makeTokens(64)
+	engineKeys := makeEngineKeys(4, 600)
+
+	// Step 1: Store blocks with full tokens (simulates initial GPU event).
+	gpuBatch := &EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes: engineKeys,
+				Tokens:      tokens,
+				ParentHash:  0,
+			},
+		},
+	}
+	pool.processEventBatch(ctx, gpuBatch, "pod-a", "test-model")
+
+	canonicalKeys, err := tp.TokensToKVBlockKeys(
+		kvblock.EmptyBlockHash, tokens, "test-model", nil)
+	require.NoError(t, err)
+	require.Len(t, canonicalKeys, 4)
+
+	// Verify GPU entry exists (default tier is uppercase "GPU").
+	for _, ck := range canonicalKeys {
+		result, err := idx.Lookup(ctx, []kvblock.BlockHash{ck}, nil)
+		require.NoError(t, err)
+		require.Len(t, result[ck], 1)
+		assert.Equal(t, "GPU", result[ck][0].DeviceTier)
+	}
+
+	// Step 2: Process offloading event — same engine keys, empty tokens, CPU tier.
+	cpuBatch := &EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes: engineKeys,
+				Tokens:      nil,
+				ParentHash:  0,
+				DeviceTier:  "CPU",
+			},
+		},
+	}
+	pool.processEventBatch(ctx, cpuBatch, "pod-a", "test-model")
+
+	// Verify both GPU and CPU entries now exist for each canonical key.
+	for _, ck := range canonicalKeys {
+		result, err := idx.Lookup(ctx, []kvblock.BlockHash{ck}, nil)
+		require.NoError(t, err)
+		require.Len(t, result[ck], 2, "should have both gpu and cpu entries")
+
+		tiers := map[string]bool{}
+		for _, pe := range result[ck] {
+			tiers[pe.DeviceTier] = true
+		}
+		assert.True(t, tiers["GPU"], "GPU entry should be present")
+		assert.True(t, tiers["cpu"], "cpu entry should be present")
+	}
+}
+
+// TestBlockStoredEvent_OffloadingUnknownEngineKeys verifies that an offloading
+// event with engine keys not yet in the index is a graceful no-op.
+func TestBlockStoredEvent_OffloadingUnknownEngineKeys(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, _, _ := newTestPool(t, 16)
+
+	// Offloading event for engine keys that were never stored.
+	cpuBatch := &EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes: makeEngineKeys(4, 900),
+				Tokens:      nil,
+				ParentHash:  0,
+				DeviceTier:  "CPU",
+			},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		pool.processEventBatch(ctx, cpuBatch, "pod-x", "test-model")
+	})
+}
+
+// TestBlockStoredEvent_EvictionOrderGPUThenCPU verifies the full lifecycle:
+// GPU store → CPU offload → GPU evict → CPU entry survives → CPU evict → full cleanup.
+func TestBlockStoredEvent_EvictionOrderGPUThenCPU(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, idx, tp := newTestPool(t, 16)
+
+	tokens := makeTokens(64)
+	engineKeys := makeEngineKeys(4, 700)
+
+	// Step 1: Store blocks on GPU.
+	gpuBatch := &EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes: engineKeys,
+				Tokens:      tokens,
+				ParentHash:  0,
+			},
+		},
+	}
+	pool.processEventBatch(ctx, gpuBatch, "pod-a", "test-model")
+
+	canonicalKeys, err := tp.TokensToKVBlockKeys(
+		kvblock.EmptyBlockHash, tokens, "test-model", nil)
+	require.NoError(t, err)
+	require.Len(t, canonicalKeys, 4)
+
+	// Step 2: Offload to CPU.
+	cpuBatch := &EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes: engineKeys,
+				Tokens:      nil,
+				ParentHash:  0,
+				DeviceTier:  "CPU",
+			},
+		},
+	}
+	pool.processEventBatch(ctx, cpuBatch, "pod-a", "test-model")
+
+	// Verify both tiers present.
+	for _, ck := range canonicalKeys {
+		result, err := idx.Lookup(ctx, []kvblock.BlockHash{ck}, nil)
+		require.NoError(t, err)
+		require.Len(t, result[ck], 2)
+	}
+
+	// Step 3: Evict from GPU.
+	gpuEvict := &EventBatch{
+		Events: []GenericEvent{
+			&BlockRemovedEvent{
+				BlockHashes: engineKeys,
+			},
+		},
+	}
+	pool.processEventBatch(ctx, gpuEvict, "pod-a", "test-model")
+
+	// CPU entries must survive, engine→request mapping must be preserved.
+	for _, ck := range canonicalKeys {
+		result, err := idx.Lookup(ctx, []kvblock.BlockHash{ck}, nil)
+		require.NoError(t, err)
+		require.Len(t, result[ck], 1, "cpu entry should survive gpu eviction")
+		assert.Equal(t, "cpu", result[ck][0].DeviceTier)
+	}
+	// Engine→request mapping must still resolve.
+	_, err = idx.GetRequestKey(ctx, kvblock.BlockHash(engineKeys[0]))
+	require.NoError(t, err, "engine→request mapping should survive gpu eviction")
+
+	// Step 4: Evict from CPU.
+	cpuEvict := &EventBatch{
+		Events: []GenericEvent{
+			&BlockRemovedEvent{
+				BlockHashes: engineKeys,
+				DeviceTier:  "CPU",
+			},
+		},
+	}
+	pool.processEventBatch(ctx, cpuEvict, "pod-a", "test-model")
+
+	// Everything should be fully cleaned up.
+	for _, ck := range canonicalKeys {
+		result, err := idx.Lookup(ctx, []kvblock.BlockHash{ck}, nil)
+		require.NoError(t, err)
+		assert.Empty(t, result[ck], "all entries should be gone after full eviction")
+	}
+	// Engine→request mapping should be gone.
+	_, err = idx.GetRequestKey(ctx, kvblock.BlockHash(engineKeys[0]))
+	assert.Error(t, err, "engine→request mapping should be removed after full eviction")
+}
+
 // TestCanonicalWritePath_PartialBlockDrop verifies that tokens fewer than the canonical block
 // size produce zero canonical keys and the event is silently skipped.
 func TestCanonicalWritePath_PartialBlockDrop(t *testing.T) {


### PR DESCRIPTION
This PR addresses the issue in CPU offloading where EPP removes GPU PodEntry and deletes engineKey→requestKey mapping. The solution is letting EPP remove GPU PodEntry, but see CPU entry still exists → preserve engineKey→requestKey mapping. 

This PR was tested using [`llm-d-benchmark`](https://github.com/llm-d/llm-d-benchmark) with [`llm-d-kv-cache`](https://github.com/llm-d/llm-d-kv-cache/tree/main) upstream (v0.8.0-rc.1) and [`offloading_index (this PR)`](https://github.com/mengmeiye/llm-d-kv-cache/tree/offloading_index).
The only different between these two experiments is the `inferenceScheduler` image. One uses `v0.8.0-rc.1` tag and the other uses `cpu-offloading`. The scenario file is in https://github.com/mengmeiye/llm-d-benchmark/blob/offloading_stress_test/config/scenarios/guides/precise-prefix-cache-aware-offloading.yaml
To reproduce the experiments:
```bash
llmdbenchmark --spec precise-prefix-cache-aware-offloading standup -p <NAMESPACE>
llmdbenchmark --spec precise-prefix-cache-aware-offloading run -p <NAMESPACE> --monitoring
```

In each of the experiments, we have

- 256 groups × 64 blocks/group = 16,384 unique prefix blocks across the system
- Each pod can hold ~5,359 GPU blocks → after ~84 groups, GPU is full and eviction begins
- With OffloadingConnector, evicted GPU blocks move to CPU
    - Here is the key improvement:
        - `Upstream (v0.8.0-rc.1)` EPP removes GPU PodEntry and deletes engineKey→requestKey mapping. Then, EPP has no record that the block exists anywhere
        - `offloading_index (this PR)` EPP removes GPU PodEntry, but sees CPU entry still exists → preserves engineKey→requestKey mapping. Then, EPP still knows this pod holds the block (on CPU tier). 
- With new requests arriving whose prefix matches those blocks, performance starts making differences: 
    - `Upstream (v0.8.0-rc.1)` The EPP finds score=0 for all pods and falls back to load-balanced routing (random pod). The request likely lands on a pod that doesn't have the prefix cached → cold prefill → high TTFT.
    - `offloading_index (this PR)` The prefix scorer finds a match → routes to the correct pod → the pod already has the KV blocks in GPU (kept hot by repeated affinity routing) → prefix cache hit → low TTFT.
 
TTFT comparison on a GPU cluster: 
- Upstream (`v0.8.0-rc.1`):          mean=1.007s, p50=0.178s,  p95=6.116s,  p99=11.435s
- `offloading_index` (this PR):    mean=0.552s,  p50=0.119s,  p95=1.814s,  p99=8.252s
- Improvement:
    - Mean TTFT improvement:  45.2%
    - P95 TTFT improvement:   70.3%