### PR TITLE
fs_backend: collapse FileMapper path + add config.json audit

### DIFF
--- a/kv_connectors/llmd_fs_backend/README.md
+++ b/kv_connectors/llmd_fs_backend/README.md
@@ -154,6 +154,37 @@ Then apply the full vLLM deployment (including the offloading connector with a f
 kubectl apply -f ./docs/deployment/vllm-storage.yaml
 ```
 
+## On-disk Layout
+
+KV blocks are organized under `shared_storage_path` by a config fingerprint, so runs with identical config share the same folder and reuse the same cache:
+
+```
+<shared_storage_path>/<safe_model_name>_<sha256-12hex>/
+    config.json                                       # shared across ranks
+<shared_storage_path>/<safe_model_name>_<sha256-12hex>_r<rank>/
+    <hhh>/<hh>_g<group>/<block-hash>.bin              # per-rank KV blocks
+```
+
+The hash fingerprints every field that affects the on-disk format (model, parallel sizes, dtype, block sizes, kv_cache_groups, inference_engine). `rank` lives outside the hash: the base folder (with `config.json`) is shared across ranks, while each rank's KV blocks land in a sibling `_r<rank>` folder.
+
+`config.json` is written by the first init and records the fields, for example:
+
+```json
+{
+  "dtype": "torch.bfloat16",
+  "hash_block_size": 16,
+  "gpu_blocks_per_file": 256,
+  "inference_engine": "vllm",
+  "kv_cache_groups": [
+    {
+      "block_size": 16,
+      "layer_names": ["model.layers.0.self_attn.attn", "..."]
+    }
+  ],
+  "model_name": "meta-llama/Meta-Llama-3.1-8B",
+  "dcp_size": 1, "pcp_size": 1, "pp_size": 1, "tp_size": 1
+}
+```
 ## Metrics
 
 The fs backend populates vLLM's built-in offloading metrics. When Prometheus metrics are enabled in vLLM, the following metrics are automatically exported:

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/file_mapper.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/file_mapper.py
@@ -12,11 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
+import json
+import os
+
+from vllm.config import VllmConfig
+from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.kv_offload.base import (
     OffloadKey,
     get_offload_block_hash,
     get_offload_group_idx,
 )
+
+_BASE_PATH_HASH_LEN = 12
+_CONFIG_FILENAME = "config.json"
 
 
 class FileMapper:
@@ -28,65 +37,106 @@ class FileMapper:
         self,
         root_dir: str,
         model_name: str,
-        gpu_block_size: int,
+        hash_block_size: int,
         gpu_blocks_per_file: int,
         tp_size: int,
         pp_size: int,
         pcp_size: int,
+        dcp_size: int,
         rank: int,
         dtype: str,
+        kv_cache_groups: list[dict] | None = None,
+        inference_engine: str = "vllm",
+        parallel_agnostic: bool = False,
     ):
         """
-        Initialize the file mapper for a specific worker.
-        All KV data files will be nested under a unique base path.
-
-        Base path format:
-            <root_dir>
-            /<model_name>
-            /block_size_<gpu_block_size>_blocks_per_file_<blocks_per_file>
-            /tp_<tp_size>_pp_<pp_size>_pcp_<pcp_size>
-            /rank_<kv_rank>
-            /<dtype>
-
-        Args:
-            root_dir: Root directory for shared storage.
-            model_name: Model identifier.
-            gpu_block_size: Number of tokens per GPU block.
-            gpu_blocks_per_file: Number of GPU blocks stored in a single file.
-            tp_size: Number of pipeline parallel groups.
-            pp_size: Number of tensor parallel groups.
-            pcp_size: Number of prefill context parallel groups.
-            rank: Worker rank.
-            dtype: Torch dtype of the KV-cache tensors.
-
-        Returns:
-            Base path under which KV-cache files are stored or loaded.
+        Initialize the file mapper. Each worker constructs its own, but
+        `config.json` (written by `write_run_config`) that is shared across
+        workers since rank lives outside the hash. When
+        `parallel_agnostic=True`, tp/pp/pcp/dcp are forced to 1 and rank
+        to 0 so multiple parallelism layouts collapse into the same folder.
         """
+        if parallel_agnostic:
+            tp_size = pp_size = pcp_size = dcp_size = 1
+            rank = 0
+        self.rank: int = rank
+        self.fields: dict = {
+            "model_name": model_name,
+            "hash_block_size": hash_block_size,
+            "gpu_blocks_per_file": gpu_blocks_per_file,
+            "tp_size": tp_size,
+            "pp_size": pp_size,
+            "pcp_size": pcp_size,
+            "dcp_size": dcp_size,
+            "dtype": str(dtype),
+            "kv_cache_groups": kv_cache_groups or [],
+            "inference_engine": inference_engine,
+        }
+        self.base_path: str = self._compute_base_path(root_dir, self.fields)
 
-        self.base_path = (
-            f"{root_dir}"
-            f"/{model_name}"
-            f"/block_size_{gpu_block_size}_blocks_per_file_{gpu_blocks_per_file}"
-            f"/tp_{tp_size}_pp_size_{pp_size}_pcp_size_{pcp_size}"
-            f"/rank_{rank}"
-            f"/{dtype}"
+    @classmethod
+    def from_vllm_config(
+        cls,
+        root_dir: str,
+        vllm_config: VllmConfig,
+        kv_cache_config: KVCacheConfig,
+        gpu_blocks_per_file: int,
+        parallel_agnostic: bool = False,
+    ) -> "FileMapper":
+        """Build a FileMapper from a vllm VllmConfig + KVCacheConfig."""
+        parallel_config = vllm_config.parallel_config
+        dtype = str(vllm_config.cache_config.cache_dtype).replace("torch.", "")
+        kv_cache_groups = [
+            {
+                "block_size": group.kv_cache_spec.block_size,
+                "layer_names": list(group.layer_names),
+            }
+            for group in kv_cache_config.kv_cache_groups
+        ]
+        return cls(
+            root_dir=root_dir,
+            model_name=vllm_config.model_config.model,
+            hash_block_size=vllm_config.cache_config.block_size,
+            gpu_blocks_per_file=gpu_blocks_per_file,
+            tp_size=parallel_config.tensor_parallel_size,
+            pp_size=parallel_config.pipeline_parallel_size,
+            pcp_size=parallel_config.prefill_context_parallel_size,
+            dcp_size=parallel_config.decode_context_parallel_size,
+            rank=parallel_config.rank,
+            dtype=dtype,
+            kv_cache_groups=kv_cache_groups,
+            parallel_agnostic=parallel_agnostic,
         )
 
     def get_file_name(self, key: OffloadKey) -> str:
-        """
-        Return the file path for a KV block.
-        The path is built using hash-based subdirectories to limit directory
-        fan-out, with the KV group index baked into the second-level folder
-        so different groups never collide on the same block hash:
-            <base>/<hhh>/<hh>_g<group_idx>/<hash>.bin
-
-        Args:
-            key: OffloadKey identifying the KV-cache block.
-
-        Returns:
-            Full file path for the given block.
-        """
+        """Map an OffloadKey to <base>_r<rank>/<hhh>/<hh>_g<group_idx>/<hash>.bin."""
         hash_hex = get_offload_block_hash(key).hex()
         group_idx = get_offload_group_idx(key)
         subfolder1, subfolder2 = hash_hex[:3], hash_hex[3:5]
-        return f"{self.base_path}/{subfolder1}/{subfolder2}_g{group_idx}/{hash_hex}.bin"
+        return (
+            f"{self.base_path}_r{self.rank}"
+            f"/{subfolder1}/{subfolder2}_g{group_idx}/{hash_hex}.bin"
+        )
+
+    def write_run_config(self) -> None:
+        """Write self.fields as JSON to <base_path>/config.json (no-op if it exists)."""
+        run_config = dict(self.fields)
+        os.makedirs(self.base_path, exist_ok=True)
+        target = os.path.join(self.base_path, _CONFIG_FILENAME)
+        if os.path.exists(target):
+            return
+        with open(target, "w") as f:
+            json.dump(run_config, f, indent=2, sort_keys=True)
+
+    @staticmethod
+    def _compute_base_path(root_dir: str, fields: dict) -> str:
+        """
+        Layout: <root_dir>/<safe_model_name>_<sha256-prefix>/.
+        safe_model_name replaces '/' with '_' so HuggingFace IDs don't nest.
+        """
+        canonical = json.dumps(fields, sort_keys=True, separators=(",", ":"))
+        digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[
+            :_BASE_PATH_HASH_LEN
+        ]
+        safe_model_name = fields["model_name"].replace("/", "_")
+        return f"{root_dir}/{safe_model_name}_{digest}"

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
@@ -71,10 +71,11 @@ class SharedStorageOffloadingSpec(OffloadingSpec):
             f"Expected exactly one KV cache group, got {len(self.gpu_block_size)}"
         )
 
-        assert self.offloaded_block_size % self.gpu_block_size[0] == 0, (
-            "offloaded_block_size must be a multiple of gpu_block_size"
+        hash_block_size = vllm_config.cache_config.block_size
+        assert self.offloaded_block_size % hash_block_size == 0, (
+            "offloaded_block_size must be a multiple of hash_block_size"
         )
-        self.gpu_blocks_per_file = self.offloaded_block_size // self.gpu_block_size[0]
+        self.gpu_blocks_per_file = self.offloaded_block_size // hash_block_size
 
         self.read_preferring_ratio = float(
             self.extra_config.get(
@@ -93,19 +94,13 @@ class SharedStorageOffloadingSpec(OffloadingSpec):
         pcp_size = parallel_config.prefill_context_parallel_size
         assert parallel_config.world_size == tp_size * pp_size * pcp_size
 
-        # TODO: use dtype from KVCacheConfig instead of VllmConfig.CacheConfig
-        dtype = str(vllm_config.cache_config.cache_dtype).replace("torch.", "")
-        self.file_mapper = FileMapper(
+        self.file_mapper = FileMapper.from_vllm_config(
             root_dir=shared_storage_path,
-            model_name=vllm_config.model_config.model,
-            gpu_block_size=self.gpu_block_size[0],
+            vllm_config=vllm_config,
+            kv_cache_config=kv_cache_config,
             gpu_blocks_per_file=self.gpu_blocks_per_file,
-            tp_size=tp_size,
-            pp_size=pp_size,
-            pcp_size=pcp_size,
-            rank=parallel_config.rank,
-            dtype=dtype,
         )
+        self.file_mapper.write_run_config()
 
     def get_manager(self) -> OffloadingManager:
         assert self.vllm_config.parallel_config.rank == 0, "Scheduler rank should be 0"

--- a/kv_connectors/llmd_fs_backend/tests/test_fs_backend.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_fs_backend.py
@@ -392,11 +392,12 @@ def test_fs_backend_roundtrip_param(
     file_mapper = FileMapper(
         root_dir=root_dir,
         model_name=model_name,
-        gpu_block_size=gpu_block_size,
+        hash_block_size=gpu_block_size,
         gpu_blocks_per_file=gpu_blocks_per_file,
         tp_size=tp_size,
         pp_size=tp_size,
         pcp_size=tp_size,
+        dcp_size=1,
         rank=tp_rank,
         dtype=str(dtype),
     )

--- a/kv_connectors/llmd_fs_backend/tests/test_gds_backend.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_gds_backend.py
@@ -121,11 +121,12 @@ class TestGDSAvailability:
         file_mapper = FileMapper(
             root_dir=str(tmp_path),
             model_name="test-model",
-            gpu_block_size=block_size,
+            hash_block_size=block_size,
             gpu_blocks_per_file=gpu_blocks_per_file,
             tp_size=1,
             pp_size=1,
             pcp_size=1,
+            dcp_size=1,
             rank=0,
             dtype=str(dtype),
         )

--- a/kv_connectors/llmd_fs_backend/tests/test_obj_backend.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_obj_backend.py
@@ -138,11 +138,12 @@ def roundtrip_once_obj(
     file_mapper = FileMapper(
         root_dir=f"kv-test/{int(time.time())}",
         model_name="test-model",
-        gpu_block_size=gpu_block_size,
+        hash_block_size=gpu_block_size,
         gpu_blocks_per_file=gpu_blocks_per_file,
         tp_size=1,
         pp_size=1,
         pcp_size=1,
+        dcp_size=1,
         rank=0,
         dtype=str(dtype),
     )

--- a/kv_connectors/llmd_fs_backend/tests/test_priority_queue.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_priority_queue.py
@@ -59,11 +59,12 @@ def create_test_handler(
     file_mapper = FileMapper(
         root_dir=TMP_DIR,
         model_name=model_name,
-        gpu_block_size=config["gpu_block_size"],
+        hash_block_size=config["gpu_block_size"],
         gpu_blocks_per_file=config["gpu_blocks_per_file"],
         tp_size=1,
         pp_size=1,
         pcp_size=1,
+        dcp_size=1,
         rank=0,
         dtype=config["dtype"],
     )


### PR DESCRIPTION
## Summary

- Replace the deep `<model>/block_X.../tp_Y.../rank_Z/<dtype>/` layout with a flat `<model>_<sha256-12hex>/` folder fingerprinted by everything that affects the on-disk format: model, parallel sizes (tp/pp/pcp/dcp), dtype, block sizes, kv_cache_groups, inference_engine. Including `dcp_size` so two DCP runs don't collide.
- `rank` lives outside the hash. The base folder (with `config.json`) is shared across ranks; per-rank KV blocks land in a sibling `_r<rank>` folder that `get_file_name` appends at lookup time.
- New `FileMapper.write_run_config()` persists `self.fields` as JSON to `<base>/config.json` on demand (no-op if it exists), so each folder is self-describing.
- `FileMapper.from_vllm_config(...)` classmethod hides VllmConfig/KVCacheConfig extraction from `spec.py` while keeping the explicit `__init__` for tests.
- `parallel_agnostic=False` kwarg on `FileMapper.__init__` — when True, forces `tp/pp/pcp/dcp = 1` and `rank = 0` so multiple parallelism layouts share one cache folder (safe only if the offloaded format is parallelism-invariant).

## Test plan
- [x] `make test` passes (21 passed, 3 skipped)
- [x] Throughput e2e test with Llama 3.1 8B