### PR TITLE
fix: avoid LRU promotion on Lookup to unblock concurrent readers

### DIFF
--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -117,7 +117,15 @@ func (m *InMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 	highestHitIdx := 0
 
 	for idx, requestKey := range requestKeys {
-		if pods, found := m.data.Get(requestKey); found { //nolint:nestif // TODO: can this be optimized?
+		// Peek (RLock) instead of Get (Lock): Get promotes the entry to MRU
+		// and so takes hashicorp/lru's exclusive Mutex on every call. With
+		// concurrent Lookup callers each iterating hundreds of blocks, the
+		// per-Get serialization dominates latency (95%+ of mutex profile).
+		// Peek takes RLock and lets readers run in parallel. The tradeoff
+		// is that LRU eviction order tracks Add-time recency only; for a
+		// prefix cache where hot blocks are continually re-Added by KV
+		// events, this is acceptable.
+		if pods, found := m.data.Peek(requestKey); found { //nolint:nestif // TODO: can this be optimized?
 			if pods == nil || pods.cache.Len() == 0 {
 				traceLogger.Info("no pods found for key, cutting search", "key", requestKey)
 				return podsPerKey, nil // early stop since prefix-chain breaks here


### PR DESCRIPTION
InMemoryIndex.Lookup walked requestKeys with hashicorp/lru's Get(), which takes an exclusive sync.Mutex on every call (LRU promotion is a write op on the linked list). For long prompts the loop runs hundreds of Get() calls, and concurrent Lookup callers serialize fully behind each other on that lock.

In production telemetry from the inference-scheduler's precise prefix cache scorer (40-pod fleet, ~263 blocks per prompt), this manifested as bimodal scorer latency: p50=0.31ms when prompts early-break on a miss, p95=735ms / max=1.42s when reader concurrency built up on shared prefixes. A mutex profile attributed 95.44% of contention to hashicorp/lru.Cache.Get under InMemoryIndex.Lookup.

Switching Lookup to Peek() takes the LRU's RLock instead, letting concurrent reads run in parallel. In a reproducer harness that faithfully mimics production load (full prefix warm, 40 KV-event writers Add()ing throughout):

  readers   blocks   Get p50    Peek p50    speedup
  64        263      21.46ms    2.86ms      7.5x
  128       263      37.88ms    2.36ms      16x
  64        1024     94.52ms    37.10ms     2.5x

Trade-off: LRU eviction order tracks Add-time recency only, no read-time recency. For a prefix cache where hot blocks are continually re-Added by KV-cache events from the engines, this is acceptable -- hot data refreshes through the write path.

Existing concurrent stress test (testStressConcurrentAddLookup) and all other in_memory tests pass without modification.