### PR TITLE
fix: remove MIN_STAGING_BUFFER_SIZE that inflates KV cache on disk

### DIFF
--- a/kv_connectors/llmd_fs_backend/csrc/storage/thread_pool.cpp
+++ b/kv_connectors/llmd_fs_backend/csrc/storage/thread_pool.cpp
@@ -31,8 +31,6 @@
 #include "numa_utils.hpp"
 #include "logger.hpp"
 
-// Minimum staging buffer size: 16 MB
-const size_t MIN_STAGING_BUFFER_SIZE = 16 * 1024 * 1024;
 
 // Define static thread-local members
 thread_local StagingBufferInfo ThreadPool::m_staging_buffer{};
@@ -227,7 +225,7 @@ at::cuda::CUDAStream& ThreadPool::get_tls_stream() { return m_thread_stream; }
 
 // Allocate the thread-local staging buffer to at least required_bytes
 bool ThreadPool::allocate_staging_buffer(size_t required_bytes) {
-  size_t alloc_size = std::max(required_bytes, MIN_STAGING_BUFFER_SIZE);
+  size_t alloc_size = required_bytes;
   cudaError_t err = cudaHostAlloc(&m_staging_buffer.ptr,
                                   alloc_size,
                                   cudaHostAllocMapped | cudaHostAllocPortable);


### PR DESCRIPTION
## Summary
- Remove the 16 MB `MIN_STAGING_BUFFER_SIZE` floor in `allocate_staging_buffer`
- Staging buffers now use the exact size computed by `calc_staging_bytes` (block_size * blocks_per_file)
- For Llama 3.1 8B, this halves the per-file on-disk size (16 MB back to ~7 MB) and reduces TTFT from 6.5 s to 2.8 s at 40k-token prefix length (numbers from #454)

The floor was applied via `std::max(required_bytes, MIN_STAGING_BUFFER_SIZE)`, then `write_buffer_to_file` wrote `buf.size` bytes to disk, padding every file to at least 16 MB regardless of actual KV block size.

Fixes #454

## Test plan
- [x] Extension compiles and loads successfully on NVIDIA L4 (CUDA 12.4, torch 2.6.0)
- [ ] CI `test_fs_backend.py` (requires matching vllm version)