### PR TITLE
Fix: Avoid OBJ backend runtime failures after vLLM 0.21 KV-offload migration

### DIFF
--- a/kv_connectors/llmd_fs_backend/llmd_nixl/manager.py
+++ b/kv_connectors/llmd_fs_backend/llmd_nixl/manager.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections.abc import Iterable
+from collections.abc import Collection
 
 from vllm.logger import init_logger
-from vllm.v1.core.kv_cache_utils import BlockHash
+from vllm.v1.kv_offload.base import OffloadKey, ReqContext
 
 from llmd_fs_backend.file_mapper import FileMapper
 from llmd_fs_backend.manager import SharedStorageOffloadingManager
@@ -48,24 +48,22 @@ class NixlStorageOffloadingManager(SharedStorageOffloadingManager):
         if self.lookup_mode == LOOKUP_MODE_NIXL_QUERY:
             self._nixl_lookup = NixlLookup(cfg)
 
-    def lookup(self, block_hashes: Iterable[BlockHash]) -> int:
-        hit_count = 0
-        for block_hash in block_hashes:
-            key = self.file_mapper.get_file_name(block_hash)
-            if self.lookup_mode == LOOKUP_MODE_NIXL_QUERY:
-                if not self._nixl_lookup.exists(key):
-                    break
-            else:  # dict
-                if key not in self._stored_keys:
-                    break
-            hit_count += 1
-        logger.debug("lookup(%s): %d", self.lookup_mode, hit_count)
-        return hit_count
+    def lookup(self, key: OffloadKey, req_context: ReqContext) -> bool | None:
+        file_name = self.file_mapper.get_file_name(key)
+        if self.lookup_mode == LOOKUP_MODE_NIXL_QUERY:
+            exists = self._nixl_lookup.exists(file_name)
+        else:  # dict
+            exists = file_name in self._stored_keys
+        logger.debug("lookup(%s): %s", self.lookup_mode, exists)
+        return exists
 
     def complete_store(
-        self, block_hashes: Iterable[BlockHash], success: bool = True
+        self,
+        keys: Collection[OffloadKey],
+        req_context: ReqContext,
+        success: bool = True,
     ) -> None:
         if not success or self.lookup_mode != LOOKUP_MODE_DICT:
             return
-        for block_hash in block_hashes:
-            self._stored_keys.add(self.file_mapper.get_file_name(block_hash))
+        for key in keys:
+            self._stored_keys.add(self.file_mapper.get_file_name(key))


### PR DESCRIPTION
Trigger Scenario
  When llmd_fs_backend is configured with backend == "OBJ", SharedStorageOffloadingSpec.get_manager() returns NixlStorageOffloadingManager. vLLM 0.21 then calls lookup() and complete_store() using the new KV-offload API signatures.

  NixlStorageOffloadingManager still uses the old method signatures:
  lookup(block_hashes: Iterable[BlockHash]) -> int
  complete_store(block_hashes: Iterable[BlockHash], success: bool = True)

  This can cause runtime argument mismatch errors, incorrect lookup behavior, or failed tracking of stored keys in dict lookup mode.


 Root Cause
  PR #588 migrated SharedStorageOffloadingManager to the vLLM 0.21 KV-offload API, but missed the overridden methods in NixlStorageOffloadingManager. Because the NIXL subclass overrides the fixed parent methods, OBJ backend calls still hit the stale vLLM 0.20-style implementation.
