### PR TITLE
Handle AllBlocksCleared events in KV index

### DIFF
--- a/pkg/kvcache/kvblock/cost_aware_memory.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory.go
@@ -79,6 +79,7 @@ func NewCostAwareMemoryIndex(cfg *CostAwareMemoryIndexConfig) (*CostAwareMemoryI
 	return &CostAwareMemoryIndex{
 		data:        cache,
 		requestKeys: requestKeys,
+		dataKeys:    make(map[BlockHash]struct{}),
 	}, nil
 }
 
@@ -94,6 +95,8 @@ type CostAwareMemoryIndex struct {
 	data *ristretto.Cache[string, *CostPodCache]
 	// requestKeys holds the mapping of engine keys to request keys.
 	requestKeys *lru.Cache[BlockHash, []BlockHash]
+	// dataKeys tracks request keys because ristretto does not expose key iteration.
+	dataKeys map[BlockHash]struct{}
 	// mu protects concurrent access to the index operations
 	mu sync.RWMutex
 }
@@ -121,6 +124,23 @@ func (c *CostPodCache) Delete(entry PodEntry) {
 	if _, loaded := c.cache.LoadAndDelete(entry); loaded {
 		c.size.Add(-1)
 	}
+}
+
+// DeleteMatching removes all entries that match the pod and optional device tier.
+func (c *CostPodCache) DeleteMatching(podIdentifier, deviceTier string) bool {
+	removed := false
+	c.cache.Range(func(key, _ interface{}) bool {
+		entry, ok := key.(PodEntry)
+		if !ok {
+			return true
+		}
+		if shouldClearPodEntry(entry, podIdentifier, deviceTier) {
+			c.Delete(entry)
+			removed = true
+		}
+		return true
+	})
+	return removed
 }
 
 // Len returns the number of entries in the cache.
@@ -213,6 +233,7 @@ func (m *CostAwareMemoryIndex) Add(ctx context.Context, engineKeys, requestKeys 
 		// Calculate the actual cost for this cache entry
 		cost := podCache.CalculateByteSize(keyStr)
 		m.data.Set(keyStr, podCache, cost)
+		m.dataKeys[requestKey] = struct{}{}
 		traceLogger.Info("added pods to key", "requestKey", requestKey, "pods", entries, "cost-bytes", cost)
 	}
 	m.data.Wait()
@@ -318,6 +339,65 @@ func (m *CostAwareMemoryIndex) Evict(ctx context.Context, key BlockHash, keyType
 	}
 }
 
+// Clear removes all entries for a pod from the cost-aware memory index.
+// If deviceTier is non-empty, only entries for that tier are removed.
+func (m *CostAwareMemoryIndex) Clear(ctx context.Context, podIdentifier, deviceTier string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if podIdentifier == "" {
+		return fmt.Errorf("no pod identifier provided for clearing from index")
+	}
+
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.CostAwareMemoryIndex.Clear")
+
+	for requestKey := range m.dataKeys {
+		keyStr := requestKey.String()
+		podCache, found := m.data.Get(keyStr)
+		if !found || podCache == nil {
+			delete(m.dataKeys, requestKey)
+			continue
+		}
+
+		if !podCache.DeleteMatching(podIdentifier, deviceTier) {
+			continue
+		}
+
+		if podCache.Len() == 0 {
+			m.data.Del(keyStr)
+			delete(m.dataKeys, requestKey)
+			traceLogger.Info("removed requestKey from index as no pods remain", "requestKey", requestKey)
+			continue
+		}
+
+		m.data.Set(keyStr, podCache, podCache.CalculateByteSize(keyStr))
+		traceLogger.Info("cleared pod entries from key",
+			"requestKey", requestKey, "podIdentifier", podIdentifier, "deviceTier", deviceTier)
+	}
+
+	for _, engineKey := range m.requestKeys.Keys() {
+		rks, found := m.requestKeys.Get(engineKey)
+		if !found {
+			continue
+		}
+
+		allEmpty := true
+		for _, rk := range rks {
+			pc, found := m.data.Get(rk.String())
+			if found && pc != nil && pc.Len() > 0 {
+				allEmpty = false
+				break
+			}
+		}
+		if allEmpty {
+			m.requestKeys.Remove(engineKey)
+		}
+	}
+
+	m.data.Wait()
+	return nil
+}
+
 // evictPodsFromRequestKey removes the given pod entries from a single request key's cache.
 // If the cache becomes empty, the request key is removed from the index.
 func (m *CostAwareMemoryIndex) evictPodsFromRequestKey(
@@ -338,6 +418,7 @@ func (m *CostAwareMemoryIndex) evictPodsFromRequestKey(
 
 	if podCache.Len() == 0 {
 		m.data.Del(keyStr)
+		delete(m.dataKeys, requestKey)
 		traceLogger.Info("removed requestKey from index as no pods remain", "requestKey", requestKey)
 	} else if podCacheLenBefore != podCache.Len() {
 		m.data.Set(keyStr, podCache, podCache.CalculateByteSize(keyStr))

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -274,6 +274,76 @@ func (m *InMemoryIndex) Evict(ctx context.Context, key BlockHash, keyType KeyTyp
 	}
 }
 
+// Clear removes all entries for a pod from the in-memory index.
+// If deviceTier is non-empty, only entries for that tier are removed.
+func (m *InMemoryIndex) Clear(ctx context.Context, podIdentifier, deviceTier string) error {
+	if podIdentifier == "" {
+		return fmt.Errorf("no pod identifier provided for clearing from index")
+	}
+
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.InMemoryIndex.Clear")
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, requestKey := range m.data.Keys() {
+		podCache, found := m.data.Get(requestKey)
+		if !found || podCache == nil {
+			continue
+		}
+
+		removed := false
+		podCache.mu.Lock()
+		for _, entry := range podCache.cache.Keys() {
+			if shouldClearPodEntry(entry, podIdentifier, deviceTier) {
+				podCache.cache.Remove(entry)
+				removed = true
+			}
+		}
+		isEmpty := podCache.cache.Len() == 0
+		podCache.mu.Unlock()
+
+		if !removed {
+			continue
+		}
+
+		traceLogger.Info("cleared pod entries from key",
+			"requestKey", requestKey, "podIdentifier", podIdentifier, "deviceTier", deviceTier)
+		if isEmpty {
+			m.data.Remove(requestKey)
+			traceLogger.Info("removed requestKey from index as no pods remain", "requestKey", requestKey)
+		}
+	}
+
+	for _, engineKey := range m.engineToRequestKeys.Keys() {
+		rks, found := m.engineToRequestKeys.Get(engineKey)
+		if !found {
+			continue
+		}
+
+		allEmpty := true
+		for _, rk := range rks {
+			pc, found := m.data.Get(rk)
+			if !found || pc == nil {
+				continue
+			}
+
+			pc.mu.Lock()
+			hasEntries := pc.cache.Len() > 0
+			pc.mu.Unlock()
+			if hasEntries {
+				allEmpty = false
+				break
+			}
+		}
+		if allEmpty {
+			m.engineToRequestKeys.Remove(engineKey)
+		}
+	}
+
+	return nil
+}
+
 // evictPodsFromRequestKey removes the given pod entries from a single request key's cache.
 // If the cache becomes empty, the request key is removed from the index.
 func (m *InMemoryIndex) evictPodsFromRequestKey(requestKey, engineKey BlockHash, entries []PodEntry, traceLogger logr.Logger) {

--- a/pkg/kvcache/kvblock/index.go
+++ b/pkg/kvcache/kvblock/index.go
@@ -144,6 +144,9 @@ type Index interface {
 	// keyType indicates whether the key is an EngineKey (requires engine→request lookup)
 	// or a RequestKey (used directly).
 	Evict(ctx context.Context, key BlockHash, keyType KeyType, entries []PodEntry) error
+	// Clear removes all entries for a pod from the index backend.
+	// If deviceTier is non-empty, only entries for that tier are removed.
+	Clear(ctx context.Context, podIdentifier, deviceTier string) error
 	// GetRequestKey returns the requestKey associated with the given engineKey.
 	GetRequestKey(ctx context.Context, engineKey BlockHash) (BlockHash, error)
 }
@@ -189,4 +192,11 @@ func (e *PodEntry) String() string {
 		suffix = "[speculative]"
 	}
 	return fmt.Sprintf("%s@%s%s", e.PodIdentifier, e.DeviceTier, suffix)
+}
+
+func shouldClearPodEntry(entry PodEntry, podIdentifier, deviceTier string) bool {
+	if entry.PodIdentifier != podIdentifier {
+		return false
+	}
+	return deviceTier == "" || entry.DeviceTier == deviceTier
 }

--- a/pkg/kvcache/kvblock/index_test.go
+++ b/pkg/kvcache/kvblock/index_test.go
@@ -118,6 +118,11 @@ func testCommonIndexBehavior(t *testing.T, indexFactory func(t *testing.T) Index
 		index := indexFactory(t)
 		testEvictPreservesEngineMappingForOtherTiers(t, ctx, index)
 	})
+
+	t.Run("ClearPodEntries", func(t *testing.T) {
+		index := indexFactory(t)
+		testClearPodEntries(t, ctx, index)
+	})
 }
 
 // testBasicAddAndLookup tests basic Add and Lookup functionality.
@@ -790,4 +795,58 @@ func testEvictPreservesEngineMappingForOtherTiers(t *testing.T, ctx context.Cont
 	// Engine→request mapping should be gone.
 	_, err = index.GetRequestKey(ctx, engineKey)
 	assert.Error(t, err, "engine→request mapping should be removed after full eviction")
+}
+
+// testClearPodEntries verifies that Clear removes a pod across all request keys,
+// supports tier-scoped clearing, preserves other pods, and prunes empty engine mappings.
+func testClearPodEntries(t *testing.T, ctx context.Context, index Index) {
+	t.Helper()
+
+	engineKeys := []BlockHash{88101, 88102}
+	requestKeys := []BlockHash{99101, 99102}
+	entries := []PodEntry{
+		{PodIdentifier: "pod-a", DeviceTier: "gpu"},
+		{PodIdentifier: "pod-a", DeviceTier: "cpu"},
+		{PodIdentifier: "pod-b", DeviceTier: "gpu"},
+	}
+
+	err := index.Add(ctx, engineKeys, requestKeys, entries)
+	require.NoError(t, err)
+
+	err = index.Clear(ctx, "pod-a", "gpu")
+	require.NoError(t, err)
+
+	for _, requestKey := range requestKeys {
+		result, err := index.Lookup(ctx, []BlockHash{requestKey}, nil)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []PodEntry{
+			{PodIdentifier: "pod-a", DeviceTier: "cpu"},
+			{PodIdentifier: "pod-b", DeviceTier: "gpu"},
+		}, result[requestKey])
+	}
+
+	rk, err := index.GetRequestKey(ctx, engineKeys[0])
+	require.NoError(t, err, "engine mapping should remain while other entries exist")
+	assert.Equal(t, requestKeys[0], rk)
+
+	err = index.Clear(ctx, "pod-a", "")
+	require.NoError(t, err)
+
+	for _, requestKey := range requestKeys {
+		result, err := index.Lookup(ctx, []BlockHash{requestKey}, nil)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []PodEntry{
+			{PodIdentifier: "pod-b", DeviceTier: "gpu"},
+		}, result[requestKey])
+	}
+
+	err = index.Clear(ctx, "pod-b", "")
+	require.NoError(t, err)
+
+	result, err := index.Lookup(ctx, requestKeys, nil)
+	require.NoError(t, err)
+	assert.Empty(t, result, "all request keys should be removed after clearing the last pod")
+
+	_, err = index.GetRequestKey(ctx, engineKeys[0])
+	assert.Error(t, err, "engine mapping should be removed after all mapped request keys are empty")
 }

--- a/pkg/kvcache/kvblock/instrumented_index.go
+++ b/pkg/kvcache/kvblock/instrumented_index.go
@@ -44,6 +44,10 @@ func (m *instrumentedIndex) Evict(ctx context.Context, key BlockHash, keyType Ke
 	return err
 }
 
+func (m *instrumentedIndex) Clear(ctx context.Context, podIdentifier, deviceTier string) error {
+	return m.next.Clear(ctx, podIdentifier, deviceTier)
+}
+
 func (m *instrumentedIndex) Lookup(
 	ctx context.Context,
 	requestKeys []BlockHash,

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -217,16 +217,12 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 
 		var filteredPods []PodEntry
 		for _, p := range pods {
-			ip := strings.SplitN(p, "@", 2)[0]
-			if !filterPods || podIdentifierSet.Has(ip) {
-				tier := strings.SplitN(p, "@", 2)[1]
-				speculative := false
-				// Strip annotation suffix e.g. "gpu[speculative]" -> "gpu"
-				if idx := strings.Index(tier, "["); idx != -1 {
-					speculative = strings.Contains(tier[idx:], "speculative")
-					tier = tier[:idx]
-				}
-				filteredPods = append(filteredPods, PodEntry{PodIdentifier: ip, DeviceTier: tier, Speculative: speculative})
+			entry, ok := podEntryFromString(p)
+			if !ok {
+				continue
+			}
+			if !filterPods || podIdentifierSet.Has(entry.PodIdentifier) {
+				filteredPods = append(filteredPods, entry)
 			}
 		}
 
@@ -317,6 +313,58 @@ func (r *RedisIndex) Evict(ctx context.Context, key BlockHash, keyType KeyType, 
 	}
 }
 
+// Clear removes all entries for a pod from the Redis-backed index.
+// If deviceTier is non-empty, only entries for that tier are removed.
+func (r *RedisIndex) Clear(ctx context.Context, podIdentifier, deviceTier string) error {
+	if podIdentifier == "" {
+		return fmt.Errorf("no pod identifier provided for clearing from index")
+	}
+
+	iter := r.RedisClient.Scan(ctx, 0, "*", 0).Iterator()
+	for iter.Next(ctx) {
+		redisKey := iter.Val()
+		if strings.HasPrefix(redisKey, "engine:") {
+			continue
+		}
+
+		keyType, err := r.RedisClient.Type(ctx, redisKey).Result()
+		if err != nil {
+			return fmt.Errorf("failed to get Redis key type for %q: %w", redisKey, err)
+		}
+		if keyType != "hash" {
+			continue
+		}
+
+		pods, err := r.RedisClient.HKeys(ctx, redisKey).Result()
+		if err != nil {
+			return fmt.Errorf("failed to get pods for Redis key %q: %w", redisKey, err)
+		}
+
+		fieldsToDelete := make([]string, 0, len(pods))
+		for _, pod := range pods {
+			entry, ok := podEntryFromString(pod)
+			if ok && shouldClearPodEntry(entry, podIdentifier, deviceTier) {
+				fieldsToDelete = append(fieldsToDelete, pod)
+			}
+		}
+		if len(fieldsToDelete) == 0 {
+			continue
+		}
+
+		if err := r.RedisClient.HDel(ctx, redisKey, fieldsToDelete...).Err(); err != nil {
+			return fmt.Errorf("failed to clear pod entries from Redis key %q: %w", redisKey, err)
+		}
+		if err := pruneRequestKeyScript.Run(ctx, r.RedisClient, []string{redisKey}).Err(); err != nil {
+			return fmt.Errorf("failed to prune empty request key %q: %w", redisKey, err)
+		}
+	}
+	if err := iter.Err(); err != nil {
+		return fmt.Errorf("failed to scan Redis request keys: %w", err)
+	}
+
+	return r.pruneEmptyEngineMappings(ctx)
+}
+
 // evictPodsFromRequestKey removes the given pod entries from a single request key.
 // If the pod hash becomes empty, the request key is removed.
 func (r *RedisIndex) evictPodsFromRequestKey(ctx context.Context, requestKey BlockHash, entries []PodEntry) error {
@@ -334,6 +382,38 @@ func (r *RedisIndex) evictPodsFromRequestKey(ctx context.Context, requestKey Blo
 	// Atomically delete the request key hash if it's now empty
 	if err := pruneRequestKeyScript.Run(ctx, r.RedisClient, []string{redisKey}).Err(); err != nil {
 		return fmt.Errorf("failed to prune empty request key: %w", err)
+	}
+
+	return nil
+}
+
+func (r *RedisIndex) pruneEmptyEngineMappings(ctx context.Context) error {
+	iter := r.RedisClient.Scan(ctx, 0, "engine:*", 0).Iterator()
+	for iter.Next(ctx) {
+		engineKey := iter.Val()
+		requestKeys, err := r.RedisClient.ZRange(ctx, engineKey, 0, -1).Result()
+		if err != nil {
+			if errors.Is(err, redis.Nil) {
+				continue
+			}
+			return fmt.Errorf("failed to get request keys for %q: %w", engineKey, err)
+		}
+		if len(requestKeys) == 0 {
+			if err := r.RedisClient.Del(ctx, engineKey).Err(); err != nil {
+				return fmt.Errorf("failed to prune empty engine key mapping %q: %w", engineKey, err)
+			}
+			continue
+		}
+
+		keys := make([]string, 0, 1+len(requestKeys))
+		keys = append(keys, engineKey)
+		keys = append(keys, requestKeys...)
+		if err := pruneEngineKeyScript.Run(ctx, r.RedisClient, keys).Err(); err != nil && !errors.Is(err, redis.Nil) {
+			return fmt.Errorf("failed to prune engine key mapping %q: %w", engineKey, err)
+		}
+	}
+	if err := iter.Err(); err != nil {
+		return fmt.Errorf("failed to scan Redis engine keys: %w", err)
 	}
 
 	return nil
@@ -379,4 +459,23 @@ func (r *RedisIndex) GetRequestKey(ctx context.Context, engineKey BlockHash) (Bl
 
 func redisEngineKey(engineKey BlockHash) string {
 	return "engine:" + engineKey.String()
+}
+
+func podEntryFromString(value string) (PodEntry, bool) {
+	podIdentifier, tier, ok := strings.Cut(value, "@")
+	if !ok {
+		return PodEntry{}, false
+	}
+
+	speculative := false
+	if idx := strings.Index(tier, "["); idx != -1 {
+		speculative = strings.Contains(tier[idx:], "speculative")
+		tier = tier[:idx]
+	}
+
+	return PodEntry{
+		PodIdentifier: podIdentifier,
+		DeviceTier:    tier,
+		Speculative:   speculative,
+	}, true
 }

--- a/pkg/kvcache/kvblock/traced_index.go
+++ b/pkg/kvcache/kvblock/traced_index.go
@@ -44,6 +44,10 @@ func (t *tracedIndex) Evict(ctx context.Context, key BlockHash, keyType KeyType,
 	return t.next.Evict(ctx, key, keyType, entries)
 }
 
+func (t *tracedIndex) Clear(ctx context.Context, podIdentifier, deviceTier string) error {
+	return t.next.Clear(ctx, podIdentifier, deviceTier)
+}
+
 func (t *tracedIndex) Lookup(
 	ctx context.Context,
 	requestKeys []BlockHash,

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -423,10 +423,20 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 			}
 
 		case *AllBlocksClearedEvent:
+			deviceTier := ""
+			if ev.DeviceTier != "" {
+				deviceTier = strings.ToLower(ev.DeviceTier)
+			}
+
 			debugLogger.Info("All blocks cleared event received",
 				"podIdentifier", podIdentifier,
-				"deviceTier", ev.DeviceTier,
+				"deviceTier", deviceTier,
 				"modelName", modelName)
+			if err := p.index.Clear(ctx, podIdentifier, deviceTier); err != nil {
+				debugLogger.Error(err, "Failed to clear pod entries from index",
+					"podIdentifier", podIdentifier, "deviceTier", deviceTier)
+				continue
+			}
 
 		default:
 			debugLogger.Info("Unknown event", "podIdentifier", podIdentifier, "event", genericEvent)

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -328,6 +328,51 @@ func TestCanonicalEviction_UnknownEngineKey(t *testing.T) {
 	})
 }
 
+func TestAllBlocksClearedEventRemovesPodEntries(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, idx, _ := newTestPool(t, 16)
+
+	tokens := makeTokens(32)
+	engineKeys := makeEngineKeys(2, 900)
+	storeBatch := &EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes: engineKeys,
+				Tokens:      tokens,
+				ParentHash:  0,
+			},
+			&BlockStoredEvent{
+				BlockHashes: engineKeys,
+				Tokens:      tokens,
+				ParentHash:  0,
+				DeviceTier:  "CPU",
+			},
+		},
+	}
+	pool.processEventBatch(ctx, storeBatch, "pod-cleared", "test-model")
+
+	requestKey, err := idx.GetRequestKey(ctx, kvblock.BlockHash(engineKeys[0]))
+	require.NoError(t, err)
+
+	before, err := idx.Lookup(ctx, []kvblock.BlockHash{requestKey}, nil)
+	require.NoError(t, err)
+	require.Len(t, before[requestKey], 2)
+
+	clearBatch := &EventBatch{
+		Events: []GenericEvent{
+			&AllBlocksClearedEvent{},
+		},
+	}
+	pool.processEventBatch(ctx, clearBatch, "pod-cleared", "test-model")
+
+	after, err := idx.Lookup(ctx, []kvblock.BlockHash{requestKey}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, after[requestKey], "AllBlocksCleared should remove all tiers for this pod")
+
+	_, err = idx.GetRequestKey(ctx, kvblock.BlockHash(engineKeys[0]))
+	assert.Error(t, err, "engine mapping should be removed after clearing all entries")
+}
+
 // TestRealignExtraFeatures verifies that engine-granularity extraFeatures are
 // correctly converted to canonical-block granularity.
 func TestRealignExtraFeatures(t *testing.T) {


### PR DESCRIPTION
## Background

`llm-d-kv-cache` consumes KV cache events emitted by inference engines, such as `BlockStored`, `BlockRemoved`, and `AllBlocksCleared`.

`BlockStored` and `BlockRemoved` update the index that tracks which pods hold which KV blocks. `AllBlocksCleared` means that a pod has cleared its local KV cache entirely.

On current `main`, both the vLLM and SGLang adapters can decode `AllBlocksCleared` into `AllBlocksClearedEvent`, but `Pool.processEventBatch` only logs the event and does not remove the pod's entries from the index.

## Problem

The KV cache index is used to answer which pods hold a given block. Scheduling and cache lookup logic can rely on this index to decide where a prefix can be reused.

If a pod has already cleared its local KV cache but the index still contains its old entries, the index becomes stale. Later lookups may still return that pod even though the pod no longer has those KV blocks.

Example:

1. `pod-a` emits `BlockStored`, and the index records `block X -> pod-a@gpu`.
2. `pod-a` later emits `AllBlocksCleared` after a reset, memory pressure, or engine-side cache cleanup.
3. The current code only logs the event and leaves the index unchanged.
4. A later `Lookup(block X)` still returns `pod-a@gpu`.
5. The scheduler may route a request to `pod-a`, but the KV cache entry is no longer available there.

## Why This Change

`AllBlocksCleared` semantically means that the pod's local KV cache has been cleared. The index should reflect that state by removing the corresponding pod entries. Otherwise, the index can diverge from the actual engine state and produce stale cache locality results.

## Changes

- Add `Clear(ctx, podIdentifier, deviceTier)` to `kvblock.Index`.
- Call `index.Clear` when `Pool.processEventBatch` receives `AllBlocksClearedEvent`.
- Treat an empty `deviceTier` as clearing all tiers for the pod.
- Treat a non-empty `deviceTier` as clearing only that tier for the pod.
- Implement `Clear` for:
  - in-memory index
  - cost-aware memory index
  - Redis / Valkey index
  - traced and instrumented index wrappers
- Remove request keys when no pod entries remain.
- Prune engine mappings when all mapped request keys are empty.
- Add shared index tests for:
  - pod-level clearing
  - tier-scoped clearing
  - preserving other pods
  - pruning stale engine mappings
- Add a pool-level regression test showing that `AllBlocksCleared` removes entries previously added by `BlockStored`.

## Validation

```bash
go test ./pkg/kvcache/kvblock ./pkg/kvevents -count=1
go mod tidy
go test ./pkg/... -count=1
git diff --check