### PR TITLE
fix: evict all index entries on AllBlocksClearedEvent

### DIFF
--- a/pkg/kvcache/kvblock/cost_aware_memory.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory.go
@@ -336,6 +336,91 @@ func (m *CostAwareMemoryIndex) evictPodsFromRequestKey(
 	}
 }
 
+// EvictByPod removes all entries associated with the given pod identifier from the index.
+// It iterates all request keys and removes the pod from each CostPodCache. Request keys
+// that become empty are removed. Engine key mappings that point to removed request keys
+// are also cleaned up.
+func (m *CostAwareMemoryIndex) EvictByPod(ctx context.Context, podIdentifier string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.CostAwareMemoryIndex.EvictByPod")
+
+	// Iterate all engine key mappings to find request keys associated with pods.
+	// We use the requestKeys LRU (engineKey -> []BlockHash) to discover all
+	// known request keys, then check each one.
+	var emptyRequestKeys []BlockHash
+	seen := make(map[string]struct{})
+
+	for _, engineKey := range m.requestKeys.Keys() {
+		rks, found := m.requestKeys.Get(engineKey)
+		if !found {
+			continue
+		}
+		for _, rk := range rks {
+			keyStr := rk.String()
+			if _, ok := seen[keyStr]; ok {
+				continue
+			}
+			seen[keyStr] = struct{}{}
+
+			podCache, found := m.data.Get(keyStr)
+			if !found || podCache == nil {
+				continue
+			}
+
+			// Remove all entries for this pod from the cache.
+			podCache.cache.Range(func(key, _ interface{}) bool {
+				entry, ok := key.(PodEntry)
+				if ok && entry.PodIdentifier == podIdentifier {
+					podCache.Delete(entry)
+				}
+				return true
+			})
+
+			if podCache.Len() == 0 {
+				m.data.Del(keyStr)
+				emptyRequestKeys = append(emptyRequestKeys, rk)
+			} else {
+				m.data.Set(keyStr, podCache, podCache.CalculateByteSize(keyStr))
+			}
+		}
+	}
+
+	// Clean up engine key mappings that point to removed request keys.
+	if len(emptyRequestKeys) > 0 {
+		emptySet := make(map[BlockHash]struct{}, len(emptyRequestKeys))
+		for _, rk := range emptyRequestKeys {
+			emptySet[rk] = struct{}{}
+		}
+
+		for _, engineKey := range m.requestKeys.Keys() {
+			rks, found := m.requestKeys.Get(engineKey)
+			if !found {
+				continue
+			}
+			remaining := make([]BlockHash, 0, len(rks))
+			for _, rk := range rks {
+				if _, removed := emptySet[rk]; !removed {
+					remaining = append(remaining, rk)
+				}
+			}
+			if len(remaining) == 0 {
+				m.requestKeys.Remove(engineKey)
+			} else if len(remaining) != len(rks) {
+				m.requestKeys.Add(engineKey, remaining)
+			}
+		}
+	}
+
+	m.data.Wait()
+
+	traceLogger.Info("evicted all blocks for pod", "podIdentifier", podIdentifier,
+		"removedRequestKeys", len(emptyRequestKeys))
+
+	return nil
+}
+
 // GetRequestKey returns the last request key (highest index in the chain) associated with the given engineKey.
 // Returns an error if the engineKey is not mapped (e.g., evicted earlier).
 func (m *CostAwareMemoryIndex) GetRequestKey(ctx context.Context, engineKey BlockHash) (BlockHash, error) {

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -292,6 +292,68 @@ func (m *InMemoryIndex) evictPodsFromRequestKey(requestKey, engineKey BlockHash,
 	currentCache.mu.Unlock()
 }
 
+// EvictByPod removes all entries associated with the given pod identifier from the index.
+// It iterates all request keys and removes the pod from each PodCache. Request keys
+// that become empty are removed. Engine key mappings that point to removed request keys
+// are also cleaned up.
+func (m *InMemoryIndex) EvictByPod(ctx context.Context, podIdentifier string) error {
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.InMemoryIndex.EvictByPod")
+
+	// Iterate all request keys and remove entries belonging to this pod.
+	var emptyRequestKeys []BlockHash
+	for _, requestKey := range m.data.Keys() {
+		podCache, found := m.data.Get(requestKey)
+		if !found || podCache == nil {
+			continue
+		}
+
+		podCache.mu.Lock()
+		for _, entry := range podCache.cache.Keys() {
+			if entry.PodIdentifier == podIdentifier {
+				podCache.cache.Remove(entry)
+			}
+		}
+		isEmpty := podCache.cache.Len() == 0
+		podCache.mu.Unlock()
+
+		if isEmpty {
+			emptyRequestKeys = append(emptyRequestKeys, requestKey)
+			m.data.Remove(requestKey)
+		}
+	}
+
+	// Clean up engine key mappings that point to removed request keys.
+	if len(emptyRequestKeys) > 0 {
+		emptySet := make(map[BlockHash]struct{}, len(emptyRequestKeys))
+		for _, rk := range emptyRequestKeys {
+			emptySet[rk] = struct{}{}
+		}
+
+		for _, engineKey := range m.engineToRequestKeys.Keys() {
+			rks, found := m.engineToRequestKeys.Get(engineKey)
+			if !found {
+				continue
+			}
+			remaining := make([]BlockHash, 0, len(rks))
+			for _, rk := range rks {
+				if _, removed := emptySet[rk]; !removed {
+					remaining = append(remaining, rk)
+				}
+			}
+			if len(remaining) == 0 {
+				m.engineToRequestKeys.Remove(engineKey)
+			} else if len(remaining) != len(rks) {
+				m.engineToRequestKeys.Add(engineKey, remaining)
+			}
+		}
+	}
+
+	traceLogger.Info("evicted all blocks for pod", "podIdentifier", podIdentifier,
+		"removedRequestKeys", len(emptyRequestKeys))
+
+	return nil
+}
+
 // GetRequestKey returns the last request key (highest index in the chain) associated with the given engineKey.
 // This is what Pool uses for parent hash resolution.
 // Returns an error if the engineKey mapping is missing (e.g., already evicted).

--- a/pkg/kvcache/kvblock/index.go
+++ b/pkg/kvcache/kvblock/index.go
@@ -144,6 +144,10 @@ type Index interface {
 	// keyType indicates whether the key is an EngineKey (requires engine→request lookup)
 	// or a RequestKey (used directly).
 	Evict(ctx context.Context, key BlockHash, keyType KeyType, entries []PodEntry) error
+	// EvictByPod removes all entries associated with the given pod identifier
+	// from the index. This is used when a pod is deleted and all its cached
+	// blocks should be removed.
+	EvictByPod(ctx context.Context, podIdentifier string) error
 	// GetRequestKey returns the requestKey associated with the given engineKey.
 	GetRequestKey(ctx context.Context, engineKey BlockHash) (BlockHash, error)
 }

--- a/pkg/kvcache/kvblock/instrumented_index.go
+++ b/pkg/kvcache/kvblock/instrumented_index.go
@@ -44,6 +44,10 @@ func (m *instrumentedIndex) Evict(ctx context.Context, key BlockHash, keyType Ke
 	return err
 }
 
+func (m *instrumentedIndex) EvictByPod(ctx context.Context, podIdentifier string) error {
+	return m.next.EvictByPod(ctx, podIdentifier)
+}
+
 func (m *instrumentedIndex) Lookup(
 	ctx context.Context,
 	requestKeys []BlockHash,

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -342,6 +342,76 @@ func (r *RedisIndex) getRequestKeys(ctx context.Context, engineKey BlockHash) ([
 	return rks, nil
 }
 
+// EvictByPod removes all entries associated with the given pod identifier from the index.
+// It scans all request key hashes and removes fields that belong to the pod.
+// Empty request key hashes are deleted.
+func (r *RedisIndex) EvictByPod(ctx context.Context, podIdentifier string) error {
+	logger := log.FromContext(ctx).WithName("kvblock.RedisIndex.EvictByPod")
+
+	var cursor uint64
+	for {
+		keys, nextCursor, err := r.RedisClient.Scan(ctx, cursor, "*", 100).Result()
+		if err != nil {
+			return fmt.Errorf("failed to scan Redis keys: %w", err)
+		}
+
+		for _, key := range keys {
+			// Skip engine key mappings (sorted sets).
+			if strings.HasPrefix(key, "engine:") {
+				continue
+			}
+
+			// Get all fields (pod entries) for this request key hash.
+			fields, err := r.RedisClient.HKeys(ctx, key).Result()
+			if err != nil {
+				logger.Error(err, "failed to get fields for key", "key", key)
+				continue
+			}
+
+			// Delete fields belonging to this pod.
+			var toDelete []string
+			for _, field := range fields {
+				// Field format: "podIdentifier@deviceTier" or "podIdentifier@deviceTier[speculative]"
+				if strings.SplitN(field, "@", 2)[0] == podIdentifier {
+					toDelete = append(toDelete, field)
+				}
+			}
+
+			if len(toDelete) == 0 {
+				continue
+			}
+
+			pipe := r.RedisClient.Pipeline()
+			for _, field := range toDelete {
+				pipe.HDel(ctx, key, field)
+			}
+			if _, err := pipe.Exec(ctx); err != nil {
+				logger.Error(err, "failed to delete pod entries", "key", key, "podIdentifier", podIdentifier)
+				continue
+			}
+
+			// Prune the key if it is now empty.
+			if err := pruneRequestKeyScript.Run(ctx, r.RedisClient, []string{key}).Err(); err != nil {
+				logger.Error(err, "failed to prune empty request key", "key", key)
+			}
+		}
+
+		cursor = nextCursor
+		if cursor == 0 {
+			break
+		}
+	}
+
+	// Clean up engine key sorted sets that reference this pod indirectly.
+	// Engine keys map to request keys (not directly to pods), so we only need
+	// to remove engine key entries whose request keys were fully pruned above.
+	// The pruneRequestKeyScript already handles removing empty request key hashes,
+	// so engine keys with dangling references will naturally fail on next Evict.
+
+	logger.Info("evicted all blocks for pod", "podIdentifier", podIdentifier)
+	return nil
+}
+
 // GetRequestKey returns the last request key (highest score) associated with the given engineKey.
 func (r *RedisIndex) GetRequestKey(ctx context.Context, engineKey BlockHash) (BlockHash, error) {
 	vals, err := r.RedisClient.ZRevRange(ctx, redisEngineKey(engineKey), 0, 0).Result()

--- a/pkg/kvcache/kvblock/traced_index.go
+++ b/pkg/kvcache/kvblock/traced_index.go
@@ -44,6 +44,10 @@ func (t *tracedIndex) Evict(ctx context.Context, key BlockHash, keyType KeyType,
 	return t.next.Evict(ctx, key, keyType, entries)
 }
 
+func (t *tracedIndex) EvictByPod(ctx context.Context, podIdentifier string) error {
+	return t.next.EvictByPod(ctx, podIdentifier)
+}
+
 func (t *tracedIndex) Lookup(
 	ctx context.Context,
 	requestKeys []BlockHash,

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -390,6 +390,10 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 				"podIdentifier", podIdentifier,
 				"deviceTier", ev.DeviceTier,
 				"modelName", modelName)
+			if err := p.index.EvictByPod(ctx, podIdentifier); err != nil {
+				debugLogger.Error(err, "Failed to evict all blocks for pod",
+					"podIdentifier", podIdentifier)
+			}
 
 		default:
 			debugLogger.Info("Unknown event", "podIdentifier", podIdentifier, "event", genericEvent)

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -504,3 +504,107 @@ func TestCanonicalWritePath_PartialBlockDrop(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result[kvblock.BlockHash(1)])
 }
+
+// TestAllBlocksClearedEvent_EvictsAllPodEntries verifies that an AllBlocksClearedEvent
+// removes all index entries for the cleared pod while leaving other pods intact.
+func TestAllBlocksClearedEvent_EvictsAllPodEntries(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, idx, tp := newTestPool(t, 64)
+
+	tokens := makeTokens(128)
+
+	// Store blocks for pod-a
+	batchA := &EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes: makeEngineKeys(8, 100),
+				Tokens:      tokens,
+				ParentHash:  0,
+			},
+		},
+	}
+	pool.processEventBatch(ctx, batchA, "pod-a", "test-model")
+
+	// Store blocks for pod-b (same tokens, different engine keys)
+	batchB := &EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes: makeEngineKeys(8, 200),
+				Tokens:      tokens,
+				ParentHash:  0,
+			},
+		},
+	}
+	pool.processEventBatch(ctx, batchB, "pod-b", "test-model")
+
+	// Verify both pods are in the index
+	canonicalKeys, err := tp.TokensToKVBlockKeys(
+		kvblock.EmptyBlockHash, tokens, "test-model", nil)
+	require.NoError(t, err)
+	require.Len(t, canonicalKeys, 2)
+
+	for _, ck := range canonicalKeys {
+		result, err := idx.Lookup(ctx, []kvblock.BlockHash{ck}, nil)
+		require.NoError(t, err)
+		require.Len(t, result[ck], 2, "both pods should be present before clear")
+	}
+
+	// Fire AllBlocksClearedEvent for pod-a
+	clearBatch := &EventBatch{
+		Events: []GenericEvent{
+			&AllBlocksClearedEvent{},
+		},
+	}
+	pool.processEventBatch(ctx, clearBatch, "pod-a", "test-model")
+
+	// Verify pod-a is gone but pod-b remains
+	for _, ck := range canonicalKeys {
+		result, err := idx.Lookup(ctx, []kvblock.BlockHash{ck}, nil)
+		require.NoError(t, err)
+		pods := result[ck]
+		require.Len(t, pods, 1, "only pod-b should remain after pod-a clear")
+		assert.Equal(t, "pod-b", pods[0].PodIdentifier)
+	}
+}
+
+// TestAllBlocksClearedEvent_RemovesEngineKeyMappings verifies that engine key
+// mappings are cleaned up when a pod's blocks are fully cleared.
+func TestAllBlocksClearedEvent_RemovesEngineKeyMappings(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, idx, _ := newTestPool(t, 16)
+
+	tokens := makeTokens(64)
+	engineKeys := makeEngineKeys(4, 500)
+
+	// Store blocks for a single pod
+	batch := &EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes: engineKeys,
+				Tokens:      tokens,
+				ParentHash:  0,
+			},
+		},
+	}
+	pool.processEventBatch(ctx, batch, "pod-only", "test-model")
+
+	// Verify engine keys are resolvable
+	for _, ek := range engineKeys {
+		_, err := idx.GetRequestKey(ctx, kvblock.BlockHash(ek))
+		require.NoError(t, err, "engine key %d should be resolvable before clear", ek)
+	}
+
+	// Fire AllBlocksClearedEvent
+	clearBatch := &EventBatch{
+		Events: []GenericEvent{
+			&AllBlocksClearedEvent{},
+		},
+	}
+	pool.processEventBatch(ctx, clearBatch, "pod-only", "test-model")
+
+	// Verify engine keys are no longer resolvable
+	for _, ek := range engineKeys {
+		_, err := idx.GetRequestKey(ctx, kvblock.BlockHash(ek))
+		assert.Error(t, err, "engine key %d should not be resolvable after clear", ek)
+	}
+}


### PR DESCRIPTION
Fixes #537

## Problem

When `AllBlocksClearedEvent` fires (pod deletion or full cache clear), the handler in `pool.go` only logs the event. The pod's entries remain in the index indefinitely, causing:
- Memory leak from accumulated stale entries
- Suboptimal routing (scorer returns hits for pods that no longer hold the data)

## Fix

Add `EvictByPod(ctx, podIdentifier string) error` to the `Index` interface and implement it for all backends:

- **InMemoryIndex**: iterates all request keys, removes entries matching the pod, cleans up empty keys and orphaned engine key mappings
- **CostAwareMemoryIndex**: same logic adapted for Ristretto cache with sync.Map pod caches
- **RedisIndex**: SCAN-based iteration, removes matching hash fields, prunes empty keys
- **tracedIndex / instrumentedIndex**: delegate to inner implementation

Call `EvictByPod` from the `AllBlocksClearedEvent` handler in `pool.go`.

## Testing

Two new tests in `pool_test.go`:
- `TestAllBlocksClearedEvent_EvictsAllPodEntries` -- verifies cleared pod is removed while other pods remain
- `TestAllBlocksClearedEvent_RemovesEngineKeyMappings` -- verifies engine key mappings are cleaned up when the only pod is cleared

All existing tests pass. Race detector clean.