### PR TITLE
feat: Emit storage KV events from the fs backend

### DIFF
--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
@@ -93,12 +93,12 @@ class StorageEventPublisher:
             return
 
         event = [
-            "BlockStored",       # [0] tag
-            hashes,              # [1] block_hashes (all hashes from this complete_store call)
-            0,                   # [2] parent_hash (unknown at storage tier)
-            [],                  # [3] token_ids (empty)
-            0,                   # [4] block_size (unused)
-            None,                # [5] lora_id
+            "BlockStored",  # [0] tag
+            hashes,  # [1] block_hashes (all hashes from this complete_store call)
+            0,  # [2] parent_hash (unknown at storage tier)
+            [],  # [3] token_ids (empty)
+            0,  # [4] block_size (unused)
+            None,  # [5] lora_id
             self._medium.value,  # [6] medium / device tier
         ]
         self._send_batch([msgpack.packb(event, use_bin_type=True)])
@@ -113,9 +113,7 @@ class StorageEventPublisher:
             if self._closed:
                 return
 
-            payload = msgpack.packb(
-                [time.time(), packed_events], use_bin_type=True
-            )
+            payload = msgpack.packb([time.time(), packed_events], use_bin_type=True)
             self._seq += 1
             self._socket.send_multipart(
                 [

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
@@ -25,6 +25,7 @@ import zmq
 logger = logging.getLogger(__name__)
 
 _UINT64_MASK = (1 << 64) - 1
+DEFAULT_STORAGE_EVENTS_HWM = 100_000  # vLLM's default
 
 
 class StorageMedium(enum.Enum):
@@ -54,6 +55,7 @@ class StorageEventPublisher:
         self,
         endpoint: str,
         model_name: str,
+        sndhwm: int = DEFAULT_STORAGE_EVENTS_HWM,
         medium: StorageMedium = StorageMedium.SHARED_STORAGE,
     ) -> None:
         """Bind a ZMQ PUB socket on *endpoint* and configure the topic prefix.
@@ -62,11 +64,12 @@ class StorageEventPublisher:
             endpoint: ZMQ bind address (e.g. ``tcp://*:5559``).
             model_name: Model identifier included in the topic string.
             medium: Storage backend type embedded in the topic and each event.
+            sndhwm: ZMQ send high-water mark.
         """
         self._ctx = zmq.Context()
         self._socket = self._ctx.socket(zmq.PUB)
         self._socket.setsockopt(zmq.LINGER, 0)
-        self._socket.setsockopt(zmq.SNDHWM, 1000)
+        self._socket.setsockopt(zmq.SNDHWM, sndhwm)
         self._socket.bind(endpoint)
 
         self._model_name = model_name

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
@@ -1,0 +1,109 @@
+# Copyright 2026 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import struct
+import threading
+import time
+from collections.abc import Iterable
+
+import msgpack
+import zmq
+
+logger = logging.getLogger(__name__)
+
+_UINT64_MASK = (1 << 64) - 1
+
+
+def _hash_to_uint64(block_hash: int | bytes) -> int:
+    """Mask each hash to lower 64 bits, matching the FileMapper."""
+    if isinstance(block_hash, bytes):
+        return int.from_bytes(block_hash, "big") & _UINT64_MASK
+    return int(block_hash) & _UINT64_MASK
+
+
+class StorageEventPublisher:
+    """Publishes storage-tier KV cache events via ZMQ PUB socket.
+
+    Events use the same msgpack positional-array format as vLLM's GPU
+    KV events so the Go vLLMAdapter can parse them without modification.
+    ZMQ messages use the 3-frame format expected by zmq_subscriber.go:
+    [topic, sequence, payload].
+    """
+
+    def __init__(
+        self, endpoint: str, model_name: str, source_id: str = "SHARED_STORAGE"
+    ):
+        self._ctx = zmq.Context()
+        self._socket = self._ctx.socket(zmq.PUB)
+        self._socket.setsockopt(zmq.LINGER, 0)
+        self._socket.setsockopt(zmq.SNDHWM, 1000)
+        self._socket.bind(endpoint)
+
+        self._model_name = model_name
+        self._source_id = source_id
+        self._topic = f"kv@{self._source_id}@{self._model_name}"
+        self._seq: int = 0
+        self._closed = False
+        self._send_lock = threading.Lock()
+        logger.info(
+            "StorageEventPublisher bound to %s (topic: %s)",
+            endpoint,
+            self._topic,
+        )
+
+    def publish_blocks_stored(self, block_hashes: Iterable[int | bytes]) -> None:
+        hashes = [_hash_to_uint64(h) for h in block_hashes]
+        if not hashes:
+            return
+
+        events: list[bytes] = []
+        for h in hashes:
+            event = [
+                "BlockStored",  # [0] tag
+                [h],  # [1] block_hashes (one per file)
+                0,  # [2] parent_hash (unused)
+                [],  # [3] token_ids (empty)
+                0,  # [4] block_size (unused)
+                None,  # [5] lora_id
+                "SHARED_STORAGE",  # [6] medium / device tier
+            ]
+            events.append(msgpack.packb(event, use_bin_type=True))
+
+        self._send_batch(events)
+
+    def _send_batch(self, packed_events: list[bytes]) -> None:
+        batch = [time.time(), packed_events]
+        payload = msgpack.packb(batch, use_bin_type=True)
+
+        with self._send_lock:
+            if self._closed:
+                return
+
+            self._seq += 1
+            self._socket.send_multipart(
+                [
+                    self._topic.encode("utf-8"),
+                    struct.pack(">Q", self._seq),
+                    payload,
+                ]
+            )
+
+    def close(self) -> None:
+        with self._send_lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._socket.close()
+            self._ctx.term()

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
@@ -92,20 +92,16 @@ class StorageEventPublisher:
         if not hashes:
             return
 
-        events: list[bytes] = []
-        for h in hashes:
-            event = [
-                "BlockStored",  # [0] tag
-                [h],  # [1] block_hashes (one per file)
-                0,  # [2] parent_hash (unused)
-                [],  # [3] token_ids (empty)
-                0,  # [4] block_size (unused)
-                None,  # [5] lora_id
-                self._medium.value,  # [6] medium / device tier
-            ]
-            events.append(msgpack.packb(event, use_bin_type=True))
-
-        self._send_batch(events)
+        event = [
+            "BlockStored",       # [0] tag
+            hashes,              # [1] block_hashes (all hashes from this complete_store call)
+            0,                   # [2] parent_hash (unknown at storage tier)
+            [],                  # [3] token_ids (empty)
+            0,                   # [4] block_size (unused)
+            None,                # [5] lora_id
+            self._medium.value,  # [6] medium / device tier
+        ]
+        self._send_batch([msgpack.packb(event, use_bin_type=True)])
 
     def _send_batch(self, packed_events: list[bytes]) -> None:
         """Send a batch of pre-packed events as a 3-frame ZMQ message.
@@ -113,13 +109,13 @@ class StorageEventPublisher:
         Frames: ``[topic, sequence, payload]``.  Thread-safe; silently
         drops the message if the publisher has been closed.
         """
-        batch = [time.time(), packed_events]
-        payload = msgpack.packb(batch, use_bin_type=True)
-
         with self._send_lock:
             if self._closed:
                 return
 
+            payload = msgpack.packb(
+                [time.time(), packed_events], use_bin_type=True
+            )
             self._seq += 1
             self._socket.send_multipart(
                 [

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import enum
 import logging
 import struct
 import threading
@@ -26,8 +27,15 @@ logger = logging.getLogger(__name__)
 _UINT64_MASK = (1 << 64) - 1
 
 
+class StorageMedium(enum.Enum):
+    """Storage backend types used as the device-tier label in events."""
+
+    SHARED_STORAGE = "SHARED_STORAGE"
+    OBJECT_STORE = "OBJECT_STORE"
+
+
 def _hash_to_uint64(block_hash: int | bytes) -> int:
-    """Mask each hash to lower 64 bits, matching the FileMapper."""
+    """Mask a block hash to its lower 64 bits to match the FileMapper truncation."""
     if isinstance(block_hash, bytes):
         return int.from_bytes(block_hash, "big") & _UINT64_MASK
     return int(block_hash) & _UINT64_MASK
@@ -43,8 +51,18 @@ class StorageEventPublisher:
     """
 
     def __init__(
-        self, endpoint: str, model_name: str, source_id: str = "SHARED_STORAGE"
-    ):
+        self,
+        endpoint: str,
+        model_name: str,
+        medium: StorageMedium = StorageMedium.SHARED_STORAGE,
+    ) -> None:
+        """Bind a ZMQ PUB socket on *endpoint* and configure the topic prefix.
+
+        Args:
+            endpoint: ZMQ bind address (e.g. ``tcp://*:5559``).
+            model_name: Model identifier included in the topic string.
+            medium: Storage backend type embedded in the topic and each event.
+        """
         self._ctx = zmq.Context()
         self._socket = self._ctx.socket(zmq.PUB)
         self._socket.setsockopt(zmq.LINGER, 0)
@@ -52,8 +70,8 @@ class StorageEventPublisher:
         self._socket.bind(endpoint)
 
         self._model_name = model_name
-        self._source_id = source_id
-        self._topic = f"kv@{self._source_id}@{self._model_name}"
+        self._medium = medium
+        self._topic = f"kv@{self._medium.value}@{self._model_name}"
         self._seq: int = 0
         self._closed = False
         self._send_lock = threading.Lock()
@@ -64,6 +82,12 @@ class StorageEventPublisher:
         )
 
     def publish_blocks_stored(self, block_hashes: Iterable[int | bytes]) -> None:
+        """Publish a ``BlockStored`` event for each hash in *block_hashes*.
+
+        Each hash is masked to 64 bits and wrapped in a positional-array event
+        matching vLLM's GPU ``BlockStored`` wire format.  All events are batched
+        into a single ZMQ multipart message.
+        """
         hashes = [_hash_to_uint64(h) for h in block_hashes]
         if not hashes:
             return
@@ -77,13 +101,18 @@ class StorageEventPublisher:
                 [],  # [3] token_ids (empty)
                 0,  # [4] block_size (unused)
                 None,  # [5] lora_id
-                "SHARED_STORAGE",  # [6] medium / device tier
+                self._medium.value,  # [6] medium / device tier
             ]
             events.append(msgpack.packb(event, use_bin_type=True))
 
         self._send_batch(events)
 
     def _send_batch(self, packed_events: list[bytes]) -> None:
+        """Send a batch of pre-packed events as a 3-frame ZMQ message.
+
+        Frames: ``[topic, sequence, payload]``.  Thread-safe; silently
+        drops the message if the publisher has been closed.
+        """
         batch = [time.time(), packed_events]
         payload = msgpack.packb(batch, use_bin_type=True)
 
@@ -101,6 +130,7 @@ class StorageEventPublisher:
             )
 
     def close(self) -> None:
+        """Close the ZMQ socket and terminate the context. Idempotent."""
         with self._send_lock:
             if self._closed:
                 return

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/file_mapper.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/file_mapper.py
@@ -72,6 +72,7 @@ class FileMapper:
             "kv_cache_groups": kv_cache_groups or [],
             "inference_engine": inference_engine,
         }
+        self.model_name: str = model_name
         self.base_path: str = self._compute_base_path(root_dir, self.fields)
 
     @classmethod

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
@@ -35,9 +35,55 @@ class SharedStorageOffloadingManager(OffloadingManager):
     SharedStorageOffloadingManager manages KV offloading to a shared storage medium.
     """
 
-    def __init__(self, file_mapper: FileMapper, event_publisher=None) -> None:
+    def __init__(
+        self,
+        file_mapper: FileMapper,
+        model_name: str = "",
+        extra_config: dict | None = None,
+        event_publisher=None,
+    ) -> None:
         self.file_mapper: FileMapper = file_mapper
-        self._event_publisher = event_publisher
+        self._event_publisher = (
+            event_publisher
+            if event_publisher is not None
+            else self._create_event_publisher(model_name, extra_config or {})
+        )
+
+    @staticmethod
+    def _create_event_publisher(model_name: str, extra_config: dict):
+        """Create a StorageEventPublisher if events are enabled in *extra_config*."""
+        if not extra_config.get("enable_events", False):
+            return None
+
+        endpoint = extra_config.get("storage_events_endpoint")
+        if not endpoint:
+            return None
+
+        try:
+            from llmd_fs_backend.event_publisher import (
+                StorageEventPublisher,
+                StorageMedium,
+            )
+
+            backend = extra_config.get("backend", "POSIX")
+            medium = (
+                StorageMedium.OBJECT_STORE
+                if backend == "OBJ"
+                else StorageMedium.SHARED_STORAGE
+            )
+
+            return StorageEventPublisher(
+                endpoint=endpoint,
+                model_name=model_name,
+                medium=medium,
+            )
+        except Exception:
+            logger.warning(
+                "failed to create storage event publisher for %s",
+                endpoint,
+                exc_info=True,
+            )
+            return None
 
     def _publish_blocks_stored(self, block_hashes: Iterable[BlockHash]) -> None:
         if self._event_publisher is None:

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
@@ -159,3 +159,7 @@ class SharedStorageOffloadingManager(OffloadingManager):
         """
         if success:
             self._publish_blocks_stored(block_hashes)
+
+    def shutdown(self) -> None:
+        if self._event_publisher is not None:
+            self._event_publisher.close()

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
@@ -23,6 +23,7 @@ from vllm.v1.kv_offload.base import (
     PrepareStoreOutput,
     ReqContext,
 )
+from zmq import ZMQError
 
 from llmd_fs_backend.event_publisher import StorageMedium
 from llmd_fs_backend.file_mapper import FileMapper
@@ -39,7 +40,6 @@ class SharedStorageOffloadingManager(OffloadingManager):
     def __init__(
         self,
         file_mapper: FileMapper,
-        model_name: str = "",
         extra_config: dict | None = None,
         event_publisher=None,
     ) -> None:
@@ -47,7 +47,9 @@ class SharedStorageOffloadingManager(OffloadingManager):
         self._event_publisher = (
             event_publisher
             if event_publisher is not None
-            else self._create_event_publisher(model_name, extra_config or {})
+            else self._create_event_publisher(
+                self.file_mapper.model_name, extra_config or {}
+            )
         )
 
     @staticmethod
@@ -60,8 +62,11 @@ class SharedStorageOffloadingManager(OffloadingManager):
         if not endpoint:
             return None
 
-        medium_str = extra_config.get("storage_medium", "SHARED_STORAGE")
-        medium = StorageMedium(medium_str)
+        kwargs = {}
+        if "storage_medium" in extra_config:
+            kwargs["medium"] = StorageMedium(extra_config["storage_medium"])
+        if "storage_events_hwm" in extra_config:
+            kwargs["sndhwm"] = int(extra_config["storage_events_hwm"])
 
         try:
             from llmd_fs_backend.event_publisher import StorageEventPublisher
@@ -69,9 +74,9 @@ class SharedStorageOffloadingManager(OffloadingManager):
             return StorageEventPublisher(
                 endpoint=endpoint,
                 model_name=model_name,
-                medium=medium,
+                **kwargs,
             )
-        except Exception:
+        except ZMQError:
             logger.warning(
                 "failed to create storage event publisher for %s",
                 endpoint,

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
@@ -24,6 +24,7 @@ from vllm.v1.kv_offload.base import (
     ReqContext,
 )
 
+from llmd_fs_backend.event_publisher import StorageMedium
 from llmd_fs_backend.file_mapper import FileMapper
 from llmd_fs_backend.mediums import SharedStorageLoadStoreSpec
 
@@ -59,18 +60,11 @@ class SharedStorageOffloadingManager(OffloadingManager):
         if not endpoint:
             return None
 
-        try:
-            from llmd_fs_backend.event_publisher import (
-                StorageEventPublisher,
-                StorageMedium,
-            )
+        medium_str = extra_config.get("storage_medium", "SHARED_STORAGE")
+        medium = StorageMedium(medium_str)
 
-            backend = extra_config.get("backend", "POSIX")
-            medium = (
-                StorageMedium.OBJECT_STORE
-                if backend == "OBJ"
-                else StorageMedium.SHARED_STORAGE
-            )
+        try:
+            from llmd_fs_backend.event_publisher import StorageEventPublisher
 
             return StorageEventPublisher(
                 endpoint=endpoint,

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
@@ -35,8 +35,17 @@ class SharedStorageOffloadingManager(OffloadingManager):
     SharedStorageOffloadingManager manages KV offloading to a shared storage medium.
     """
 
-    def __init__(self, file_mapper: FileMapper) -> None:
+    def __init__(self, file_mapper: FileMapper, event_publisher=None) -> None:
         self.file_mapper: FileMapper = file_mapper
+        self._event_publisher = event_publisher
+
+    def _publish_blocks_stored(self, block_hashes: Iterable[BlockHash]) -> None:
+        if self._event_publisher is None:
+            return
+        try:
+            self._event_publisher.publish_blocks_stored(block_hashes)
+        except Exception:
+            logger.warning("failed to publish storage event", exc_info=True)
 
     # ----------------------------------------------------------------------
     # Lookup
@@ -100,6 +109,7 @@ class SharedStorageOffloadingManager(OffloadingManager):
         success: bool = True,
     ):
         """
-        For shared storage, storing is stateless - no action needed.
+        For shared storage, storing is stateless but we emit events for stored blocks.
         """
-        pass
+        if success:
+            self._publish_blocks_stored(block_hashes)

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
@@ -84,7 +84,7 @@ class SharedStorageOffloadingManager(OffloadingManager):
             )
             return None
 
-    def _publish_blocks_stored(self, block_hashes: Iterable[BlockHash]) -> None:
+    def _publish_blocks_stored(self, block_hashes: Collection[OffloadKey]) -> None:
         if self._event_publisher is None:
             return
         try:
@@ -157,7 +157,7 @@ class SharedStorageOffloadingManager(OffloadingManager):
         For shared storage, storing is stateless but we emit events for stored blocks.
         """
         if success:
-            self._publish_blocks_stored(block_hashes)
+            self._publish_blocks_stored(keys)
 
     def shutdown(self) -> None:
         if self._event_publisher is not None:

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from collections.abc import Iterator
 
 from vllm.config import VllmConfig
@@ -37,6 +39,7 @@ from llmd_fs_backend.worker import (
 )
 
 DEFAULT_STORAGE_BLOCK_SIZE = 256
+logger = logging.getLogger(__name__)
 
 
 class SharedStorageOffloadingSpec(OffloadingSpec):
@@ -102,9 +105,33 @@ class SharedStorageOffloadingSpec(OffloadingSpec):
         )
         self.file_mapper.write_run_config()
 
+        self._storage_events_endpoint = self.extra_config.get(
+            "storage_events_endpoint", None
+        )
+
+    def _create_event_publisher(self):
+        if not self._storage_events_endpoint:
+            return None
+
+        try:
+            from llmd_fs_backend.event_publisher import StorageEventPublisher
+
+            return StorageEventPublisher(
+                endpoint=self._storage_events_endpoint,
+                model_name=self.vllm_config.model_config.model,
+            )
+        except Exception:
+            logger.warning(
+                "failed to create storage event publisher for %s",
+                self._storage_events_endpoint,
+                exc_info=True,
+            )
+            return None
+
     def get_manager(self) -> OffloadingManager:
         assert self.vllm_config.parallel_config.rank == 0, "Scheduler rank should be 0"
         if not self._manager:
+            event_publisher = self._create_event_publisher()
             backend = self.extra_config.get("backend", "POSIX")
             if backend == "OBJ":
                 from llmd_nixl.manager import NixlStorageOffloadingManager
@@ -112,10 +139,12 @@ class SharedStorageOffloadingSpec(OffloadingSpec):
                 self._manager = NixlStorageOffloadingManager(
                     file_mapper=self.file_mapper,
                     extra_config=self.extra_config,
+                    event_publisher=event_publisher,
                 )
             else:
                 self._manager = SharedStorageOffloadingManager(
                     file_mapper=self.file_mapper,
+                    event_publisher=event_publisher,
                 )
         return self._manager
 

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
@@ -104,46 +104,24 @@ class SharedStorageOffloadingSpec(OffloadingSpec):
         )
         self.file_mapper.write_run_config()
 
-        self._storage_events_endpoint = self.extra_config.get(
-            "storage_events_endpoint", None
-        )
-
-    def _create_event_publisher(self):
-        if not self._storage_events_endpoint:
-            return None
-
-        try:
-            from llmd_fs_backend.event_publisher import StorageEventPublisher
-
-            return StorageEventPublisher(
-                endpoint=self._storage_events_endpoint,
-                model_name=self.vllm_config.model_config.model,
-            )
-        except Exception:
-            logger.warning(
-                "failed to create storage event publisher for %s",
-                self._storage_events_endpoint,
-                exc_info=True,
-            )
-            return None
-
     def get_manager(self) -> OffloadingManager:
         assert self.vllm_config.parallel_config.rank == 0, "Scheduler rank should be 0"
         if not self._manager:
-            event_publisher = self._create_event_publisher()
+            model_name = self.vllm_config.model_config.model
             backend = self.extra_config.get("backend", "POSIX")
             if backend == "OBJ":
                 from llmd_nixl.manager import NixlStorageOffloadingManager
 
                 self._manager = NixlStorageOffloadingManager(
                     file_mapper=self.file_mapper,
+                    model_name=model_name,
                     extra_config=self.extra_config,
-                    event_publisher=event_publisher,
                 )
             else:
                 self._manager = SharedStorageOffloadingManager(
                     file_mapper=self.file_mapper,
-                    event_publisher=event_publisher,
+                    model_name=model_name,
+                    extra_config=self.extra_config,
                 )
         return self._manager
 

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from collections.abc import Iterator
 
 from vllm.config import VllmConfig
@@ -38,7 +37,6 @@ from llmd_fs_backend.worker import (
 )
 
 DEFAULT_STORAGE_BLOCK_SIZE = 256
-logger = logging.getLogger(__name__)
 
 
 class SharedStorageOffloadingSpec(OffloadingSpec):
@@ -107,20 +105,21 @@ class SharedStorageOffloadingSpec(OffloadingSpec):
     def get_manager(self) -> OffloadingManager:
         assert self.vllm_config.parallel_config.rank == 0, "Scheduler rank should be 0"
         if not self._manager:
-            model_name = self.vllm_config.model_config.model
             backend = self.extra_config.get("backend", "POSIX")
             if backend == "OBJ":
                 from llmd_nixl.manager import NixlStorageOffloadingManager
 
+                self.extra_config.setdefault("storage_medium", "OBJECT_STORE")
                 self._manager = NixlStorageOffloadingManager(
                     file_mapper=self.file_mapper,
-                    model_name=model_name,
+                    model_name=self.file_mapper.model_name,
                     extra_config=self.extra_config,
                 )
             else:
+                self.extra_config.setdefault("storage_medium", "SHARED_STORAGE")
                 self._manager = SharedStorageOffloadingManager(
                     file_mapper=self.file_mapper,
-                    model_name=model_name,
+                    model_name=self.file_mapper.model_name,
                     extra_config=self.extra_config,
                 )
         return self._manager

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
@@ -112,14 +112,12 @@ class SharedStorageOffloadingSpec(OffloadingSpec):
                 self.extra_config.setdefault("storage_medium", "OBJECT_STORE")
                 self._manager = NixlStorageOffloadingManager(
                     file_mapper=self.file_mapper,
-                    model_name=self.file_mapper.model_name,
                     extra_config=self.extra_config,
                 )
             else:
                 self.extra_config.setdefault("storage_medium", "SHARED_STORAGE")
                 self._manager = SharedStorageOffloadingManager(
                     file_mapper=self.file_mapper,
-                    model_name=self.file_mapper.model_name,
                     extra_config=self.extra_config,
                 )
         return self._manager

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-
 from collections.abc import Iterator
 
 from vllm.config import VllmConfig

--- a/kv_connectors/llmd_fs_backend/llmd_nixl/manager.py
+++ b/kv_connectors/llmd_fs_backend/llmd_nixl/manager.py
@@ -38,10 +38,16 @@ class NixlStorageOffloadingManager(SharedStorageOffloadingManager):
     def __init__(
         self,
         file_mapper: FileMapper,
+        model_name: str = "",
         extra_config: dict | None = None,
         event_publisher=None,
     ) -> None:
-        super().__init__(file_mapper, event_publisher=event_publisher)
+        super().__init__(
+            file_mapper,
+            model_name=model_name,
+            extra_config=extra_config,
+            event_publisher=event_publisher,
+        )
         cfg = extra_config or {}
         self.lookup_mode = cfg.get("lookup_mode", LOOKUP_MODE_NIXL_QUERY)
 

--- a/kv_connectors/llmd_fs_backend/llmd_nixl/manager.py
+++ b/kv_connectors/llmd_fs_backend/llmd_nixl/manager.py
@@ -41,12 +41,13 @@ class NixlStorageOffloadingManager(SharedStorageOffloadingManager):
         extra_config: dict | None = None,
         event_publisher=None,
     ) -> None:
-        super().__init__(file_mapper)
+        super().__init__(file_mapperi,event_publisher=event_publisher)
         cfg = extra_config or {}
         self.lookup_mode = cfg.get("lookup_mode", LOOKUP_MODE_NIXL_QUERY)
 
         self._stored_keys: set[str] = set()
         self._nixl_lookup = None
+
 
         if self.lookup_mode == LOOKUP_MODE_NIXL_QUERY:
             self._nixl_lookup = NixlLookup(cfg)
@@ -66,6 +67,8 @@ class NixlStorageOffloadingManager(SharedStorageOffloadingManager):
         req_context: ReqContext,
         success: bool = True,
     ) -> None:
+        block_hashes = list(block_hashes)
+
         if success:
             self._publish_blocks_stored(block_hashes)
 

--- a/kv_connectors/llmd_fs_backend/llmd_nixl/manager.py
+++ b/kv_connectors/llmd_fs_backend/llmd_nixl/manager.py
@@ -38,13 +38,11 @@ class NixlStorageOffloadingManager(SharedStorageOffloadingManager):
     def __init__(
         self,
         file_mapper: FileMapper,
-        model_name: str = "",
         extra_config: dict | None = None,
         event_publisher=None,
     ) -> None:
         super().__init__(
             file_mapper,
-            model_name=model_name,
             extra_config=extra_config,
             event_publisher=event_publisher,
         )

--- a/kv_connectors/llmd_fs_backend/llmd_nixl/manager.py
+++ b/kv_connectors/llmd_fs_backend/llmd_nixl/manager.py
@@ -41,13 +41,12 @@ class NixlStorageOffloadingManager(SharedStorageOffloadingManager):
         extra_config: dict | None = None,
         event_publisher=None,
     ) -> None:
-        super().__init__(file_mapperi,event_publisher=event_publisher)
+        super().__init__(file_mapper, event_publisher=event_publisher)
         cfg = extra_config or {}
         self.lookup_mode = cfg.get("lookup_mode", LOOKUP_MODE_NIXL_QUERY)
 
         self._stored_keys: set[str] = set()
         self._nixl_lookup = None
-
 
         if self.lookup_mode == LOOKUP_MODE_NIXL_QUERY:
             self._nixl_lookup = NixlLookup(cfg)

--- a/kv_connectors/llmd_fs_backend/llmd_nixl/manager.py
+++ b/kv_connectors/llmd_fs_backend/llmd_nixl/manager.py
@@ -70,10 +70,10 @@ class NixlStorageOffloadingManager(SharedStorageOffloadingManager):
         req_context: ReqContext,
         success: bool = True,
     ) -> None:
-        block_hashes = list(block_hashes)
+        keys = list(keys)
 
         if success:
-            self._publish_blocks_stored(block_hashes)
+            self._publish_blocks_stored(keys)
 
         if not success or self.lookup_mode != LOOKUP_MODE_DICT:
             return

--- a/kv_connectors/llmd_fs_backend/llmd_nixl/manager.py
+++ b/kv_connectors/llmd_fs_backend/llmd_nixl/manager.py
@@ -36,7 +36,10 @@ class NixlStorageOffloadingManager(SharedStorageOffloadingManager):
     """
 
     def __init__(
-        self, file_mapper: FileMapper, extra_config: dict | None = None
+        self,
+        file_mapper: FileMapper,
+        extra_config: dict | None = None,
+        event_publisher=None,
     ) -> None:
         super().__init__(file_mapper)
         cfg = extra_config or {}
@@ -63,6 +66,9 @@ class NixlStorageOffloadingManager(SharedStorageOffloadingManager):
         req_context: ReqContext,
         success: bool = True,
     ) -> None:
+        if success:
+            self._publish_blocks_stored(block_hashes)
+
         if not success or self.lookup_mode != LOOKUP_MODE_DICT:
             return
         for key in keys:

--- a/kv_connectors/llmd_fs_backend/pyproject.toml
+++ b/kv_connectors/llmd_fs_backend/pyproject.toml
@@ -22,6 +22,8 @@ requires-python = ">=3.12"
 dependencies = [
     "torch==2.11.0",
     "nixl",
+    "msgpack",
+    "pyzmq",
 ]
 
 [tool.setuptools]

--- a/kv_connectors/llmd_fs_backend/tests/performance/test_stress.py
+++ b/kv_connectors/llmd_fs_backend/tests/performance/test_stress.py
@@ -132,6 +132,8 @@ def run_stress_test(
     threads_per_gpu: int = 24,
     with_gpu_prefix_cache: bool = False,
     storage_type: str = "fs",
+    enable_events: bool = False,
+    storage_events_endpoint: str = "tcp://*:5559",
 ) -> tuple[float, float, float, float, float, float]:
     """
     Run a hot/cold-ratio sweep stress test (see module docstring).
@@ -173,6 +175,8 @@ def run_stress_test(
         cpu_block_size=cpu_block_size,
         threads_per_gpu=threads_per_gpu,
         storage_type=storage_type,
+        enable_events=enable_events,
+        storage_events_endpoint=storage_events_endpoint,
     )
 
     llm = LLM(
@@ -458,6 +462,17 @@ if __name__ == "__main__":
         choices=LOG_LEVELS,
         help=f"Set STORAGE_LOG_LEVEL for storage tier (one of {LOG_LEVELS})",
     )
+    parser.add_argument(
+        "--enable-events",
+        action="store_true",
+        help="Enable ZMQ storage event emission (for A/B perf comparison)",
+    )
+    parser.add_argument(
+        "--storage-events-endpoint",
+        type=str,
+        default="tcp://*:5559",
+        help="ZMQ PUB endpoint for storage events (default: tcp://*:5559)",
+    )
     args = parser.parse_args()
 
     hot_ratios = [float(x.strip()) for x in args.hot_ratios.split(",") if x.strip()]
@@ -484,6 +499,8 @@ if __name__ == "__main__":
             threads_per_gpu=args.threads_per_gpu,
             with_gpu_prefix_cache=args.with_gpu_prefix_cache,
             storage_type=args.storage_type,
+            enable_events=args.enable_events,
+            storage_events_endpoint=args.storage_events_endpoint,
         )
     finally:
         cleanup_storage_dir(args.storage_path)

--- a/kv_connectors/llmd_fs_backend/tests/performance/test_throughput.py
+++ b/kv_connectors/llmd_fs_backend/tests/performance/test_throughput.py
@@ -72,6 +72,8 @@ def run_throughput_test(
     threads_per_gpu: int = 24,
     with_gpu_prefix_cache: bool = False,
     storage_type: str = "fs",
+    enable_events: bool = False,
+    storage_events_endpoint: str = "tcp://*:5559",
 ) -> tuple[float, float, float, float, float]:
     """
     Run sustained throughput test: cold -> hot -> steady-state.
@@ -93,6 +95,8 @@ def run_throughput_test(
         cpu_block_size=cpu_block_size,
         threads_per_gpu=threads_per_gpu,
         storage_type=storage_type,
+        enable_events=enable_events,
+        storage_events_endpoint=storage_events_endpoint,
     )
 
     llm = LLM(
@@ -310,6 +314,17 @@ if __name__ == "__main__":
         choices=LOG_LEVELS,
         help=f"Set STORAGE_LOG_LEVEL for storage tier (one of {LOG_LEVELS})",
     )
+    parser.add_argument(
+        "--enable-events",
+        action="store_true",
+        help="Enable ZMQ storage event emission (for A/B perf comparison)",
+    )
+    parser.add_argument(
+        "--storage-events-endpoint",
+        type=str,
+        default="tcp://*:5559",
+        help="ZMQ PUB endpoint for storage events (default: tcp://*:5559)",
+    )
     args = parser.parse_args()
 
     try:
@@ -328,6 +343,8 @@ if __name__ == "__main__":
             threads_per_gpu=args.threads_per_gpu,
             with_gpu_prefix_cache=args.with_gpu_prefix_cache,
             storage_type=args.storage_type,
+            enable_events=args.enable_events,
+            storage_events_endpoint=args.storage_events_endpoint,
         )
     finally:
         cleanup_storage_dir(args.storage_path)

--- a/kv_connectors/llmd_fs_backend/tests/performance/utils.py
+++ b/kv_connectors/llmd_fs_backend/tests/performance/utils.py
@@ -97,6 +97,8 @@ def get_kv_transfer_config(
     threads_per_gpu: int = 24,
     max_staging_memory_gb: int = 150,
     storage_type: str = "fs",
+    enable_events: bool = False,
+    storage_events_endpoint: str = "tcp://*:5559",
 ) -> KVTransferConfig | None:
     """
     Build a KVTransferConfig for the specified backend.
@@ -116,6 +118,8 @@ def get_kv_transfer_config(
         max_staging_memory_gb: Max CPU staging buffer for the storage tier.
         storage_type: Storage implementation flavor — "fs" (default, CPU
             staging) or "gds" (full read/write GPUDirect Storage).
+        enable_events: Enable ZMQ event emission for storage events.
+        storage_events_endpoint: ZMQ PUB endpoint for storage events.
 
     Returns:
         A KVTransferConfig, or None if backend is "base" or "gpu".
@@ -129,6 +133,13 @@ def get_kv_transfer_config(
         return None
 
     gds_mode = "read_write" if storage_type == "gds" else "disabled"
+
+    event_config = {}
+    if enable_events:
+        event_config = {
+            "enable_events": True,
+            "storage_events_endpoint": storage_events_endpoint,
+        }
 
     if backend == "storage":
         if storage_path is None:
@@ -145,6 +156,7 @@ def get_kv_transfer_config(
                 "max_staging_memory_gb": max_staging_memory_gb,
                 "gds_mode": gds_mode,
                 "read_preferring_ratio": 0.75,
+                **event_config,
             },
         )
 
@@ -185,6 +197,7 @@ def get_kv_transfer_config(
                             "block_size": storage_block_size,
                             "max_staging_memory_gb": max_staging_memory_gb,
                             "gds_mode": gds_mode,
+                            **event_config,
                         },
                     },
                 ],

--- a/kv_connectors/llmd_fs_backend/tests/test_storage_events.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_storage_events.py
@@ -213,17 +213,22 @@ def _publisher_with_fake_zmq(monkeypatch):
     ctx = FakeZMQContext()
     monkeypatch.setattr(event_publisher_module.zmq, "Context", lambda: ctx)
 
-    publisher = StorageEventPublisher("tcp://*:5559", "test-model")
+    publisher = StorageEventPublisher("tcp://*:5559", "test-model", 100_000)
     return publisher, ctx
 
 
 def test_hash_to_uint64_matches_file_mapper_lower_64_bits():
+    """Verify _hash_to_uint64 masks ints to lower 64 bits
+    and converts bytes big-endian."""
     assert _hash_to_uint64(1) == 1
     assert _hash_to_uint64((1 << 72) + 5) == 5
     assert _hash_to_uint64(b"\x01\x02") == 0x0102
 
 
 def test_storage_event_publisher_emits_go_compatible_three_frame_message(monkeypatch):
+    """Verify publish_blocks_stored produces the 3-frame ZMQ
+    message (topic, sequence, payload) with msgpack events
+    matching the Go VLLMAdapter positional array format."""
     publisher, ctx = _publisher_with_fake_zmq(monkeypatch)
 
     publisher.publish_blocks_stored([0xABCDEF0123456789, (1 << 72) + 7, b"\x01\x02"])
@@ -254,6 +259,8 @@ def test_storage_event_publisher_emits_go_compatible_three_frame_message(monkeyp
 
 
 def test_storage_event_publisher_sequence_and_close_are_idempotent(monkeypatch):
+    """Verify sequence numbers are monotonically increasing,
+    close() is idempotent, and no sends occur after close."""
     publisher, ctx = _publisher_with_fake_zmq(monkeypatch)
 
     publisher.publish_blocks_stored([1])
@@ -275,6 +282,8 @@ def test_storage_event_publisher_sequence_and_close_are_idempotent(monkeypatch):
 
 
 def test_shared_storage_manager_publishes_successful_stores_only():
+    """Verify complete_store publishes events only when
+    success=True and skips on failure."""
     publisher = RecordingPublisher()
     manager = SharedStorageOffloadingManager(
         FakeFileMapper(), event_publisher=publisher
@@ -287,6 +296,8 @@ def test_shared_storage_manager_publishes_successful_stores_only():
 
 
 def test_shared_storage_manager_publish_errors_are_fail_open():
+    """Verify a publisher exception during complete_store
+    is caught and does not propagate."""
     manager = SharedStorageOffloadingManager(
         FakeFileMapper(), event_publisher=ExplodingPublisher()
     )
@@ -295,6 +306,8 @@ def test_shared_storage_manager_publish_errors_are_fail_open():
 
 
 def test_nixl_manager_publishes_and_preserves_dict_lookup_bookkeeping():
+    """Verify NIXL complete_store publishes events and
+    updates _stored_keys for dict lookup mode."""
     publisher = RecordingPublisher()
     manager = NixlStorageOffloadingManager(
         FakeFileMapper(),
@@ -309,6 +322,8 @@ def test_nixl_manager_publishes_and_preserves_dict_lookup_bookkeeping():
 
 
 def test_nixl_manager_does_not_publish_or_record_failed_stores():
+    """Verify NIXL complete_store emits no events and does
+    not update _stored_keys when success=False."""
     publisher = RecordingPublisher()
     manager = NixlStorageOffloadingManager(
         FakeFileMapper(),

--- a/kv_connectors/llmd_fs_backend/tests/test_storage_events.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_storage_events.py
@@ -1,0 +1,321 @@
+# Copyright 2026 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import struct
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+
+import msgpack
+
+CONNECTOR_ROOT = Path(__file__).resolve().parents[1]
+
+
+class PrepareStoreOutput:
+    def __init__(self, block_hashes_to_store, store_spec, block_hashes_evicted):
+        self.block_hashes_to_store = block_hashes_to_store
+        self.store_spec = store_spec
+        self.block_hashes_evicted = block_hashes_evicted
+
+
+class SharedStorageLoadStoreSpec:
+    def __init__(self, block_hashes):
+        self.block_hashes = list(block_hashes)
+
+
+class NixlLookup:
+    def __init__(self, _cfg):
+        pass
+
+    def exists(self, _key):
+        return False
+
+
+@contextmanager
+def temporary_modules(modules):
+    sentinel = object()
+    previous = {name: sys.modules.get(name, sentinel) for name in modules}
+    sys.modules.update(modules)
+    try:
+        yield
+    finally:
+        for name, module in previous.items():
+            if module is sentinel:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+def module(name, **attrs):
+    mod = types.ModuleType(name)
+    for attr_name, value in attrs.items():
+        setattr(mod, attr_name, value)
+    return mod
+
+
+def package(name):
+    mod = module(name)
+    mod.__path__ = []
+    return mod
+
+
+def load_module(name, path):
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def load_storage_event_modules():
+    llmd_fs_backend_pkg = package("llmd_fs_backend")
+    llmd_nixl_pkg = package("llmd_nixl")
+    loaded_names = [
+        "storage_event_publisher_under_test",
+        "llmd_fs_backend.manager",
+        "storage_nixl_manager_under_test",
+    ]
+    sentinel = object()
+    previous_loaded = {name: sys.modules.get(name, sentinel) for name in loaded_names}
+
+    stubs = {
+        "llmd_fs_backend": llmd_fs_backend_pkg,
+        "llmd_fs_backend.file_mapper": module(
+            "llmd_fs_backend.file_mapper", FileMapper=object
+        ),
+        "llmd_fs_backend.mediums": module(
+            "llmd_fs_backend.mediums",
+            SharedStorageLoadStoreSpec=SharedStorageLoadStoreSpec,
+        ),
+        "llmd_nixl": llmd_nixl_pkg,
+        "llmd_nixl.nixl_lookup": module("llmd_nixl.nixl_lookup", NixlLookup=NixlLookup),
+        "vllm": package("vllm"),
+        "vllm.v1": package("vllm.v1"),
+        "vllm.v1.core": package("vllm.v1.core"),
+        "vllm.v1.kv_offload": package("vllm.v1.kv_offload"),
+        "vllm.logger": module(
+            "vllm.logger", init_logger=lambda name: logging.getLogger(name)
+        ),
+        "vllm.v1.core.kv_cache_utils": module(
+            "vllm.v1.core.kv_cache_utils", BlockHash=int
+        ),
+        "vllm.v1.kv_offload.abstract": module(
+            "vllm.v1.kv_offload.abstract",
+            LoadStoreSpec=object,
+            OffloadingManager=object,
+            PrepareStoreOutput=PrepareStoreOutput,
+        ),
+    }
+
+    with temporary_modules(stubs):
+        event_publisher = load_module(
+            "storage_event_publisher_under_test",
+            CONNECTOR_ROOT / "llmd_fs_backend" / "event_publisher.py",
+        )
+        manager = load_module(
+            "llmd_fs_backend.manager",
+            CONNECTOR_ROOT / "llmd_fs_backend" / "manager.py",
+        )
+        nixl_manager = load_module(
+            "storage_nixl_manager_under_test",
+            CONNECTOR_ROOT / "llmd_nixl" / "manager.py",
+        )
+
+    for name, previous in previous_loaded.items():
+        if previous is sentinel:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
+
+    return event_publisher, manager, nixl_manager
+
+
+event_publisher_module, manager_module, nixl_manager_module = (
+    load_storage_event_modules()
+)
+
+StorageEventPublisher = event_publisher_module.StorageEventPublisher
+_hash_to_uint64 = event_publisher_module._hash_to_uint64
+SharedStorageOffloadingManager = manager_module.SharedStorageOffloadingManager
+LOOKUP_MODE_DICT = nixl_manager_module.LOOKUP_MODE_DICT
+NixlStorageOffloadingManager = nixl_manager_module.NixlStorageOffloadingManager
+
+
+class FakeZMQSocket:
+    def __init__(self):
+        self.bound_endpoint = None
+        self.closed = 0
+        self.options = []
+        self.sent = []
+
+    def setsockopt(self, option, value):
+        self.options.append((option, value))
+
+    def bind(self, endpoint):
+        self.bound_endpoint = endpoint
+
+    def send_multipart(self, frames):
+        self.sent.append(frames)
+
+    def close(self):
+        self.closed += 1
+
+
+class FakeZMQContext:
+    def __init__(self):
+        self.socket_instance = FakeZMQSocket()
+        self.socket_types = []
+        self.terminated = 0
+
+    def socket(self, socket_type):
+        self.socket_types.append(socket_type)
+        return self.socket_instance
+
+    def term(self):
+        self.terminated += 1
+
+
+class RecordingPublisher:
+    def __init__(self):
+        self.stored_calls = []
+
+    def publish_blocks_stored(self, block_hashes):
+        self.stored_calls.append(list(block_hashes))
+
+
+class ExplodingPublisher:
+    def publish_blocks_stored(self, _block_hashes):
+        raise RuntimeError("publish failed")
+
+
+class FakeFileMapper:
+    def get_file_name(self, block_hash):
+        return f"file-{block_hash}"
+
+
+def _publisher_with_fake_zmq(monkeypatch):
+    ctx = FakeZMQContext()
+    monkeypatch.setattr(event_publisher_module.zmq, "Context", lambda: ctx)
+
+    publisher = StorageEventPublisher("tcp://*:5559", "test-model")
+    return publisher, ctx
+
+
+def test_hash_to_uint64_matches_file_mapper_lower_64_bits():
+    assert _hash_to_uint64(1) == 1
+    assert _hash_to_uint64((1 << 72) + 5) == 5
+    assert _hash_to_uint64(b"\x01\x02") == 0x0102
+
+
+def test_storage_event_publisher_emits_go_compatible_three_frame_message(monkeypatch):
+    publisher, ctx = _publisher_with_fake_zmq(monkeypatch)
+
+    publisher.publish_blocks_stored([0xABCDEF0123456789, (1 << 72) + 7, b"\x01\x02"])
+
+    assert ctx.socket_instance.bound_endpoint == "tcp://*:5559"
+    assert len(ctx.socket_instance.sent) == 1
+
+    topic, seq, payload = ctx.socket_instance.sent[0]
+    assert topic == b"kv@SHARED_STORAGE@test-model"
+    assert struct.unpack(">Q", seq)[0] == 1
+
+    timestamp, raw_events = msgpack.unpackb(payload, raw=False)
+    assert isinstance(timestamp, float)
+    assert len(raw_events) == 3
+
+    decoded_events = [msgpack.unpackb(raw, raw=False) for raw in raw_events]
+    assert decoded_events[0] == [
+        "BlockStored",
+        [0xABCDEF0123456789],
+        0,
+        [],
+        0,
+        None,
+        "SHARED_STORAGE",
+    ]
+    assert decoded_events[1][1] == [7]
+    assert decoded_events[2][1] == [0x0102]
+
+
+def test_storage_event_publisher_sequence_and_close_are_idempotent(monkeypatch):
+    publisher, ctx = _publisher_with_fake_zmq(monkeypatch)
+
+    publisher.publish_blocks_stored([1])
+    publisher.publish_blocks_stored([2])
+    assert [
+        struct.unpack(">Q", frames[1])[0] for frames in ctx.socket_instance.sent
+    ] == [
+        1,
+        2,
+    ]
+
+    publisher.close()
+    publisher.close()
+    assert ctx.socket_instance.closed == 1
+    assert ctx.terminated == 1
+
+    publisher.publish_blocks_stored([3])
+    assert len(ctx.socket_instance.sent) == 2
+
+
+def test_shared_storage_manager_publishes_successful_stores_only():
+    publisher = RecordingPublisher()
+    manager = SharedStorageOffloadingManager(
+        FakeFileMapper(), event_publisher=publisher
+    )
+
+    manager.complete_store(iter([11, 22]), success=True)
+    manager.complete_store([33], success=False)
+
+    assert publisher.stored_calls == [[11, 22]]
+
+
+def test_shared_storage_manager_publish_errors_are_fail_open():
+    manager = SharedStorageOffloadingManager(
+        FakeFileMapper(), event_publisher=ExplodingPublisher()
+    )
+
+    manager.complete_store([11], success=True)
+
+
+def test_nixl_manager_publishes_and_preserves_dict_lookup_bookkeeping():
+    publisher = RecordingPublisher()
+    manager = NixlStorageOffloadingManager(
+        FakeFileMapper(),
+        extra_config={"lookup_mode": LOOKUP_MODE_DICT},
+        event_publisher=publisher,
+    )
+
+    manager.complete_store(iter([11, 22]), success=True)
+
+    assert publisher.stored_calls == [[11, 22]]
+    assert manager._stored_keys == {"file-11", "file-22"}
+
+
+def test_nixl_manager_does_not_publish_or_record_failed_stores():
+    publisher = RecordingPublisher()
+    manager = NixlStorageOffloadingManager(
+        FakeFileMapper(),
+        extra_config={"lookup_mode": LOOKUP_MODE_DICT},
+        event_publisher=publisher,
+    )
+
+    manager.complete_store([11], success=False)
+
+    assert publisher.stored_calls == []
+    assert manager._stored_keys == set()

--- a/kv_connectors/llmd_fs_backend/tests/test_storage_events.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_storage_events.py
@@ -87,6 +87,7 @@ def load_storage_event_modules():
     llmd_nixl_pkg = package("llmd_nixl")
     loaded_names = [
         "storage_event_publisher_under_test",
+        "llmd_fs_backend.event_publisher",
         "llmd_fs_backend.manager",
         "storage_nixl_manager_under_test",
     ]
@@ -106,19 +107,17 @@ def load_storage_event_modules():
         "llmd_nixl.nixl_lookup": module("llmd_nixl.nixl_lookup", NixlLookup=NixlLookup),
         "vllm": package("vllm"),
         "vllm.v1": package("vllm.v1"),
-        "vllm.v1.core": package("vllm.v1.core"),
         "vllm.v1.kv_offload": package("vllm.v1.kv_offload"),
         "vllm.logger": module(
             "vllm.logger", init_logger=lambda name: logging.getLogger(name)
         ),
-        "vllm.v1.core.kv_cache_utils": module(
-            "vllm.v1.core.kv_cache_utils", BlockHash=int
-        ),
-        "vllm.v1.kv_offload.abstract": module(
-            "vllm.v1.kv_offload.abstract",
+        "vllm.v1.kv_offload.base": module(
+            "vllm.v1.kv_offload.base",
             LoadStoreSpec=object,
             OffloadingManager=object,
+            OffloadKey=object,
             PrepareStoreOutput=PrepareStoreOutput,
+            ReqContext=object,
         ),
     }
 
@@ -127,6 +126,7 @@ def load_storage_event_modules():
             "storage_event_publisher_under_test",
             CONNECTOR_ROOT / "llmd_fs_backend" / "event_publisher.py",
         )
+        sys.modules["llmd_fs_backend.event_publisher"] = event_publisher
         manager = load_module(
             "llmd_fs_backend.manager",
             CONNECTOR_ROOT / "llmd_fs_backend" / "manager.py",
@@ -242,20 +242,18 @@ def test_storage_event_publisher_emits_go_compatible_three_frame_message(monkeyp
 
     timestamp, raw_events = msgpack.unpackb(payload, raw=False)
     assert isinstance(timestamp, float)
-    assert len(raw_events) == 3
+    assert len(raw_events) == 1
 
-    decoded_events = [msgpack.unpackb(raw, raw=False) for raw in raw_events]
-    assert decoded_events[0] == [
+    decoded = msgpack.unpackb(raw_events[0], raw=False)
+    assert decoded == [
         "BlockStored",
-        [0xABCDEF0123456789],
+        [0xABCDEF0123456789, 7, 0x0102],
         0,
         [],
         0,
         None,
         "SHARED_STORAGE",
     ]
-    assert decoded_events[1][1] == [7]
-    assert decoded_events[2][1] == [0x0102]
 
 
 def test_storage_event_publisher_sequence_and_close_are_idempotent(monkeypatch):
@@ -289,8 +287,8 @@ def test_shared_storage_manager_publishes_successful_stores_only():
         FakeFileMapper(), event_publisher=publisher
     )
 
-    manager.complete_store(iter([11, 22]), success=True)
-    manager.complete_store([33], success=False)
+    manager.complete_store(iter([11, 22]), None, success=True)
+    manager.complete_store([33], None, success=False)
 
     assert publisher.stored_calls == [[11, 22]]
 
@@ -302,7 +300,7 @@ def test_shared_storage_manager_publish_errors_are_fail_open():
         FakeFileMapper(), event_publisher=ExplodingPublisher()
     )
 
-    manager.complete_store([11], success=True)
+    manager.complete_store([11], None, success=True)
 
 
 def test_nixl_manager_publishes_and_preserves_dict_lookup_bookkeeping():
@@ -315,7 +313,7 @@ def test_nixl_manager_publishes_and_preserves_dict_lookup_bookkeeping():
         event_publisher=publisher,
     )
 
-    manager.complete_store(iter([11, 22]), success=True)
+    manager.complete_store(iter([11, 22]), None, success=True)
 
     assert publisher.stored_calls == [[11, 22]]
     assert manager._stored_keys == {"file-11", "file-22"}
@@ -331,7 +329,7 @@ def test_nixl_manager_does_not_publish_or_record_failed_stores():
         event_publisher=publisher,
     )
 
-    manager.complete_store([11], success=False)
+    manager.complete_store([11], None, success=False)
 
     assert publisher.stored_calls == []
     assert manager._stored_keys == set()

--- a/kv_connectors/llmd_fs_backend/tests/test_storage_events.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_storage_events.py
@@ -150,6 +150,7 @@ event_publisher_module, manager_module, nixl_manager_module = (
 )
 
 StorageEventPublisher = event_publisher_module.StorageEventPublisher
+StorageMedium = event_publisher_module.StorageMedium
 _hash_to_uint64 = event_publisher_module._hash_to_uint64
 SharedStorageOffloadingManager = manager_module.SharedStorageOffloadingManager
 LOOKUP_MODE_DICT = nixl_manager_module.LOOKUP_MODE_DICT


### PR DESCRIPTION
## Summary

This PR adds storage-tier `BlockStored` event emission for the llm-d fs backend as part of the larger storage-aware KV cache indexing effort. When POSIX or OBJ/NIXL storage offload completes successfully, the connector can publish storage events through a ZMQ publisher configured via `storage_events_endpoint`.

The emitted events use the same vLLM KV event transport contract expected by the Go event subscriber: a three-frame ZMQ message containing topic, sequence, and msgpack payload. The event payload follows the existing vLLM positional `BlockStored` shape, uses `SHARED_STORAGE` as the medium/source, and normalizes block hashes to the lower 64 bits to match the fs backend `FileMapper` behavior.

The publisher is fail-open so storage success is not blocked by event publishing errors, and NIXL/OBJ manager wiring is covered so both backend paths emit events consistently.

## Testing

All existing tests pass, and this PR adds focused storage-event unit coverage.

Validated with:

```
pytest kv_connectors/llmd_fs_backend/tests/test_storage_events.py -q
```

## Related Issues

- #520 