### PR TITLE
build(fs_backend): produce manylinux_2_35 wheels for cu12 + cu130

### DIFF
--- a/.github/workflows/ci-wheels.yaml
+++ b/.github/workflows/ci-wheels.yaml
@@ -22,10 +22,10 @@ jobs:
             os: ubuntu-24.04
           - arch: arm64
             os: ubuntu-24.04-arm
-          # cu12 uses Dockerfile defaults (CUDA 12.9.1 / cu129 / no local version).
-          # cu130 overrides only what differs:
+          # cu12 uses Dockerfile defaults (CUDA 12.8.1 Ubuntu 22.04 / cu128 /
+          # no local version). cu130 overrides only what differs:
           - variant: cu130
-            cuda_version: "13.0.0"
+            cuda_base_tag: "13.0.0-devel-ubuntu22.04"
             torch_cuda_index: "cu130"
             wheel_local_version: "+cu130"
 
@@ -47,7 +47,7 @@ jobs:
             --build-arg torch_cuda_arch_list='8.7 8.9 9.0 10.0+PTX'
             --build-arg max_jobs=4
           )
-          [[ -n "${{ matrix.cuda_version }}" ]]        && BUILD_ARGS+=(--build-arg "CUDA_VERSION=${{ matrix.cuda_version }}")
+          [[ -n "${{ matrix.cuda_base_tag }}" ]]       && BUILD_ARGS+=(--build-arg "CUDA_BASE_TAG=${{ matrix.cuda_base_tag }}")
           [[ -n "${{ matrix.torch_cuda_index }}" ]]    && BUILD_ARGS+=(--build-arg "TORCH_CUDA_INDEX=${{ matrix.torch_cuda_index }}")
           [[ -n "${{ matrix.wheel_local_version }}" ]] && BUILD_ARGS+=(--build-arg "WHEEL_LOCAL_VERSION=${{ matrix.wheel_local_version }}")
 

--- a/kv_connectors/llmd_fs_backend/Dockerfile.wheel
+++ b/kv_connectors/llmd_fs_backend/Dockerfile.wheel
@@ -1,38 +1,37 @@
 # syntax=docker/dockerfile:1
 
-ARG CUDA_VERSION=12.9.1
-FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04 AS build
+# Ubuntu 22.04 (glibc 2.35) = manylinux_2_35 baseline; multi-arch; mirrors
+# vLLM's published wheel naming. No PPA / no api.launchpad.net dependency
+# because Python is installed via uv (hermetic standalone interpreter).
+ARG CUDA_BASE_TAG=12.8.1-devel-ubuntu22.04
+FROM nvcr.io/nvidia/cuda:${CUDA_BASE_TAG} AS build
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG max_jobs=16
 ARG torch_cuda_arch_list="8.7 8.9 9.0 10.0+PTX"
 ARG TORCH_VERSION=2.10.0
-ARG TORCH_CUDA_INDEX=cu129
+ARG TORCH_CUDA_INDEX=cu128
 ARG WHEEL_LOCAL_VERSION=
+ARG PYTHON_VERSION=3.12
 
-# System deps
+# System build deps — all from jammy main (no PPA). patchelf is needed by
+# auditwheel.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      software-properties-common \
-      curl \
-      git \
-      ca-certificates \
-      build-essential \
-      ninja-build \
-      libnuma-dev && \
-    add-apt-repository -y ppa:deadsnakes/ppa && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-      python3.12 \
-      python3.12-dev && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+      curl ca-certificates git \
+      build-essential ninja-build \
+      libnuma-dev \
+      patchelf \
+      xz-utils \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# pip for Python 3.12
-RUN curl -sSL https://bootstrap.pypa.io/get-pip.py | python3.12
-
-# Make python/python3 point to 3.12
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3.12 1
+# Install Python via uv (hermetic standalone interpreter, multi-arch).
+# --seed installs pip+setuptools into the venv so `python -m pip` works.
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    /root/.local/bin/uv python install ${PYTHON_VERSION} && \
+    /root/.local/bin/uv venv /opt/venv --python ${PYTHON_VERSION} --seed
+ENV PATH=/opt/venv/bin:/root/.local/bin:${PATH}
+ENV VIRTUAL_ENV=/opt/venv
 
 # CUDA env (must be set for torch.utils.cpp_extension)
 ENV CUDA_HOME=/usr/local/cuda
@@ -43,8 +42,8 @@ ENV MAX_JOBS=${max_jobs}
 # Enable -static-libstdc++ for the redistributable wheel (read by setup.py).
 ENV FS_PORTABLE_WHEEL=1
 
-# Python build deps
-RUN python -m pip install --upgrade pip setuptools wheel ninja numpy
+# Python build deps + auditwheel.
+RUN python -m pip install --upgrade pip setuptools wheel ninja numpy auditwheel
 
 # Install torch (CUDA index + version controlled by build args).
 RUN python -m pip install --no-cache-dir \
@@ -68,7 +67,25 @@ RUN echo "CUDA_HOME=$CUDA_HOME" && \
     which nvcc && nvcc --version && \
     python -c "import os; print('CUDA_HOME=', os.environ.get('CUDA_HOME')); import torch; print('torch cuda=', torch.version.cuda)"
 
-# Build wheel
-RUN rm -rf build dist *.egg-info wheels && \
-    mkdir -p dist && \
-    python setup.py bdist_wheel -d dist
+# Build wheel (cp312-cp312; cp38-abi3 isn't viable — torch's bundled
+# pybind11 uses non-stable-API macros like PyTuple_SET_ITEM).
+RUN rm -rf build dist-raw dist *.egg-info && \
+    mkdir -p dist-raw dist && \
+    python setup.py bdist_wheel -d dist-raw
+
+# auditwheel: stamp manylinux_2_35_<arch> (matches vLLM) and bundle small
+# non-system deps. torch + CUDA libs excluded — they come from the user's
+# torch install; bundling would bloat the wheel and conflict at runtime.
+RUN auditwheel show dist-raw/*.whl && \
+    auditwheel repair \
+      --plat manylinux_2_35_$(uname -m) \
+      --only-plat \
+      --exclude 'libtorch*.so*' \
+      --exclude 'libc10*.so*' \
+      --exclude 'libcuda*.so*' \
+      --exclude 'libcublas*.so*' \
+      --exclude 'libcublasLt*.so*' \
+      --exclude 'libcufile*.so*' \
+      --exclude 'libnvToolsExt*.so*' \
+      -w dist dist-raw/*.whl && \
+    ls -lh dist/


### PR DESCRIPTION
## Summary
- Switch wheel base to NVIDIA's Ubuntu 22.04 CUDA images (12.8.1 / 13.0.0,
  multi-arch) with Python 3.12 installed via `uv`. Removes the
  api.launchpad.net + deadsnakes PPA dependency that's been intermittently
  breaking CI with HTTP 504s.
- Add `auditwheel repair --plat manylinux_2_35_<arch> --only-plat` so wheels
  are stamped as proper `manylinux_2_35` wheels (was `linux_<arch>` before
  — pip deprioritizes plain-linux tags). Matches vLLM's published cu130 /
  cpu wheel naming exactly.
- cu12 variant: CUDA 12.9 → 12.8 (strictly more permissive at runtime,
  forward-compat drivers).

cp38-abi3 (vLLM-style stable ABI) isn't viable while bindings use torch's
bundled pybind11 (`PyTuple_SET_ITEM` is non-stable-API). Aligning would
require a CMake build with non-torch pybind11 — separate effort.

## Test plan
- [x] CI builds wheels for all 4 variants (amd64/arm64 × cu128/cu130)
- [x] Resulting wheel name:
      `llmd_fs_connector-0.19[+cu130]-cp312-cp312-manylinux_2_35_<arch>.whl`
- [x] `pip install 'llmd-fs-connector==0.19' --extra-index-url
      https://llm-d.github.io/llm-d-kv-cache/simple/` installs and imports
      cleanly on `vllm/vllm-openai:v0.19.1`. Same install with
      `simple/cu130/` works on the cu130 variant.