### PR TITLE
fs_backend: pin vllm image to cu129 and link simple index

### DIFF
--- a/kv_connectors/llmd_fs_backend/README.md
+++ b/kv_connectors/llmd_fs_backend/README.md
@@ -51,6 +51,8 @@ pip install 'llmd-fs-connector==0.18' \
 
 Or download a wheel manually from the release assets at <https://github.com/llm-d/llm-d-kv-cache/releases>.
 
+A complete list of available releases is published at <https://llm-d.ai/llm-d-kv-cache/simple/llmd-fs-connector/>.
+
 ### 2. Build from source (compile yourself)
 
 Requires CUDA toolkit and system dependencies. 

--- a/kv_connectors/llmd_fs_backend/docs/deployment/vllm-storage.yaml
+++ b/kv_connectors/llmd_fs_backend/docs/deployment/vllm-storage.yaml
@@ -34,7 +34,7 @@ spec:
         fsGroup: 1001060000
       containers:
       - name: vllm
-        image: vllm/vllm-openai:v0.20.2
+        image: vllm/vllm-openai:v0.20.2-cu129
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "-c"]
         args:


### PR DESCRIPTION
## Summary
- Pin the vLLM image in the storage deployment example to `vllm/vllm-openai:v0.20.2-cu129` so it matches the CUDA 12 wheels installed via the default simple index (`pip install 'llmd-fs-connector==0.20' --extra-index-url https://llm-d.github.io/llm-d-kv-cache/simple/`). The plain `:v0.20.2` tag now resolves to a cu130 build, which mismatches the wheel ABI.
- Add a pointer to the PEP 503 simple index page (<https://llm-d.ai/llm-d-kv-cache/simple/llmd-fs-connector/>) so users can browse all published releases.