### PR TITLE
Replace BlockSize with BlockSizeTokens

### DIFF
--- a/benchmarking/37-capacity/README.md
+++ b/benchmarking/37-capacity/README.md
@@ -153,7 +153,7 @@ plugins:
   parameters:
     mode: cache_tracking
     tokenProcessorConfig:
-      blockSize: 64   
+      blockSizeTokens: 64
       hashSeed: "42"
     indexerConfig:
       kvBlockIndexConfig:

--- a/benchmarking/73-capacity/README.md
+++ b/benchmarking/73-capacity/README.md
@@ -160,7 +160,7 @@ plugins:
   parameters:
     mode: cache_tracking
     tokenProcessorConfig:
-      blockSize: 64   
+      blockSizeTokens: 64
       hashSeed: "42"
     indexerConfig:
       kvBlockIndexConfig:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,7 +239,7 @@ Adapters shipping today:
 
 To look up blocks by request keys, the indexer reproduces the engine's content-addressing scheme:
 
-- **Token chunking**: prompts are converted to tokens, grouped into fixed-size chunks (configurable via `blockSize`; default 16).
+- **Token chunking**: prompts are converted to tokens, grouped into fixed-size chunks (configurable via `blockSizeTokens`; default 16).
 - **Hash algorithm**: a chained hash is computed. Each block's key is an **FNV-64a** hash over the CBOR-encoded tuple `[parentHash, tokenChunk, extra]`.
 - **Initialization**: the hash chain starts with a configurable `hashSeed` mixed with the model name.
 - **Extra parameter**: the third component enables cache differentiation:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -456,7 +456,7 @@ Configures how tokens are converted to KV-block keys.
 | Field | Type | Description | Default |
 |-------|------|-------------|---------|
 | `blockSizeTokens` | `integer` | Number of tokens per block | `16` |
-| `blockSize` | `integer` | **Deprecated:** Use `blockSizeTokens` instead | `16` |
+| `blockSize` | `integer` | **Deprecated:** Use `blockSizeTokens` instead. Still accepted for backward compatibility. | `16` |
 | `hashSeed` | `string` | Seed for the indexer's own request-key hash chain. Independent of any engine-side seed. | `""` |
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -448,14 +448,15 @@ Configures how tokens are converted to KV-block keys.
 
 ```json
 {
-  "blockSize": 16,
+  "blockSizeTokens": 16,
   "hashSeed": ""
 }
 ```
 
 | Field | Type | Description | Default |
 |-------|------|-------------|---------|
-| `blockSize` | `integer` | Number of tokens per block | `16` |
+| `blockSizeTokens` | `integer` | Number of tokens per block | `16` |
+| `blockSize` | `integer` | **Deprecated:** Use `blockSizeTokens` instead | `16` |
 | `hashSeed` | `string` | Seed for the indexer's own request-key hash chain. Independent of any engine-side seed. | `""` |
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -456,7 +456,7 @@ Configures how tokens are converted to KV-block keys.
 | Field | Type | Description | Default |
 |-------|------|-------------|---------|
 | `blockSizeTokens` | `integer` | Number of tokens per block | `16` |
-| `blockSize` | `integer` | **Deprecated:** Use `blockSizeTokens` instead. Still accepted for backward compatibility. | `16` |
+| `blockSize` | `integer` | **Deprecated:** Use `blockSizeTokens` instead. Still accepted for backward compatibility. | default of `blockSizeTokens` |
 | `hashSeed` | `string` | Seed for the indexer's own request-key hash chain. Independent of any engine-side seed. | `""` |
 
 ---

--- a/examples/helper/indexer.go
+++ b/examples/helper/indexer.go
@@ -84,7 +84,7 @@ func getKVCacheIndexerConfig() (*kvcache.Config, error) {
 
 func getTokenProcessorConfig() *kvblock.TokenProcessorConfig {
 	return &kvblock.TokenProcessorConfig{
-		BlockSize: 256,
+		BlockSizeTokens: 256,
 	}
 }
 

--- a/examples/kv_cache_index/main.go
+++ b/examples/kv_cache_index/main.go
@@ -99,7 +99,7 @@ func setupKVCacheIndexer(ctx context.Context) (*kvcache.Indexer, error) {
 	}
 
 	tokenProcessor, err := kvblock.NewChunkedTokenDatabase(&kvblock.TokenProcessorConfig{
-		BlockSize: 256,
+		BlockSizeTokens: 256,
 	})
 	if err != nil {
 		return nil, err

--- a/examples/kv_events/online/main.go
+++ b/examples/kv_events/online/main.go
@@ -219,7 +219,7 @@ func setupEventsPool(ctx context.Context, kvBlockIndex kvblock.Index) (*kvevents
 	cfg := getEventsPoolConfig()
 
 	logger.Info("Creating events pool", "config", cfg)
-	tokenProcessor, err := kvblock.NewChunkedTokenDatabase(kvblock.DefaultTokenProcessorConfig())
+	tokenProcessor, err := kvblock.NewChunkedTokenDatabase(getTokenProcessorConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/examples/kv_events/online/main.go
+++ b/examples/kv_events/online/main.go
@@ -157,7 +157,7 @@ func getTokenProcessorConfig() *kvblock.TokenProcessorConfig {
 
 	blockSize, err := strconv.Atoi(os.Getenv(blockSizeEnvVar))
 	if err == nil && blockSize >= 0 {
-		config.BlockSize = blockSize
+		config.BlockSizeTokens = blockSize
 	}
 	return config
 }

--- a/examples/valkey_example/main.go
+++ b/examples/valkey_example/main.go
@@ -117,7 +117,7 @@ func createValkeyConfig() (*kvcache.Config, error) {
 func createTokenProcessorConfig() *kvblock.TokenProcessorConfig {
 	// Set a reasonable block size for demonstration
 	return &kvblock.TokenProcessorConfig{
-		BlockSize: 128,
+		BlockSizeTokens: 128,
 	}
 }
 

--- a/pkg/kvcache/kvblock/extra_keys_test.go
+++ b/pkg/kvcache/kvblock/extra_keys_test.go
@@ -184,7 +184,7 @@ func TestComputeBlockExtraFeatures_TextOnlyBlocksBetweenImages(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestMMFeatures_DifferentImagesProduceDifferentHashes(t *testing.T) {
-	config := &kvblock.TokenProcessorConfig{BlockSize: 16, HashSeed: "test"}
+	config := &kvblock.TokenProcessorConfig{BlockSizeTokens: 16, HashSeed: "test"}
 	processor, err := kvblock.NewChunkedTokenDatabase(config)
 	require.NoError(t, err)
 
@@ -211,7 +211,7 @@ func TestMMFeatures_DifferentImagesProduceDifferentHashes(t *testing.T) {
 }
 
 func TestMMFeatures_NilFeaturesSameAsTextOnly(t *testing.T) {
-	config := &kvblock.TokenProcessorConfig{BlockSize: 16, HashSeed: "test"}
+	config := &kvblock.TokenProcessorConfig{BlockSizeTokens: 16, HashSeed: "test"}
 	processor, err := kvblock.NewChunkedTokenDatabase(config)
 	require.NoError(t, err)
 
@@ -234,7 +234,7 @@ func TestMMFeatures_NilFeaturesSameAsTextOnly(t *testing.T) {
 }
 
 func TestMMFeatures_OnlyAffectOverlappingBlocks(t *testing.T) {
-	config := &kvblock.TokenProcessorConfig{BlockSize: 16, HashSeed: "test"}
+	config := &kvblock.TokenProcessorConfig{BlockSizeTokens: 16, HashSeed: "test"}
 	processor, err := kvblock.NewChunkedTokenDatabase(config)
 	require.NoError(t, err)
 
@@ -273,7 +273,7 @@ func TestMMFeatures_OnlyAffectOverlappingBlocks(t *testing.T) {
 }
 
 func TestMMFeatures_MismatchedLengthReturnsError(t *testing.T) {
-	config := &kvblock.TokenProcessorConfig{BlockSize: 16, HashSeed: "test"}
+	config := &kvblock.TokenProcessorConfig{BlockSizeTokens: 16, HashSeed: "test"}
 	processor, err := kvblock.NewChunkedTokenDatabase(config)
 	require.NoError(t, err)
 

--- a/pkg/kvcache/kvblock/token_processor.go
+++ b/pkg/kvcache/kvblock/token_processor.go
@@ -33,7 +33,13 @@ const defaultBlockSize = 16
 
 // TokenProcessorConfig holds the configuration for the token processor.
 type TokenProcessorConfig struct {
-	BlockSize int `json:"blockSize"`
+	// BlockSize is deprecated. Use BlockSizeTokens instead.
+	//
+	// Deprecated: Use BlockSizeTokens instead.
+	BlockSize int `json:"blockSize,omitempty"`
+	// BlockSizeTokens is the number of tokens per block.
+	// This field replaces the deprecated BlockSize field.
+	BlockSizeTokens int `json:"blockSizeTokens"`
 	// HashSeed is used to prefix initial hash chunks, similarly to vLLM's NONE_HASH.
 	// This should be aligned with vLLM's `PYTHONHASHSEED` environment variable.
 	// The system's deployer is responsible for aligning the vLLM deployments
@@ -45,8 +51,8 @@ type TokenProcessorConfig struct {
 // DefaultTokenProcessorConfig returns the default configuration for the token processor.
 func DefaultTokenProcessorConfig() *TokenProcessorConfig {
 	return &TokenProcessorConfig{
-		BlockSize: defaultBlockSize,
-		HashSeed:  "",
+		BlockSizeTokens: defaultBlockSize,
+		HashSeed:        "",
 	}
 }
 
@@ -83,8 +89,13 @@ func NewChunkedTokenDatabase(config *TokenProcessorConfig) (TokenProcessor, erro
 		config = DefaultTokenProcessorConfig()
 	}
 
-	if config.BlockSize <= 0 {
-		return nil, fmt.Errorf("blockSize must be greater than 0, got %d", config.BlockSize)
+	// Handle backward compatibility: if BlockSize is set but BlockSizeTokens is not, use BlockSize
+	if config.BlockSizeTokens == 0 && config.BlockSize > 0 {
+		config.BlockSizeTokens = config.BlockSize
+	}
+
+	if config.BlockSizeTokens <= 0 {
+		return nil, fmt.Errorf("blockSizeTokens must be greater than 0, got %d", config.BlockSizeTokens)
 	}
 
 	if config.initHash == 0 {
@@ -154,12 +165,12 @@ func (db *chunkedTokenDatabase) prefixHashes(
 
 // BlockSize returns the number of tokens per block.
 func (db *chunkedTokenDatabase) BlockSize() int {
-	return db.TokenProcessorConfig.BlockSize
+	return db.BlockSizeTokens
 }
 
 // chunkTokens splits the input slice of tokens into chunks of size blockSize.
 func (db *chunkedTokenDatabase) chunkTokens(tokens []uint32) [][]uint32 {
-	bs := db.TokenProcessorConfig.BlockSize
+	bs := db.BlockSizeTokens
 	var chunks [][]uint32
 	for i := 0; i < len(tokens); i += bs {
 		end := i + bs

--- a/pkg/kvcache/kvblock/token_processor.go
+++ b/pkg/kvcache/kvblock/token_processor.go
@@ -38,7 +38,7 @@ type TokenProcessorConfig struct {
 	// Deprecated: Use BlockSizeTokens instead.
 	BlockSize int `json:"blockSize,omitempty"`
 	// BlockSizeTokens is the number of tokens per block.
-	// This field replaces the deprecated BlockSize field.
+	// A value of zero is treated as "not set" and resolved to the default (16) by NewChunkedTokenDatabase.
 	BlockSizeTokens int `json:"blockSizeTokens"`
 	// HashSeed is used to prefix initial hash chunks, similarly to vLLM's NONE_HASH.
 	// This should be aligned with vLLM's `PYTHONHASHSEED` environment variable.
@@ -85,24 +85,36 @@ var _ TokenProcessor = &chunkedTokenDatabase{}
 
 // NewChunkedTokenDatabase creates a new instance with the given config and metadata.
 func NewChunkedTokenDatabase(config *TokenProcessorConfig) (TokenProcessor, error) {
+	var cfg TokenProcessorConfig
 	if config == nil {
-		config = DefaultTokenProcessorConfig()
+		cfg = *DefaultTokenProcessorConfig()
+	} else {
+		cfg = *config // local copy — caller's struct is never mutated
 	}
 
-	// Handle backward compatibility: if BlockSize is set but BlockSizeTokens is not, use BlockSize
-	if config.BlockSizeTokens == 0 && config.BlockSize > 0 {
-		config.BlockSizeTokens = config.BlockSize
+	// Apply defaults for omitted fields so partial configs (e.g. only hashSeed set) work correctly.
+	if cfg.BlockSizeTokens == 0 && cfg.BlockSize == 0 {
+		cfg.BlockSizeTokens = defaultBlockSize
 	}
 
-	if config.BlockSizeTokens <= 0 {
-		return nil, fmt.Errorf("blockSizeTokens must be greater than 0, got %d", config.BlockSizeTokens)
+	// Handle backward compatibility: if only deprecated BlockSize is set, promote it.
+	if cfg.BlockSizeTokens == 0 && cfg.BlockSize > 0 {
+		cfg.BlockSizeTokens = cfg.BlockSize
 	}
 
-	if config.initHash == 0 {
-		// Create initial hash
+	if cfg.BlockSizeTokens <= 0 {
+		// Report the actual invalid value the caller set, not the zero from the other field.
+		invalidBlockSize := cfg.BlockSizeTokens
+		if cfg.BlockSizeTokens == 0 && cfg.BlockSize != 0 {
+			invalidBlockSize = cfg.BlockSize
+		}
+		return nil, fmt.Errorf("blockSizeTokens must be greater than 0, got %d", invalidBlockSize)
+	}
+
+	if cfg.initHash == 0 {
 		h := fnv.New64a()
-		_, _ = h.Write([]byte(config.HashSeed))
-		config.initHash = h.Sum64()
+		_, _ = h.Write([]byte(cfg.HashSeed))
+		cfg.initHash = h.Sum64()
 	}
 
 	encoder, err := cbor.CanonicalEncOptions().EncMode()
@@ -111,7 +123,7 @@ func NewChunkedTokenDatabase(config *TokenProcessorConfig) (TokenProcessor, erro
 	}
 
 	return &chunkedTokenDatabase{
-		TokenProcessorConfig: *config,
+		TokenProcessorConfig: cfg,
 		encoder:              encoder,
 	}, nil
 }
@@ -204,8 +216,8 @@ func (db *chunkedTokenDatabase) TokensToKVBlockKeys(
 	if extraFeatures == nil {
 		extraFeatures = make([]*BlockExtraFeatures, len(chunks))
 	} else if len(extraFeatures) != len(chunks) {
-		return nil, fmt.Errorf("extraFeatures length %d does not match token chunk count %d (blockSize=%d, tokens=%d)",
-			len(extraFeatures), len(chunks), db.TokenProcessorConfig.BlockSize, len(tokens))
+		return nil, fmt.Errorf("extraFeatures length %d does not match token chunk count %d (blockSizeTokens=%d, tokens=%d)",
+			len(extraFeatures), len(chunks), db.BlockSizeTokens, len(tokens))
 	}
 
 	ph := db.prefixHashes(currentParentHash, chunks, extraFeatures)

--- a/pkg/kvcache/kvblock/token_processor_test.go
+++ b/pkg/kvcache/kvblock/token_processor_test.go
@@ -35,20 +35,30 @@ func TestNewChunkedTokenDatabase_Validation(t *testing.T) {
 		errSubstr string
 	}{
 		{
-			name:      "BlockSize zero returns error",
-			config:    &kvblock.TokenProcessorConfig{BlockSize: 0},
+			name:      "BlockSizeTokens zero returns error",
+			config:    &kvblock.TokenProcessorConfig{BlockSizeTokens: 0},
 			wantErr:   true,
-			errSubstr: "blockSize must be greater than 0, got 0",
+			errSubstr: "blockSizeTokens must be greater than 0, got 0",
 		},
 		{
-			name:      "BlockSize negative returns error",
-			config:    &kvblock.TokenProcessorConfig{BlockSize: -1},
+			name:      "BlockSizeTokens negative returns error",
+			config:    &kvblock.TokenProcessorConfig{BlockSizeTokens: -1},
 			wantErr:   true,
-			errSubstr: "blockSize must be greater than 0, got -1",
+			errSubstr: "blockSizeTokens must be greater than 0, got -1",
 		},
 		{
-			name:    "BlockSize positive succeeds",
+			name:    "BlockSizeTokens positive succeeds",
+			config:  &kvblock.TokenProcessorConfig{BlockSizeTokens: 16},
+			wantErr: false,
+		},
+		{
+			name:    "Backward compatibility: BlockSize still works",
 			config:  &kvblock.TokenProcessorConfig{BlockSize: 16},
+			wantErr: false,
+		},
+		{
+			name:    "BlockSizeTokens takes precedence when both are set",
+			config:  &kvblock.TokenProcessorConfig{BlockSize: 8, BlockSizeTokens: 16},
 			wantErr: false,
 		},
 		{
@@ -73,10 +83,37 @@ func TestNewChunkedTokenDatabase_Validation(t *testing.T) {
 	}
 }
 
+func TestBlockSizeTokensPrecedence(t *testing.T) {
+	// Test that BlockSizeTokens takes precedence over BlockSize when both are set
+	config := &kvblock.TokenProcessorConfig{
+		BlockSize:       8,  // deprecated field
+		BlockSizeTokens: 16, // new field should take precedence
+		HashSeed:        "test",
+	}
+
+	processor, err := kvblock.NewChunkedTokenDatabase(config)
+	require.NoError(t, err)
+	require.NotNil(t, processor)
+
+	// Create tokens that would create different number of blocks depending on block size
+	// With BlockSize=8: 32 tokens = 4 blocks
+	// With BlockSizeTokens=16: 32 tokens = 2 blocks
+	tokens := make([]uint32, 32)
+	for i := range tokens {
+		tokens[i] = uint32(i + 1)
+	}
+
+	keys, err := processor.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "test-model", nil)
+	require.NoError(t, err)
+
+	// Should create 2 blocks (32/16) not 4 blocks (32/8)
+	assert.Len(t, keys, 2, "Should use BlockSizeTokens=16, creating 2 blocks from 32 tokens")
+}
+
 func TestGetInitHash_ConsistentHashesForSameModel(t *testing.T) {
 	config := &kvblock.TokenProcessorConfig{
-		BlockSize: 16,
-		HashSeed:  "test-seed",
+		BlockSizeTokens: 16,
+		HashSeed:        "test-seed",
 	}
 
 	processor, err := kvblock.NewChunkedTokenDatabase(config)
@@ -105,8 +142,8 @@ func TestGetInitHash_ConsistentHashesForSameModel(t *testing.T) {
 
 func TestGetInitHash_DifferentHashesForDifferentModels(t *testing.T) {
 	config := &kvblock.TokenProcessorConfig{
-		BlockSize: 16,
-		HashSeed:  "test-seed",
+		BlockSizeTokens: 16,
+		HashSeed:        "test-seed",
 	}
 
 	processor, err := kvblock.NewChunkedTokenDatabase(config)
@@ -164,8 +201,8 @@ func TestGetInitHash_DifferentSeedsProduceDifferentHashes(t *testing.T) {
 
 	for _, seed := range seeds {
 		config := &kvblock.TokenProcessorConfig{
-			BlockSize: 16,
-			HashSeed:  seed,
+			BlockSizeTokens: 16,
+			HashSeed:        seed,
 		}
 
 		processor, err := kvblock.NewChunkedTokenDatabase(config)
@@ -191,8 +228,8 @@ func TestGetInitHash_DifferentSeedsProduceDifferentHashes(t *testing.T) {
 
 func TestGetInitHash_ConcurrentAccess(t *testing.T) {
 	config := &kvblock.TokenProcessorConfig{
-		BlockSize: 16,
-		HashSeed:  "test-seed",
+		BlockSizeTokens: 16,
+		HashSeed:        "test-seed",
 	}
 
 	processor, err := kvblock.NewChunkedTokenDatabase(config)
@@ -249,8 +286,8 @@ func TestGetInitHash_Deterministic(t *testing.T) {
 	// Create multiple instances with same config
 	for i := 0; i < 5; i++ {
 		config := &kvblock.TokenProcessorConfig{
-			BlockSize: 16,
-			HashSeed:  seed,
+			BlockSizeTokens: 16,
+			HashSeed:        seed,
 		}
 
 		processor, err := kvblock.NewChunkedTokenDatabase(config)

--- a/pkg/kvcache/kvblock/token_processor_test.go
+++ b/pkg/kvcache/kvblock/token_processor_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kvblock_test
 
 import (
+	"encoding/json"
 	"sync"
 	"testing"
 
@@ -35,10 +36,9 @@ func TestNewChunkedTokenDatabase_Validation(t *testing.T) {
 		errSubstr string
 	}{
 		{
-			name:      "BlockSizeTokens zero returns error",
-			config:    &kvblock.TokenProcessorConfig{BlockSizeTokens: 0},
-			wantErr:   true,
-			errSubstr: "blockSizeTokens must be greater than 0, got 0",
+			name:    "BlockSizeTokens zero uses default",
+			config:  &kvblock.TokenProcessorConfig{BlockSizeTokens: 0},
+			wantErr: false,
 		},
 		{
 			name:      "BlockSizeTokens negative returns error",
@@ -66,6 +66,12 @@ func TestNewChunkedTokenDatabase_Validation(t *testing.T) {
 			config:  nil,
 			wantErr: false,
 		},
+		{
+			name:      "deprecated BlockSize negative reports actual value in error",
+			config:    &kvblock.TokenProcessorConfig{BlockSize: -5},
+			wantErr:   true,
+			errSubstr: "blockSizeTokens must be greater than 0, got -5",
+		},
 	}
 
 	for _, tc := range tests {
@@ -81,6 +87,161 @@ func TestNewChunkedTokenDatabase_Validation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTokenProcessorConfig_JSONUnmarshal(t *testing.T) {
+	tests := []struct {
+		name            string
+		json            string
+		wantBlockSize   int
+		wantBlockTokens int
+		wantErr         bool
+	}{
+		{
+			name:            "blockSizeTokens field is decoded",
+			json:            `{"blockSizeTokens": 32}`,
+			wantBlockTokens: 32,
+		},
+		{
+			name:          "legacy blockSize field is decoded",
+			json:          `{"blockSize": 8}`,
+			wantBlockSize: 8,
+		},
+		{
+			name:            "both fields present",
+			json:            `{"blockSize": 8, "blockSizeTokens": 32}`,
+			wantBlockSize:   8,
+			wantBlockTokens: 32,
+		},
+		{
+			name:            "hashSeed decoded alongside blockSizeTokens",
+			json:            `{"blockSizeTokens": 16, "hashSeed": "abc"}`,
+			wantBlockTokens: 16,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var cfg kvblock.TokenProcessorConfig
+			err := json.Unmarshal([]byte(tc.json), &cfg)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantBlockSize, cfg.BlockSize, "BlockSize mismatch")
+			assert.Equal(t, tc.wantBlockTokens, cfg.BlockSizeTokens, "BlockSizeTokens mismatch")
+		})
+	}
+}
+
+func TestTokenProcessorConfig_JSONUnmarshal_EndToEnd(t *testing.T) {
+	// Verify that a config decoded from JSON produces a working processor with the correct block size.
+	tests := []struct {
+		name           string
+		json           string
+		tokens         int
+		wantBlockCount int
+	}{
+		{
+			name:           "blockSizeTokens drives chunking",
+			json:           `{"blockSizeTokens": 8}`,
+			tokens:         32,
+			wantBlockCount: 4, // 32 / 8
+		},
+		{
+			name:           "legacy blockSize drives chunking via compat path",
+			json:           `{"blockSize": 16}`,
+			tokens:         32,
+			wantBlockCount: 2, // 32 / 16
+		},
+		{
+			name:           "partial config with only hashSeed uses default block size of 16",
+			json:           `{"hashSeed": "test"}`,
+			tokens:         32,
+			wantBlockCount: 2, // 32 / 16 (default)
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var cfg kvblock.TokenProcessorConfig
+			require.NoError(t, json.Unmarshal([]byte(tc.json), &cfg))
+
+			processor, err := kvblock.NewChunkedTokenDatabase(&cfg)
+			require.NoError(t, err)
+
+			tokens := make([]uint32, tc.tokens)
+			for i := range tokens {
+				tokens[i] = uint32(i + 1) // #nosec G115 -- test data, i is small
+			}
+			keys, err := processor.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "test-model", nil)
+			require.NoError(t, err)
+			assert.Len(t, keys, tc.wantBlockCount)
+		})
+	}
+}
+
+func TestTokenProcessorConfig_JSONMarshal(t *testing.T) {
+	// Verify field names in the serialized output so a tag rename is caught in both directions.
+	tests := []struct {
+		name            string
+		cfg             kvblock.TokenProcessorConfig
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name:            "blockSizeTokens appears in output",
+			cfg:             kvblock.TokenProcessorConfig{BlockSizeTokens: 32},
+			wantContains:    []string{`"blockSizeTokens":32`},
+			wantNotContains: []string{`"blockSize"`}, // omitempty — absent when zero
+		},
+		{
+			name:            "deprecated blockSize appears when non-zero",
+			cfg:             kvblock.TokenProcessorConfig{BlockSize: 8, BlockSizeTokens: 16},
+			wantContains:    []string{`"blockSize":8`, `"blockSizeTokens":16`},
+			wantNotContains: nil,
+		},
+		{
+			name:            "blockSize omitted when zero",
+			cfg:             kvblock.TokenProcessorConfig{BlockSizeTokens: 16},
+			wantContains:    []string{`"blockSizeTokens":16`},
+			wantNotContains: []string{`"blockSize"`},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.cfg)
+			require.NoError(t, err)
+			out := string(b)
+			for _, want := range tc.wantContains {
+				assert.Contains(t, out, want)
+			}
+			for _, notWant := range tc.wantNotContains {
+				assert.NotContains(t, out, notWant)
+			}
+		})
+	}
+}
+
+func TestTokenProcessorConfig_JSONRoundTrip(t *testing.T) {
+	// Marshal then unmarshal; the recovered struct must equal the original.
+	original := kvblock.TokenProcessorConfig{
+		BlockSize:       8,
+		BlockSizeTokens: 32,
+		HashSeed:        "round-trip-seed",
+	}
+
+	b, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var recovered kvblock.TokenProcessorConfig
+	require.NoError(t, json.Unmarshal(b, &recovered))
+
+	assert.Equal(t, original.BlockSize, recovered.BlockSize)
+	assert.Equal(t, original.BlockSizeTokens, recovered.BlockSizeTokens)
+	assert.Equal(t, original.HashSeed, recovered.HashSeed)
 }
 
 func TestBlockSizeTokensPrecedence(t *testing.T) {
@@ -100,7 +261,7 @@ func TestBlockSizeTokensPrecedence(t *testing.T) {
 	// With BlockSizeTokens=16: 32 tokens = 2 blocks
 	tokens := make([]uint32, 32)
 	for i := range tokens {
-		tokens[i] = uint32(i + 1)
+		tokens[i] = uint32(i + 1) // #nosec G115 -- test data, i is small
 	}
 
 	keys, err := processor.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "test-model", nil)
@@ -108,6 +269,42 @@ func TestBlockSizeTokensPrecedence(t *testing.T) {
 
 	// Should create 2 blocks (32/16) not 4 blocks (32/8)
 	assert.Len(t, keys, 2, "Should use BlockSizeTokens=16, creating 2 blocks from 32 tokens")
+}
+
+func TestNewChunkedTokenDatabase_DoesNotMutateCallerConfig(t *testing.T) {
+	config := &kvblock.TokenProcessorConfig{
+		BlockSize: 16, // deprecated; BlockSizeTokens intentionally left zero
+		HashSeed:  "test",
+	}
+
+	_, err := kvblock.NewChunkedTokenDatabase(config)
+	require.NoError(t, err)
+
+	assert.Zero(t, config.BlockSizeTokens, "NewChunkedTokenDatabase must not populate BlockSizeTokens on caller's struct")
+}
+
+func TestBackwardCompatibility_BlockSize(t *testing.T) {
+	// Test that setting only the deprecated BlockSize field still works correctly.
+	config := &kvblock.TokenProcessorConfig{
+		BlockSize: 8, // deprecated field, BlockSizeTokens not set
+		HashSeed:  "test",
+	}
+
+	processor, err := kvblock.NewChunkedTokenDatabase(config)
+	require.NoError(t, err)
+	require.NotNil(t, processor)
+
+	// 32 tokens / blockSize=8 → 4 blocks
+	tokens := make([]uint32, 32)
+	for i := range tokens {
+		tokens[i] = uint32(i + 1) // #nosec G115 -- test data, i is small
+	}
+
+	keys, err := processor.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "test-model", nil)
+	require.NoError(t, err)
+
+	assert.Len(t, keys, 4, "BlockSize=8 should produce 4 blocks from 32 tokens")
+	assert.Equal(t, 8, processor.BlockSize(), "BlockSize() should report 8")
 }
 
 func TestGetInitHash_ConsistentHashesForSameModel(t *testing.T) {

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // newTestPool creates a Pool with real InMemoryIndex and
-// ChunkedTokenDatabase. blockSize is the canonical block size used by the
+// ChunkedTokenDatabase. blockSize (blockSizeTokens) is the canonical block size used by the
 // TokenProcessor; engine block sizes are derived per-event from the ratio of
 // tokens to engine keys.
 func newTestPool(t *testing.T, blockSize int) (
@@ -24,8 +24,8 @@ func newTestPool(t *testing.T, blockSize int) (
 	require.NoError(t, err)
 
 	tp, err := kvblock.NewChunkedTokenDatabase(&kvblock.TokenProcessorConfig{
-		BlockSize: blockSize,
-		HashSeed:  "test",
+		BlockSizeTokens: blockSize,
+		HashSeed:        "test",
 	})
 	require.NoError(t, err)
 

--- a/tests/e2e/uds_tokenizer/uds_e2e_mm_test.go
+++ b/tests/e2e/uds_tokenizer/uds_e2e_mm_test.go
@@ -119,17 +119,17 @@ func (s *UDSTokenizerSuite) TestMM_BlockFeatureAssignmentMatchesPlaceholders() {
 
 	blockFeatures := kvblock.ComputeBlockExtraFeatures(
 		result.Features.MMHashes, result.Features.MMPlaceholders,
-		s.tokenProcessorConfig.BlockSize, len(result.Tokens),
+		s.tokenProcessorConfig.BlockSizeTokens, len(result.Tokens),
 	)
 
-	numBlocks := len(result.Tokens) / s.tokenProcessorConfig.BlockSize
+	numBlocks := len(result.Tokens) / s.tokenProcessorConfig.BlockSizeTokens
 	s.Require().Len(blockFeatures, numBlocks)
 
 	for mod, ranges := range result.Features.MMPlaceholders {
 		for _, r := range ranges {
 			for bi := 0; bi < numBlocks; bi++ {
-				blockStart := bi * s.tokenProcessorConfig.BlockSize
-				blockEnd := blockStart + s.tokenProcessorConfig.BlockSize
+				blockStart := bi * s.tokenProcessorConfig.BlockSizeTokens
+				blockEnd := blockStart + s.tokenProcessorConfig.BlockSizeTokens
 				overlaps := r.Offset < blockEnd && (r.Offset+r.Length) > blockStart
 				hasFeat := blockFeatures[bi] != nil
 
@@ -164,10 +164,10 @@ func (s *UDSTokenizerSuite) TestMM_Determinism() {
 	// Block keys must match.
 	bf1 := kvblock.ComputeBlockExtraFeatures(
 		r1.Features.MMHashes, r1.Features.MMPlaceholders,
-		s.tokenProcessorConfig.BlockSize, len(r1.Tokens))
+		s.tokenProcessorConfig.BlockSizeTokens, len(r1.Tokens))
 	bf2 := kvblock.ComputeBlockExtraFeatures(
 		r2.Features.MMHashes, r2.Features.MMPlaceholders,
-		s.tokenProcessorConfig.BlockSize, len(r2.Tokens))
+		s.tokenProcessorConfig.BlockSizeTokens, len(r2.Tokens))
 
 	keys1, err := s.tokenProcessor.TokensToKVBlockKeys(kvblock.EmptyBlockHash, r1.Tokens, mmModelName, bf1)
 	s.Require().NoError(err)
@@ -200,10 +200,10 @@ func (s *UDSTokenizerSuite) TestMM_DifferentImagesProduceDifferentKeys() {
 
 	bfA := kvblock.ComputeBlockExtraFeatures(
 		rA.Features.MMHashes, rA.Features.MMPlaceholders,
-		s.tokenProcessorConfig.BlockSize, len(rA.Tokens))
+		s.tokenProcessorConfig.BlockSizeTokens, len(rA.Tokens))
 	bfB := kvblock.ComputeBlockExtraFeatures(
 		rB.Features.MMHashes, rB.Features.MMPlaceholders,
-		s.tokenProcessorConfig.BlockSize, len(rB.Tokens))
+		s.tokenProcessorConfig.BlockSizeTokens, len(rB.Tokens))
 
 	keysA, err := s.tokenProcessor.TokensToKVBlockKeys(kvblock.EmptyBlockHash, rA.Tokens, mmModelName, bfA)
 	s.Require().NoError(err)
@@ -236,7 +236,7 @@ func (s *UDSTokenizerSuite) TestMM_TextBlocksBeforeImageUnaffected() {
 
 	blockFeatures := kvblock.ComputeBlockExtraFeatures(
 		result.Features.MMHashes, result.Features.MMPlaceholders,
-		s.tokenProcessorConfig.BlockSize, len(result.Tokens),
+		s.tokenProcessorConfig.BlockSizeTokens, len(result.Tokens),
 	)
 
 	keysWithMM, err := s.tokenProcessor.TokensToKVBlockKeys(
@@ -277,7 +277,7 @@ func (s *UDSTokenizerSuite) TestMM_IndexLookupRoundTrip() {
 
 	blockFeatures := kvblock.ComputeBlockExtraFeatures(
 		result.Features.MMHashes, result.Features.MMPlaceholders,
-		s.tokenProcessorConfig.BlockSize, len(result.Tokens),
+		s.tokenProcessorConfig.BlockSizeTokens, len(result.Tokens),
 	)
 
 	// Compute request-path keys (what the indexer would compute from a new request).
@@ -318,7 +318,7 @@ func (s *UDSTokenizerSuite) TestMM_IndexLookupRoundTrip() {
 
 	bfB := kvblock.ComputeBlockExtraFeatures(
 		resultB.Features.MMHashes, resultB.Features.MMPlaceholders,
-		s.tokenProcessorConfig.BlockSize, len(resultB.Tokens))
+		s.tokenProcessorConfig.BlockSizeTokens, len(resultB.Tokens))
 	keysB, err := s.tokenProcessor.TokensToKVBlockKeys(
 		kvblock.EmptyBlockHash, resultB.Tokens, mmModelName, bfB)
 	s.Require().NoError(err)
@@ -513,7 +513,7 @@ func (s *UDSTokenizerSuite) TestGoldenMM_BlockKeys() {
 
 	blockFeatures := kvblock.ComputeBlockExtraFeatures(
 		result.Features.MMHashes, result.Features.MMPlaceholders,
-		s.tokenProcessorConfig.BlockSize, len(result.Tokens),
+		s.tokenProcessorConfig.BlockSizeTokens, len(result.Tokens),
 	)
 
 	requestKeys, err := s.tokenProcessor.TokensToKVBlockKeys(
@@ -544,7 +544,7 @@ func (s *UDSTokenizerSuite) TestGoldenMM_Scoring() {
 
 	blockFeatures := kvblock.ComputeBlockExtraFeatures(
 		result.Features.MMHashes, result.Features.MMPlaceholders,
-		s.tokenProcessorConfig.BlockSize, len(result.Tokens),
+		s.tokenProcessorConfig.BlockSizeTokens, len(result.Tokens),
 	)
 
 	requestKeys, err := s.tokenProcessor.TokensToKVBlockKeys(

--- a/tests/e2e/uds_tokenizer/uds_e2e_suite_test.go
+++ b/tests/e2e/uds_tokenizer/uds_e2e_suite_test.go
@@ -118,7 +118,7 @@ func (s *UDSTokenizerSuite) SetupTest() {
 	s.config.TokenizersPoolConfig = tokenizerPoolConfig
 
 	s.tokenProcessorConfig = kvblock.DefaultTokenProcessorConfig()
-	s.tokenProcessorConfig.BlockSize = 4
+	s.tokenProcessorConfig.BlockSizeTokens = 4
 	s.tokenProcessor, err = kvblock.NewChunkedTokenDatabase(s.tokenProcessorConfig)
 	s.Require().NoError(err)
 


### PR DESCRIPTION
Based on the issue https://github.com/llm-d/llm-d-inference-scheduler/issues/747 and the community discussion, this PR replaces `BlockSize` in `TokenProcessorConfig` with `BlockSizeTokens`. 

This change will prevent users from being misled in the llm-d EPP configuration. 


**A side fix(examples)**: 
events pool token processor ignores `BLOCK_SIZE` and `PYTHONHASHSEED` env vars

Description:

In `examples/kv_events/online/main.go`, `setupEventsPool` was constructing its token processor using `kvblock.DefaultTokenProcessorConfig()` directly, bypassing the `getTokenProcessorConfig()` helper. As a result, the `BLOCK_SIZE` and `PYTHONHASHSEED` environment variables were silently ignored for the events pool processor, while `setupKVCacheIndexer` (in the same process) correctly read them via `getTokenProcessorConfig()`.

This meant the two processors in the same process could end up with different block sizes and/or hash seeds, causing hash mismatches between events-side block keys and indexer-side block keys.

Fix: Replace `kvblock.DefaultTokenProcessorConfig()` with `getTokenProcessorConfig()` in `setupEventsPool`, consistent with how `setupKVCacheIndexer `already worked.