### PR TITLE
feat: Add PVC evictor BlockRemoved events

### DIFF
--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
@@ -54,7 +54,7 @@ class StorageEventPublisher:
     def __init__(
         self,
         endpoint: str,
-        model_name: str,
+        model_name: str | None = None,
         sndhwm: int = DEFAULT_STORAGE_EVENTS_HWM,
         medium: StorageMedium = StorageMedium.SHARED_STORAGE,
     ) -> None:
@@ -74,7 +74,9 @@ class StorageEventPublisher:
 
         self._model_name = model_name
         self._medium = medium
-        self._topic = f"kv@{self._medium.value}@{self._model_name}"
+        self._topic = (
+            f"kv@{self._medium.value}@{self._model_name}" if self._model_name else None
+        )
         self._seq: int = 0
         self._closed = False
         self._send_lock = threading.Lock()
@@ -106,7 +108,35 @@ class StorageEventPublisher:
         ]
         self._send_batch([msgpack.packb(event, use_bin_type=True)])
 
-    def _send_batch(self, packed_events: list[bytes]) -> None:
+    def publish_blocks_removed(
+        self,
+        block_hashes: Iterable[int | bytes],
+        model_name: str | None = None,
+    ) -> None:
+        """Publish a ``BlockRemoved`` event for each hash in *block_hashes*.
+
+        Each hash is masked to 64 bits and wrapped in a 3-field positional
+        array matching the Go ``convertBlockRemovedEvent()`` wire format.
+
+        Args:
+            block_hashes: Block hashes to publish removal events for.
+            model_name: Override the model name in the ZMQ topic. Useful
+                when the publisher handles multiple models (e.g. PVC evictor).
+        """
+        hashes = [_hash_to_uint64(h) for h in block_hashes]
+        if not hashes:
+            return
+
+        event = [
+            "BlockRemoved",  # [0] tag
+            hashes,  # [1] block_hashes (all hashes from this XXX call)
+            self._medium.value,  # [2] medium / device tier
+        ]
+
+        topic = f"kv@{self._medium.value}@{model_name}" if model_name else None
+        self._send_batch([msgpack.packb(event, use_bin_type=True)], topic=topic)
+
+    def _send_batch(self, packed_events: list[bytes], topic: str | None = None) -> None:
         """Send a batch of pre-packed events as a 3-frame ZMQ message.
 
         Frames: ``[topic, sequence, payload]``.  Thread-safe; silently
@@ -116,11 +146,12 @@ class StorageEventPublisher:
             if self._closed:
                 return
 
+            effective_topic = topic or self._topic
             payload = msgpack.packb([time.time(), packed_events], use_bin_type=True)
             self._seq += 1
             self._socket.send_multipart(
                 [
-                    self._topic.encode("utf-8"),
+                    effective_topic.encode("utf-8"),
                     struct.pack(">Q", self._seq),
                     payload,
                 ]

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
@@ -129,7 +129,7 @@ class StorageEventPublisher:
 
         event = [
             "BlockRemoved",  # [0] tag
-            hashes,  # [1] block_hashes (all hashes from this XXX call)
+            hashes,  # [1] block_hashes
             self._medium.value,  # [2] medium / device tier
         ]
 

--- a/kv_connectors/llmd_fs_backend/tests/test_storage_events.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_storage_events.py
@@ -195,9 +195,13 @@ class FakeZMQContext:
 class RecordingPublisher:
     def __init__(self):
         self.stored_calls = []
+        self.removed_calls = []
 
     def publish_blocks_stored(self, block_hashes):
         self.stored_calls.append(list(block_hashes))
+
+    def publish_blocks_removed(self, block_hashes, model_name=None):
+        self.removed_calls.append((model_name, list(block_hashes)))
 
 
 class ExplodingPublisher:
@@ -334,3 +338,76 @@ def test_nixl_manager_does_not_publish_or_record_failed_stores():
 
     assert publisher.stored_calls == []
     assert manager._stored_keys == set()
+
+
+def test_publish_blocks_removed_emits_correct_event_format(monkeypatch):
+    publisher, ctx = _publisher_with_fake_zmq(monkeypatch)
+
+    publisher.publish_blocks_removed([0xABCDEF0123456789, 0x1234])
+
+    assert len(ctx.socket_instance.sent) == 1
+
+    topic, seq, payload = ctx.socket_instance.sent[0]
+    assert topic == b"kv@SHARED_STORAGE@test-model"
+    assert struct.unpack(">Q", seq)[0] == 1
+
+    timestamp, raw_events = msgpack.unpackb(payload, raw=False)
+    assert isinstance(timestamp, float)
+    assert len(raw_events) == 1
+
+    event = msgpack.unpackb(raw_events[0], raw=False)
+    assert event == [
+        "BlockRemoved",
+        [0xABCDEF0123456789, 0x1234],
+        "SHARED_STORAGE",
+    ]
+
+
+def test_publish_blocks_removed_with_model_name_override(monkeypatch):
+    publisher, ctx = _publisher_with_fake_zmq(monkeypatch)
+
+    publisher.publish_blocks_removed([0x1234], model_name="other-model")
+
+    topic, _, _ = ctx.socket_instance.sent[0]
+    assert topic == b"kv@SHARED_STORAGE@other-model"
+
+
+def test_publish_blocks_removed_empty_hashes_is_noop(monkeypatch):
+    publisher, ctx = _publisher_with_fake_zmq(monkeypatch)
+
+    publisher.publish_blocks_removed([])
+
+    assert len(ctx.socket_instance.sent) == 0
+
+
+def test_publisher_without_model_name(monkeypatch):
+    ctx = FakeZMQContext()
+    monkeypatch.setattr(event_publisher_module.zmq, "Context", lambda: ctx)
+
+    publisher = StorageEventPublisher("tcp://*:5559")
+    assert publisher._topic is None
+
+    publisher.publish_blocks_removed([0x1234], model_name="some-model")
+
+    topic, _, _ = ctx.socket_instance.sent[0]
+    assert topic == b"kv@SHARED_STORAGE@some-model"
+
+
+def test_publish_blocks_removed_uses_instance_topic_when_no_override(monkeypatch):
+    publisher, ctx = _publisher_with_fake_zmq(monkeypatch)
+
+    publisher.publish_blocks_removed([0x1234])
+
+    topic, _, _ = ctx.socket_instance.sent[0]
+    assert topic == b"kv@SHARED_STORAGE@test-model"
+
+
+def test_publish_blocks_removed_masks_to_uint64(monkeypatch):
+    publisher, ctx = _publisher_with_fake_zmq(monkeypatch)
+
+    publisher.publish_blocks_removed([(1 << 72) + 5, b"\x01\x02"])
+
+    _, _, payload = ctx.socket_instance.sent[0]
+    _, raw_events = msgpack.unpackb(payload, raw=False)
+    event = msgpack.unpackb(raw_events[0], raw=False)
+    assert event[1] == [5, 0x0102]

--- a/kv_connectors/pvc_evictor/config.py
+++ b/kv_connectors/pvc_evictor/config.py
@@ -17,6 +17,7 @@ DEFAULT_FILE_QUEUE_MIN_SIZE = 1000
 DEFAULT_DELETION_BATCH_SIZE = 100
 DEFAULT_FILE_ACCESS_TIME_THRESHOLD_MINUTES = 60.0
 DEFAULT_HEX_BUCKET_LEN = 3
+DEFAULT_STORAGE_EVENTS_ENDPOINT = ""
 
 
 @dataclass
@@ -40,6 +41,7 @@ class Config:
     hex_bucket_len: int  # Number of hex chars in the first-level bucket directory (default: 3)
     # log_file_path: Optional file logging for persistent log storage and debugging
     log_file_path: str | None = None  # Optional file path to write logs to (default: None, stdout only)
+    storage_events_endpoint: str = ""  # Storage events publisher endpoint
 
     def to_dict(self) -> dict:
         """Convert configuration to dictionary for multiprocessing."""
@@ -56,6 +58,7 @@ class Config:
             "log_file_path": self.log_file_path,
             "file_access_time_threshold_minutes": self.file_access_time_threshold_minutes,
             "hex_bucket_len": self.hex_bucket_len,
+            "storage_events_endpoint": self.storage_events_endpoint,
         }
 
     @classmethod
@@ -81,4 +84,7 @@ class Config:
                 )
             ),
             hex_bucket_len=int(float(os.getenv("HEX_BUCKET_LEN", str(DEFAULT_HEX_BUCKET_LEN)))),
+            storage_events_endpoint=os.getenv(
+                "STORAGE_EVENTS_ENDPOINT", str(DEFAULT_STORAGE_EVENTS_ENDPOINT)
+            ),
         )

--- a/kv_connectors/pvc_evictor/config.py
+++ b/kv_connectors/pvc_evictor/config.py
@@ -84,7 +84,5 @@ class Config:
                 )
             ),
             hex_bucket_len=int(float(os.getenv("HEX_BUCKET_LEN", str(DEFAULT_HEX_BUCKET_LEN)))),
-            storage_events_endpoint=os.getenv(
-                "STORAGE_EVENTS_ENDPOINT", str(DEFAULT_STORAGE_EVENTS_ENDPOINT)
-            ),
+            storage_events_endpoint=os.getenv("STORAGE_EVENTS_ENDPOINT", str(DEFAULT_STORAGE_EVENTS_ENDPOINT)),
         )

--- a/kv_connectors/pvc_evictor/processes/deleter.py
+++ b/kv_connectors/pvc_evictor/processes/deleter.py
@@ -73,17 +73,17 @@ def extract_model_name(file_path: str, cache_path: str) -> str | None:
     return model_name
 
 
-def delete_batch(file_paths: list[str], dry_run: bool, logger: logging.Logger) -> tuple[int, int]:
+def delete_batch(file_paths: list[str], dry_run: bool, logger: logging.Logger) -> tuple[int, int, list[str]]:
     """
     Delete a batch of files using xargs rm -f (batch deletion).
 
     If xargs fails, logs error and skips the batch (files will be retried in next cycle).
 
-    Returns: (files_deleted, bytes_freed)
+    Returns: (files_deleted, bytes_freed, deleted_paths)
     """
     if dry_run:
         logger.debug(f"[DRY RUN] Would delete {len(file_paths)} files")
-        return len(file_paths), 0
+        return len(file_paths), 0, []
 
     valid_paths = []
     total_bytes = 0
@@ -103,7 +103,7 @@ def delete_batch(file_paths: list[str], dry_run: bool, logger: logging.Logger) -
         # All files in batch don't exist (already deleted or invalid paths)
         # This is normal - files may have been deleted between queuing and processing
         # or the same files were queued multiple times
-        return 0, 0
+        return 0, 0, []
 
     # Use xargs rm -f for batch deletion
     # Use null-terminated input for xargs -0 (safe handling of file paths with special characters)
@@ -118,7 +118,7 @@ def delete_batch(file_paths: list[str], dry_run: bool, logger: logging.Logger) -
         )
 
         if result.returncode == 0:
-            return len(valid_paths), total_bytes
+            return len(valid_paths), total_bytes, valid_paths
         else:
             # Log error and skip batch - files will be retried in next cycle
             logger.error(
@@ -127,18 +127,18 @@ def delete_batch(file_paths: list[str], dry_run: bool, logger: logging.Logger) -
             )
             if result.stderr:
                 logger.debug(f"xargs stderr: {result.stderr.decode('utf-8', errors='ignore')}")
-            return 0, 0
+            return 0, 0, []
     except subprocess.TimeoutExpired:
         logger.error(
             f"xargs rm timed out, skipping batch of {len(valid_paths)} files. Files will be retried in next cycle."
         )
-        return 0, 0
+        return 0, 0, []
     except Exception as e:
         logger.error(
             f"Batch deletion error: {e}, skipping batch of {len(valid_paths)} files. "
             f"Files will be retried in next cycle."
         )
-        return 0, 0
+        return 0, 0, []
 
 
 def delete_file_batch(
@@ -159,13 +159,13 @@ def delete_file_batch(
     Returns: (updated_total_files_deleted, updated_total_bytes_freed, batch_start_time)
     """
     batch_start_time = time.time()
-    deleted, freed = delete_batch(batch, dry_run, logger)
+    deleted, freed, deleted_paths = delete_batch(batch, dry_run, logger)
 
-    if deleted > 0 and event_publisher is not None and cache_path is not None:
+    if deleted_paths and event_publisher is not None and cache_path is not None:
         model_hashes = {}
-        for b in batch:
-            h = extract_block_hash(b)
-            model = extract_model_name(b, str(cache_path))
+        for p in deleted_paths:
+            h = extract_block_hash(p)
+            model = extract_model_name(p, str(cache_path))
             if h is not None and model is not None:
                 model_hashes.setdefault(model, []).append(h)
 
@@ -322,7 +322,7 @@ def deleter_process(
 
         # Delete remaining batch on shutdown
         if current_batch:
-            deleted, freed = delete_batch(current_batch, dry_run, logger)
+            deleted, freed, _ = delete_batch(current_batch, dry_run, logger)
             total_files_deleted += deleted
             total_bytes_freed += freed
 

--- a/kv_connectors/pvc_evictor/processes/deleter.py
+++ b/kv_connectors/pvc_evictor/processes/deleter.py
@@ -1,9 +1,11 @@
 """Deleter process for batch file deletion."""
 
 import contextlib
-import os
+import json
 import logging
 import multiprocessing
+import os
+import re
 import subprocess
 import time
 from pathlib import Path
@@ -13,9 +15,11 @@ from utils.system import setup_logging
 # Constants for timing
 PARTIAL_BATCH_TIMEOUT_SECONDS = 5.0  # Process partial batch after N seconds of inactivity
 
+_model_name_cache: dict[str, str | None] = {}
+
 
 def extract_block_hash(file_path: str) -> int | None:
-    """Extract block hash from a file path like .../abc/de/abcdef0123456789.bin"""
+    """Extract block hash from a file path like .../abc/de_g0/abcdef0123456789.bin"""
     basename = os.path.basename(file_path)
     if not basename.endswith(".bin"):
         return None
@@ -34,9 +38,10 @@ def extract_model_name(file_path: str, cache_path: str) -> str | None:
     """Extract the model name from the directory structure.
 
     The FileMapper layout is:
-        <cache_path>/<model_name>/block_size_.../tp_.../rank_.../<dtype>/hhh/hh/hash.bin
+        <cache_path>/<safe_model_name>_<sha256[:12]>_r<rank>/hhh/hh_g<idx>/hash.bin
 
-    The model name may contain slashes (e.g. "meta-llama/Llama-3.1-8B").
+    The original model name is read from config.json at:
+        <cache_path>/<safe_model_name>_<sha256[:12]>/config.json
     """
     try:
         relative = os.path.relpath(file_path, cache_path)
@@ -44,13 +49,28 @@ def extract_model_name(file_path: str, cache_path: str) -> str | None:
         return None
 
     parts = relative.split(os.sep)
-    for i, part in enumerate(parts):
-        if part.startswith("block_size_"):
-            if i == 0:
-                return None
-            return os.sep.join(parts[:i])
+    if len(parts) < 2:
+        return None
 
-    return None
+    rank_dir = parts[0]
+    match = re.match(r"^(.+)_r\d+$", rank_dir)
+    if not match:
+        return None
+
+    base_dir_path = os.path.join(cache_path, match.group(1))
+
+    if base_dir_path in _model_name_cache:
+        return _model_name_cache[base_dir_path]
+
+    config_path = os.path.join(base_dir_path, "config.json")
+    try:
+        with open(config_path) as f:
+            model_name = json.load(f).get("model_name")
+    except (OSError, json.JSONDecodeError):
+        model_name = None
+
+    _model_name_cache[base_dir_path] = model_name
+    return model_name
 
 
 def delete_batch(file_paths: list[str], dry_run: bool, logger: logging.Logger) -> tuple[int, int]:

--- a/kv_connectors/pvc_evictor/processes/deleter.py
+++ b/kv_connectors/pvc_evictor/processes/deleter.py
@@ -322,9 +322,18 @@ def deleter_process(
 
         # Delete remaining batch on shutdown
         if current_batch:
-            deleted, freed, _ = delete_batch(current_batch, dry_run, logger)
-            total_files_deleted += deleted
-            total_bytes_freed += freed
+            total_files_deleted, total_bytes_freed, prev_batch_time = delete_file_batch(
+                current_batch,
+                dry_run,
+                logger,
+                process_id,
+                total_files_deleted,
+                total_bytes_freed,
+                prev_batch_time,
+                result_queue,
+                event_publisher,
+                cache_path,
+            )
 
     except Exception as e:
         logger.exception(f"Deleter P{process_num} error: {e}")

--- a/kv_connectors/pvc_evictor/processes/deleter.py
+++ b/kv_connectors/pvc_evictor/processes/deleter.py
@@ -1,6 +1,7 @@
 """Deleter process for batch file deletion."""
 
 import contextlib
+import os
 import logging
 import multiprocessing
 import subprocess
@@ -11,6 +12,45 @@ from utils.system import setup_logging
 
 # Constants for timing
 PARTIAL_BATCH_TIMEOUT_SECONDS = 5.0  # Process partial batch after N seconds of inactivity
+
+
+def extract_block_hash(file_path: str) -> int | None:
+    """Extract block hash from a file path like .../abc/de/abcdef0123456789.bin"""
+    basename = os.path.basename(file_path)
+    if not basename.endswith(".bin"):
+        return None
+
+    hex_str = basename[:-4]
+    if len(hex_str) != 16:
+        return None
+
+    try:
+        return int(hex_str, 16)
+    except ValueError:
+        return None
+
+
+def extract_model_name(file_path: str, cache_path: str) -> str | None:
+    """Extract the model name from the directory structure.
+
+    The FileMapper layout is:
+        <cache_path>/<model_name>/block_size_.../tp_.../rank_.../<dtype>/hhh/hh/hash.bin
+
+    The model name may contain slashes (e.g. "meta-llama/Llama-3.1-8B").
+    """
+    try:
+        relative = os.path.relpath(file_path, cache_path)
+    except ValueError:
+        return None
+
+    parts = relative.split(os.sep)
+    for i, part in enumerate(parts):
+        if part.startswith("block_size_"):
+            if i == 0:
+                return None
+            return os.sep.join(parts[:i])
+
+    return None
 
 
 def delete_batch(file_paths: list[str], dry_run: bool, logger: logging.Logger) -> tuple[int, int]:
@@ -90,6 +130,8 @@ def delete_file_batch(
     total_bytes_freed: int,
     prev_batch_time: float | None,
     result_queue: multiprocessing.Queue,
+    event_publisher=None,
+    cache_path=None,
 ) -> tuple[int, int, float]:
     """
     Process a batch of files for deletion and report progress to main process.
@@ -98,6 +140,20 @@ def delete_file_batch(
     """
     batch_start_time = time.time()
     deleted, freed = delete_batch(batch, dry_run, logger)
+
+    if deleted > 0 and event_publisher is not None and cache_path is not None:
+        model_hashes = {}
+        for b in batch:
+            h = extract_block_hash(b)
+            model = extract_model_name(b, str(cache_path))
+            if h is not None and model is not None:
+                model_hashes.setdefault(model, []).append(h)
+
+        for model, hashes in model_hashes.items():
+            try:
+                event_publisher.publish_blocks_removed(hashes, model_name=model)
+            except Exception:
+                logger.warning("Failed to publish deletion events", exc_info=True)
 
     total_files_deleted += deleted
     total_bytes_freed += freed
@@ -143,6 +199,27 @@ def deleter_process(
     partial_batch_timeout = PARTIAL_BATCH_TIMEOUT_SECONDS
     last_idle_log_time = 0.0
 
+    event_publisher = None
+    endpoint = config_dict.get("storage_events_endpoint", "")
+
+    if endpoint:
+        try:
+            from llmd_fs_backend.event_publisher import (
+                StorageEventPublisher,
+                StorageMedium,
+            )
+
+            event_publisher = StorageEventPublisher(
+                endpoint=endpoint,
+                medium=StorageMedium.SHARED_STORAGE,
+            )
+            logger.info(
+                "Storage event publisher created: endpoint=%s",
+                endpoint,
+            )
+        except Exception:
+            logger.warning("Failed to create storage event publisher", exc_info=True)
+
     try:
         while not shutdown_event.is_set():
             # Only process when deletion is ON
@@ -165,6 +242,8 @@ def deleter_process(
                                 total_bytes_freed,
                                 prev_batch_time,
                                 result_queue,
+                                event_publisher,
+                                cache_path,
                             )
                             current_batch = []
 
@@ -200,6 +279,8 @@ def deleter_process(
                             total_bytes_freed,
                             prev_batch_time,
                             result_queue,
+                            event_publisher,
+                            cache_path,
                         )
                         current_batch = []
                         last_batch_check_time = current_time

--- a/kv_connectors/pvc_evictor/tests/test_deleter.py
+++ b/kv_connectors/pvc_evictor/tests/test_deleter.py
@@ -1,11 +1,13 @@
 """Tests for deleter process helper functions and event publishing integration."""
 
 import importlib.util
+import json
 import logging
-import os
 import sys
 import types
 from pathlib import Path
+
+import pytest
 
 PVC_ROOT = Path(__file__).resolve().parents[1]
 
@@ -48,11 +50,24 @@ extract_model_name = _deleter.extract_model_name
 delete_file_batch = _deleter.delete_file_batch
 
 
+@pytest.fixture(autouse=True)
+def _clear_model_name_cache():
+    _deleter._model_name_cache.clear()
+    yield
+    _deleter._model_name_cache.clear()
+
+
+def _write_config(cache_path: Path, base_dir_name: str, model_name: str) -> None:
+    base_dir = cache_path / base_dir_name
+    base_dir.mkdir(parents=True, exist_ok=True)
+    (base_dir / "config.json").write_text(json.dumps({"model_name": model_name}))
+
+
 # -- extract_block_hash tests --
 
 
 def test_extract_block_hash_valid_path():
-    path = "/cache/model/block_size_16/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin"
+    path = "/cache/my-model_abc123def456_r0/abc/de_g0/abcdef0123456789.bin"
     assert extract_block_hash(path) == 0xABCDEF0123456789
 
 
@@ -93,42 +108,47 @@ def test_extract_block_hash_directory_path():
 # -- extract_model_name tests --
 
 
-def test_extract_model_name_simple():
-    cache_path = "/kv-cache/models"
-    file_path = f"{cache_path}/my-model/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin"
-    assert extract_model_name(file_path, cache_path) == "my-model"
+def test_extract_model_name_simple(tmp_path):
+    cache_path = tmp_path / "models"
+    _write_config(cache_path, "my-model_abcdef012345", "my-model")
+
+    file_path = str(cache_path / "my-model_abcdef012345_r0/abc/de_g0/abcdef0123456789.bin")
+    assert extract_model_name(file_path, str(cache_path)) == "my-model"
 
 
-def test_extract_model_name_hf_style_with_slash():
-    cache_path = "/kv-cache/models"
-    file_path = f"{cache_path}/meta-llama/Llama-3.1-8B/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin"
-    assert extract_model_name(file_path, cache_path) == os.sep.join(
-        ["meta-llama", "Llama-3.1-8B"]
-    )
+def test_extract_model_name_hf_style(tmp_path):
+    cache_path = tmp_path / "models"
+    _write_config(cache_path, "meta-llama_Llama-3.1-8B_fedcba987654", "meta-llama/Llama-3.1-8B")
+
+    file_path = str(cache_path / "meta-llama_Llama-3.1-8B_fedcba987654_r0/abc/de_g0/abcdef0123456789.bin")
+    assert extract_model_name(file_path, str(cache_path)) == "meta-llama/Llama-3.1-8B"
 
 
-def test_extract_model_name_deeply_nested_org():
-    cache_path = "/kv-cache/models"
-    file_path = f"{cache_path}/org/sub/model/block_size_32_blocks_per_file_2/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin"
-    assert extract_model_name(file_path, cache_path) == os.sep.join(
-        ["org", "sub", "model"]
-    )
+def test_extract_model_name_no_rank_suffix():
+    assert extract_model_name("/cache/some_dir/abc/de_g0/hash.bin", "/cache") is None
 
 
-def test_extract_model_name_no_block_size_marker():
-    cache_path = "/kv-cache/models"
-    file_path = f"{cache_path}/my-model/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin"
-    assert extract_model_name(file_path, cache_path) is None
+def test_extract_model_name_no_config_json(tmp_path):
+    cache_path = tmp_path / "models"
+    file_path = str(cache_path / "no-config_aaaaaaaaaaaa_r0/abc/de_g0/hash.bin")
+    assert extract_model_name(file_path, str(cache_path)) is None
 
 
-def test_extract_model_name_block_size_at_root():
-    cache_path = "/kv-cache/models"
-    file_path = f"{cache_path}/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin"
-    assert extract_model_name(file_path, cache_path) is None
+def test_extract_model_name_too_few_path_components():
+    assert extract_model_name("/cache/file.bin", "/cache") is None
 
 
-def test_extract_model_name_file_outside_cache_path():
-    assert extract_model_name("/other/path/file.bin", "/kv-cache/models") is None
+def test_extract_model_name_caches_result(tmp_path):
+    cache_path = tmp_path / "models"
+    _write_config(cache_path, "cached-model_abcdef012345", "cached-model")
+
+    file_a = str(cache_path / "cached-model_abcdef012345_r0/abc/de_g0/aaaaaaaaaaaaaaaa.bin")
+    file_b = str(cache_path / "cached-model_abcdef012345_r0/fff/ff_g0/ffffffffffffffff.bin")
+
+    assert extract_model_name(file_a, str(cache_path)) == "cached-model"
+    # Delete config.json — second call should still work from cache
+    (cache_path / "cached-model_abcdef012345" / "config.json").unlink()
+    assert extract_model_name(file_b, str(cache_path)) == "cached-model"
 
 
 # -- delete_file_batch event publishing integration --
@@ -155,12 +175,15 @@ class ExplodingPublisher:
         raise RuntimeError("publish failed")
 
 
-def test_delete_file_batch_publishes_events_grouped_by_model(monkeypatch):
-    cache_path = "/kv-cache/models"
+def test_delete_file_batch_publishes_events_grouped_by_model(tmp_path, monkeypatch):
+    cache_path = tmp_path / "models"
+    _write_config(cache_path, "meta-llama_Llama-3.1-8B_aaaaaaaaaaaa", "meta-llama/Llama-3.1-8B")
+    _write_config(cache_path, "other-model_bbbbbbbbbbbb", "other-model")
+
     files = [
-        f"{cache_path}/meta-llama/Llama-3.1-8B/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin",
-        f"{cache_path}/meta-llama/Llama-3.1-8B/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/123/45/1234567890abcdef.bin",
-        f"{cache_path}/other-model/block_size_32_blocks_per_file_1/tp_1/rank_0/float16/fed/cb/fedcba9876543210.bin",
+        str(cache_path / "meta-llama_Llama-3.1-8B_aaaaaaaaaaaa_r0/abc/de_g0/abcdef0123456789.bin"),
+        str(cache_path / "meta-llama_Llama-3.1-8B_aaaaaaaaaaaa_r0/123/45_g0/1234567890abcdef.bin"),
+        str(cache_path / "other-model_bbbbbbbbbbbb_r0/fed/cb_g0/fedcba9876543210.bin"),
     ]
 
     publisher = RecordingPublisher()
@@ -169,15 +192,13 @@ def test_delete_file_batch_publishes_events_grouped_by_model(monkeypatch):
 
     monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (len(paths), 1024))
 
-    delete_file_batch(
-        files, False, logger, "P1", 0, 0, None, queue, publisher, cache_path
-    )
+    delete_file_batch(files, False, logger, "P1", 0, 0, None, queue, publisher, str(cache_path))
 
     assert len(publisher.calls) == 2
     publisher.calls.sort(key=lambda x: x[0])
 
     model1, hashes1 = publisher.calls[0]
-    assert model1 == os.sep.join(["meta-llama", "Llama-3.1-8B"])
+    assert model1 == "meta-llama/Llama-3.1-8B"
     assert len(hashes1) == 2
     assert 0xABCDEF0123456789 in hashes1
     assert 0x1234567890ABCDEF in hashes1
@@ -188,48 +209,39 @@ def test_delete_file_batch_publishes_events_grouped_by_model(monkeypatch):
 
 
 def test_delete_file_batch_no_events_when_publisher_is_none(monkeypatch):
-    cache_path = "/kv-cache/models"
-    files = [
-        f"{cache_path}/model/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin",
-    ]
+    files = ["/cache/model_aaa_r0/abc/de_g0/abcdef0123456789.bin"]
     queue = FakeQueue()
     logger = logging.getLogger("test_deleter")
 
     monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (1, 512))
 
-    total_deleted, total_freed, _ = delete_file_batch(
-        files, False, logger, "P1", 0, 0, None, queue, None, None
-    )
+    total_deleted, total_freed, _ = delete_file_batch(files, False, logger, "P1", 0, 0, None, queue, None, None)
 
     assert total_deleted == 1
     assert total_freed == 512
 
 
-def test_delete_file_batch_no_events_when_nothing_deleted(monkeypatch):
-    cache_path = "/kv-cache/models"
-    files = [
-        f"{cache_path}/model/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin",
-    ]
+def test_delete_file_batch_no_events_when_nothing_deleted(tmp_path, monkeypatch):
+    cache_path = tmp_path / "models"
+    _write_config(cache_path, "model_aaaaaaaaaaaa", "model")
 
+    files = [str(cache_path / "model_aaaaaaaaaaaa_r0/abc/de_g0/abcdef0123456789.bin")]
     publisher = RecordingPublisher()
     queue = FakeQueue()
     logger = logging.getLogger("test_deleter")
 
     monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (0, 0))
 
-    delete_file_batch(
-        files, False, logger, "P1", 0, 0, None, queue, publisher, cache_path
-    )
+    delete_file_batch(files, False, logger, "P1", 0, 0, None, queue, publisher, str(cache_path))
 
     assert publisher.calls == []
 
 
-def test_delete_file_batch_publish_failure_is_fail_open(monkeypatch):
-    cache_path = "/kv-cache/models"
-    files = [
-        f"{cache_path}/model/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin",
-    ]
+def test_delete_file_batch_publish_failure_is_fail_open(tmp_path, monkeypatch):
+    cache_path = tmp_path / "models"
+    _write_config(cache_path, "model_aaaaaaaaaaaa", "model")
 
+    files = [str(cache_path / "model_aaaaaaaaaaaa_r0/abc/de_g0/abcdef0123456789.bin")]
     publisher = ExplodingPublisher()
     queue = FakeQueue()
     logger = logging.getLogger("test_deleter")
@@ -237,19 +249,21 @@ def test_delete_file_batch_publish_failure_is_fail_open(monkeypatch):
     monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (1, 512))
 
     total_deleted, total_freed, _ = delete_file_batch(
-        files, False, logger, "P1", 0, 0, None, queue, publisher, cache_path
+        files, False, logger, "P1", 0, 0, None, queue, publisher, str(cache_path)
     )
 
     assert total_deleted == 1
     assert total_freed == 512
 
 
-def test_delete_file_batch_skips_unparseable_paths(monkeypatch):
-    cache_path = "/kv-cache/models"
+def test_delete_file_batch_skips_unparsable_paths(tmp_path, monkeypatch):
+    cache_path = tmp_path / "models"
+    _write_config(cache_path, "model_aaaaaaaaaaaa", "model")
+
     files = [
-        f"{cache_path}/model/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin",
+        str(cache_path / "model_aaaaaaaaaaaa_r0/abc/de_g0/abcdef0123456789.bin"),
         "/some/random/file.txt",
-        f"{cache_path}/model/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/no-hash-dir/bad.bin",
+        str(cache_path / "model_aaaaaaaaaaaa_r0/no-hash-dir/bad.bin"),
     ]
 
     publisher = RecordingPublisher()
@@ -258,9 +272,7 @@ def test_delete_file_batch_skips_unparseable_paths(monkeypatch):
 
     monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (len(paths), 1024))
 
-    delete_file_batch(
-        files, False, logger, "P1", 0, 0, None, queue, publisher, cache_path
-    )
+    delete_file_batch(files, False, logger, "P1", 0, 0, None, queue, publisher, str(cache_path))
 
     assert len(publisher.calls) == 1
     model, hashes = publisher.calls[0]

--- a/kv_connectors/pvc_evictor/tests/test_deleter.py
+++ b/kv_connectors/pvc_evictor/tests/test_deleter.py
@@ -1,0 +1,268 @@
+"""Tests for deleter process helper functions and event publishing integration."""
+
+import importlib.util
+import logging
+import os
+import sys
+import types
+from pathlib import Path
+
+PVC_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_deleter():
+    """Load deleter module with stubs for utils.system."""
+    utils_pkg = types.ModuleType("utils")
+    utils_pkg.__path__ = []
+    utils_system = types.ModuleType("utils.system")
+    utils_system.setup_logging = lambda *args, **kwargs: None
+
+    sentinel = object()
+    saved = {}
+    for name in ["utils", "utils.system"]:
+        saved[name] = sys.modules.get(name, sentinel)
+
+    sys.modules["utils"] = utils_pkg
+    sys.modules["utils.system"] = utils_system
+
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "processes.deleter",
+            PVC_ROOT / "processes" / "deleter.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    finally:
+        for name, previous in saved.items():
+            if previous is sentinel:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+
+    return mod
+
+
+_deleter = _load_deleter()
+extract_block_hash = _deleter.extract_block_hash
+extract_model_name = _deleter.extract_model_name
+delete_file_batch = _deleter.delete_file_batch
+
+
+# -- extract_block_hash tests --
+
+
+def test_extract_block_hash_valid_path():
+    path = "/cache/model/block_size_16/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin"
+    assert extract_block_hash(path) == 0xABCDEF0123456789
+
+
+def test_extract_block_hash_all_zeros():
+    path = "/cache/0000000000000000.bin"
+    assert extract_block_hash(path) == 0
+
+
+def test_extract_block_hash_max_value():
+    path = "/cache/ffffffffffffffff.bin"
+    assert extract_block_hash(path) == 0xFFFFFFFFFFFFFFFF
+
+
+def test_extract_block_hash_not_bin_extension():
+    assert extract_block_hash("/cache/abcdef0123456789.txt") is None
+
+
+def test_extract_block_hash_no_extension():
+    assert extract_block_hash("/cache/abcdef0123456789") is None
+
+
+def test_extract_block_hash_wrong_hex_length_short():
+    assert extract_block_hash("/cache/abcdef.bin") is None
+
+
+def test_extract_block_hash_wrong_hex_length_long():
+    assert extract_block_hash("/cache/abcdef01234567890.bin") is None
+
+
+def test_extract_block_hash_invalid_hex_chars():
+    assert extract_block_hash("/cache/ghijklmnopqrstuv.bin") is None
+
+
+def test_extract_block_hash_directory_path():
+    assert extract_block_hash("/cache/abc/de/") is None
+
+
+# -- extract_model_name tests --
+
+
+def test_extract_model_name_simple():
+    cache_path = "/kv-cache/models"
+    file_path = f"{cache_path}/my-model/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin"
+    assert extract_model_name(file_path, cache_path) == "my-model"
+
+
+def test_extract_model_name_hf_style_with_slash():
+    cache_path = "/kv-cache/models"
+    file_path = f"{cache_path}/meta-llama/Llama-3.1-8B/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin"
+    assert extract_model_name(file_path, cache_path) == os.sep.join(
+        ["meta-llama", "Llama-3.1-8B"]
+    )
+
+
+def test_extract_model_name_deeply_nested_org():
+    cache_path = "/kv-cache/models"
+    file_path = f"{cache_path}/org/sub/model/block_size_32_blocks_per_file_2/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin"
+    assert extract_model_name(file_path, cache_path) == os.sep.join(
+        ["org", "sub", "model"]
+    )
+
+
+def test_extract_model_name_no_block_size_marker():
+    cache_path = "/kv-cache/models"
+    file_path = f"{cache_path}/my-model/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin"
+    assert extract_model_name(file_path, cache_path) is None
+
+
+def test_extract_model_name_block_size_at_root():
+    cache_path = "/kv-cache/models"
+    file_path = f"{cache_path}/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin"
+    assert extract_model_name(file_path, cache_path) is None
+
+
+def test_extract_model_name_file_outside_cache_path():
+    assert extract_model_name("/other/path/file.bin", "/kv-cache/models") is None
+
+
+# -- delete_file_batch event publishing integration --
+
+
+class FakeQueue:
+    def __init__(self):
+        self.items = []
+
+    def put(self, item, timeout=None):
+        self.items.append(item)
+
+
+class RecordingPublisher:
+    def __init__(self):
+        self.calls = []
+
+    def publish_blocks_removed(self, block_hashes, model_name=None):
+        self.calls.append((model_name, list(block_hashes)))
+
+
+class ExplodingPublisher:
+    def publish_blocks_removed(self, block_hashes, model_name=None):
+        raise RuntimeError("publish failed")
+
+
+def test_delete_file_batch_publishes_events_grouped_by_model(monkeypatch):
+    cache_path = "/kv-cache/models"
+    files = [
+        f"{cache_path}/meta-llama/Llama-3.1-8B/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin",
+        f"{cache_path}/meta-llama/Llama-3.1-8B/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/123/45/1234567890abcdef.bin",
+        f"{cache_path}/other-model/block_size_32_blocks_per_file_1/tp_1/rank_0/float16/fed/cb/fedcba9876543210.bin",
+    ]
+
+    publisher = RecordingPublisher()
+    logger = logging.getLogger("test_deleter")
+    queue = FakeQueue()
+
+    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (len(paths), 1024))
+
+    delete_file_batch(
+        files, False, logger, "P1", 0, 0, None, queue, publisher, cache_path
+    )
+
+    assert len(publisher.calls) == 2
+    publisher.calls.sort(key=lambda x: x[0])
+
+    model1, hashes1 = publisher.calls[0]
+    assert model1 == os.sep.join(["meta-llama", "Llama-3.1-8B"])
+    assert len(hashes1) == 2
+    assert 0xABCDEF0123456789 in hashes1
+    assert 0x1234567890ABCDEF in hashes1
+
+    model2, hashes2 = publisher.calls[1]
+    assert model2 == "other-model"
+    assert hashes2 == [0xFEDCBA9876543210]
+
+
+def test_delete_file_batch_no_events_when_publisher_is_none(monkeypatch):
+    cache_path = "/kv-cache/models"
+    files = [
+        f"{cache_path}/model/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin",
+    ]
+    queue = FakeQueue()
+    logger = logging.getLogger("test_deleter")
+
+    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (1, 512))
+
+    total_deleted, total_freed, _ = delete_file_batch(
+        files, False, logger, "P1", 0, 0, None, queue, None, None
+    )
+
+    assert total_deleted == 1
+    assert total_freed == 512
+
+
+def test_delete_file_batch_no_events_when_nothing_deleted(monkeypatch):
+    cache_path = "/kv-cache/models"
+    files = [
+        f"{cache_path}/model/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin",
+    ]
+
+    publisher = RecordingPublisher()
+    queue = FakeQueue()
+    logger = logging.getLogger("test_deleter")
+
+    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (0, 0))
+
+    delete_file_batch(
+        files, False, logger, "P1", 0, 0, None, queue, publisher, cache_path
+    )
+
+    assert publisher.calls == []
+
+
+def test_delete_file_batch_publish_failure_is_fail_open(monkeypatch):
+    cache_path = "/kv-cache/models"
+    files = [
+        f"{cache_path}/model/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin",
+    ]
+
+    publisher = ExplodingPublisher()
+    queue = FakeQueue()
+    logger = logging.getLogger("test_deleter")
+
+    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (1, 512))
+
+    total_deleted, total_freed, _ = delete_file_batch(
+        files, False, logger, "P1", 0, 0, None, queue, publisher, cache_path
+    )
+
+    assert total_deleted == 1
+    assert total_freed == 512
+
+
+def test_delete_file_batch_skips_unparseable_paths(monkeypatch):
+    cache_path = "/kv-cache/models"
+    files = [
+        f"{cache_path}/model/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/abc/de/abcdef0123456789.bin",
+        "/some/random/file.txt",
+        f"{cache_path}/model/block_size_16_blocks_per_file_1/tp_1/rank_0/float16/no-hash-dir/bad.bin",
+    ]
+
+    publisher = RecordingPublisher()
+    queue = FakeQueue()
+    logger = logging.getLogger("test_deleter")
+
+    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (len(paths), 1024))
+
+    delete_file_batch(
+        files, False, logger, "P1", 0, 0, None, queue, publisher, cache_path
+    )
+
+    assert len(publisher.calls) == 1
+    model, hashes = publisher.calls[0]
+    assert model == "model"
+    assert hashes == [0xABCDEF0123456789]

--- a/kv_connectors/pvc_evictor/tests/test_deleter.py
+++ b/kv_connectors/pvc_evictor/tests/test_deleter.py
@@ -190,7 +190,7 @@ def test_delete_file_batch_publishes_events_grouped_by_model(tmp_path, monkeypat
     logger = logging.getLogger("test_deleter")
     queue = FakeQueue()
 
-    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (len(paths), 1024))
+    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (len(paths), 1024, list(paths)))
 
     delete_file_batch(files, False, logger, "P1", 0, 0, None, queue, publisher, str(cache_path))
 
@@ -213,7 +213,7 @@ def test_delete_file_batch_no_events_when_publisher_is_none(monkeypatch):
     queue = FakeQueue()
     logger = logging.getLogger("test_deleter")
 
-    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (1, 512))
+    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (1, 512, list(paths)))
 
     total_deleted, total_freed, _ = delete_file_batch(files, False, logger, "P1", 0, 0, None, queue, None, None)
 
@@ -230,7 +230,7 @@ def test_delete_file_batch_no_events_when_nothing_deleted(tmp_path, monkeypatch)
     queue = FakeQueue()
     logger = logging.getLogger("test_deleter")
 
-    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (0, 0))
+    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (0, 0, []))
 
     delete_file_batch(files, False, logger, "P1", 0, 0, None, queue, publisher, str(cache_path))
 
@@ -246,7 +246,7 @@ def test_delete_file_batch_publish_failure_is_fail_open(tmp_path, monkeypatch):
     queue = FakeQueue()
     logger = logging.getLogger("test_deleter")
 
-    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (1, 512))
+    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (1, 512, list(paths)))
 
     total_deleted, total_freed, _ = delete_file_batch(
         files, False, logger, "P1", 0, 0, None, queue, publisher, str(cache_path)
@@ -270,7 +270,7 @@ def test_delete_file_batch_skips_unparsable_paths(tmp_path, monkeypatch):
     queue = FakeQueue()
     logger = logging.getLogger("test_deleter")
 
-    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (len(paths), 1024))
+    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (len(paths), 1024, list(paths)))
 
     delete_file_batch(files, False, logger, "P1", 0, 0, None, queue, publisher, str(cache_path))
 
@@ -278,3 +278,22 @@ def test_delete_file_batch_skips_unparsable_paths(tmp_path, monkeypatch):
     model, hashes = publisher.calls[0]
     assert model == "model"
     assert hashes == [0xABCDEF0123456789]
+
+
+def test_delete_file_batch_no_events_on_dry_run(tmp_path, monkeypatch):
+    cache_path = tmp_path / "models"
+    _write_config(cache_path, "model_aaaaaaaaaaaa", "model")
+
+    files = [str(cache_path / "model_aaaaaaaaaaaa_r0/abc/de_g0/abcdef0123456789.bin")]
+    publisher = RecordingPublisher()
+    queue = FakeQueue()
+    logger = logging.getLogger("test_deleter")
+
+    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (len(paths), 0, []))
+
+    total_deleted, total_freed, _ = delete_file_batch(
+        files, True, logger, "P1", 0, 0, None, queue, publisher, str(cache_path)
+    )
+
+    assert total_deleted == len(files)
+    assert publisher.calls == []


### PR DESCRIPTION
## Summary

This PR adds `BlockRemoved` event emission from the PVC evictor's deleter process, complementing the `BlockStored` events added in #571. When the evictor deletes KV cache files from shared storage, it now publishes `BlockRemoved` events so downstream consumers (e.g. the Go storage indexer) can remove stale checkpoints.

The implementation extends `StorageEventPublisher` with a `publish_blocks_removed()` method that supports per-call `model_name` overrides, since the evictor handles files from multiple models on the same PVC. The `model_name` constructor parameter is optional to just support this multi-model use case.

Block hashes are extracted by reversing the `FileMapper` filename convention (16-char hex basename), and the original model name is recovered from `config.json` at the FileMapper base directory. Model name lookups are cached per base directory so only one filesystem read occurs per model per process lifetime. Events are grouped by model and published after each successful batch deletion.

## Testing

All existing tests pass. This PR adds the new deleter tests and extends storage event tests.

Validated with:

```
pytest kv_connectors/pvc_evictor/tests/test_deleter.py -q
pytest kv_connectors/llmd_fs_backend/tests/test_storage_events.py -q
```

## Related Issues

- #520 

> [!NOTE]
> Test layout depends on wether #578 is merged before this one or not. 
