### PR TITLE
fs_backend: strip group_idx before publishing storage event hash

### DIFF
--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
@@ -22,6 +22,7 @@ from vllm.v1.kv_offload.base import (
     OffloadKey,
     PrepareStoreOutput,
     ReqContext,
+    get_offload_block_hash,
 )
 from zmq import ZMQError
 
@@ -84,10 +85,11 @@ class SharedStorageOffloadingManager(OffloadingManager):
             )
             return None
 
-    def _publish_blocks_stored(self, block_hashes: Collection[OffloadKey]) -> None:
+    def _publish_blocks_stored(self, keys: Collection[OffloadKey]) -> None:
         if self._event_publisher is None:
             return
         try:
+            block_hashes = [get_offload_block_hash(k) for k in keys]
             self._event_publisher.publish_blocks_stored(block_hashes)
         except Exception:
             logger.warning("failed to publish storage event", exc_info=True)


### PR DESCRIPTION
## Summary
- `SharedStorageOffloadingManager._publish_blocks_stored` passed the full `OffloadKey` (block_hash + 4-byte group_idx) to `_hash_to_uint64`, which truncated the *combined* bytes to 64 bits. With `group_idx=0` the published hash was `<last 4 bytes of block_hash><0x00000000>` — the lower 32 bits of the real block hash were lost.
- Result: storage event hashes did not match the vLLM GPU `BlockStored` value or the filename written by `FileMapper` (which uses the full block hash via `get_offload_block_hash`).
- Fix: call `get_offload_block_hash(key)` to strip the group_idx before publishing.

After the fix, the uint64 in the event equals `file_stem[-16:]` 1:1.

## Example (after fix)

Event hash (uint64, from `BlockStored.block_hashes[i]`):
```
00c8f68b40daffce
```

Matched file on disk:
```
/<root>/meta-llama_Meta-Llama-3.1-8B_<digest>_r0/e70/5e_g0/e705ed1b3938d512148e8d64e4bed8d205000d20097a34cf00c8f68b40daffce.bin
```

```
event hash:           00c8f68b40daffce
file stem (last 16): …00c8f68b40daffce   ✓
file stem (full):     e705ed1b3938d512148e8d64e4bed8d205000d20097a34cf00c8f68b40daffce
                      └──────── upper 48 hex (only in filename) ────────┘└─ uint64 hex ─┘
```

## Test plan
- [x] Reproduced the bug: storage events emitted hashes of the form `<4-hex><00000000>` (zero suffix), 0/N matched any file on disk.
- [x] After fix: 256/256 received events match `file_stem[-16:]` (2-request × 128-block run, 0 unmatched).
- [x] Pre-commit hooks (`ruff`, `typos`) pass.