### PR TITLE
fix(pvc_evictor): walk current FileMapper layout in crawler

### DIFF
--- a/kv_connectors/pvc_evictor/config.py
+++ b/kv_connectors/pvc_evictor/config.py
@@ -16,6 +16,7 @@ DEFAULT_FILE_QUEUE_MAXSIZE = 10000
 DEFAULT_FILE_QUEUE_MIN_SIZE = 1000
 DEFAULT_DELETION_BATCH_SIZE = 100
 DEFAULT_FILE_ACCESS_TIME_THRESHOLD_MINUTES = 60.0
+DEFAULT_HEX_BUCKET_LEN = 3
 
 
 @dataclass
@@ -36,6 +37,7 @@ class Config:
     file_queue_min_size: int  # Min queue size to maintain when deletion OFF (default: 1000)
     deletion_batch_size: int  # Files per deletion batch (default: 100)
     file_access_time_threshold_minutes: float  # Skip files accessed within this time (default: 60.0 minutes)
+    hex_bucket_len: int  # Number of hex chars in the first-level bucket directory (default: 3)
     # log_file_path: Optional file logging for persistent log storage and debugging
     log_file_path: str | None = None  # Optional file path to write logs to (default: None, stdout only)
 
@@ -53,6 +55,7 @@ class Config:
             "file_queue_maxsize": self.file_queue_maxsize,
             "log_file_path": self.log_file_path,
             "file_access_time_threshold_minutes": self.file_access_time_threshold_minutes,
+            "hex_bucket_len": self.hex_bucket_len,
         }
 
     @classmethod
@@ -65,11 +68,11 @@ class Config:
             cache_directory=os.getenv("CACHE_DIRECTORY", DEFAULT_CACHE_DIRECTORY),
             dry_run=os.getenv("DRY_RUN", str(DEFAULT_DRY_RUN).lower()).lower() == "true",
             log_level=os.getenv("LOG_LEVEL", DEFAULT_LOG_LEVEL),
-            num_crawler_processes=int(os.getenv("NUM_CRAWLER_PROCESSES", str(DEFAULT_NUM_CRAWLER_PROCESSES))),
+            num_crawler_processes=int(float(os.getenv("NUM_CRAWLER_PROCESSES", str(DEFAULT_NUM_CRAWLER_PROCESSES)))),
             logger_interval=float(os.getenv("LOGGER_INTERVAL_SECONDS", str(DEFAULT_LOGGER_INTERVAL))),
-            file_queue_maxsize=int(os.getenv("FILE_QUEUE_MAXSIZE", str(DEFAULT_FILE_QUEUE_MAXSIZE))),
-            file_queue_min_size=int(os.getenv("FILE_QUEUE_MIN_SIZE", str(DEFAULT_FILE_QUEUE_MIN_SIZE))),
-            deletion_batch_size=int(os.getenv("DELETION_BATCH_SIZE", str(DEFAULT_DELETION_BATCH_SIZE))),
+            file_queue_maxsize=int(float(os.getenv("FILE_QUEUE_MAXSIZE", str(DEFAULT_FILE_QUEUE_MAXSIZE)))),
+            file_queue_min_size=int(float(os.getenv("FILE_QUEUE_MIN_SIZE", str(DEFAULT_FILE_QUEUE_MIN_SIZE)))),
+            deletion_batch_size=int(float(os.getenv("DELETION_BATCH_SIZE", str(DEFAULT_DELETION_BATCH_SIZE)))),
             log_file_path=os.getenv("LOG_FILE_PATH", None),
             file_access_time_threshold_minutes=float(
                 os.getenv(
@@ -77,4 +80,5 @@ class Config:
                     str(DEFAULT_FILE_ACCESS_TIME_THRESHOLD_MINUTES),
                 )
             ),
+            hex_bucket_len=int(float(os.getenv("HEX_BUCKET_LEN", str(DEFAULT_HEX_BUCKET_LEN)))),
         )

--- a/kv_connectors/pvc_evictor/processes/crawler.py
+++ b/kv_connectors/pvc_evictor/processes/crawler.py
@@ -11,17 +11,11 @@ from pathlib import Path
 from utils.logging_helpers import send_stats_to_queue
 from utils.system import setup_logging
 
-# FileMapper integration for canonical cache structure
-try:
-    from llmd_fs_backend.file_mapper import FileMapper
-
-    FILEMAPPER_AVAILABLE = True
-except ImportError:
-    FILEMAPPER_AVAILABLE = False
-    FileMapper = None
-
 # Module-level logger for functions
 logger = logging.getLogger(__name__)
+
+# Pattern for a rank-suffixed FileMapper base directory: <safe_model>_<sha>_r<rank>
+_RANK_DIR_RE = re.compile(r"_r\d+$")
 
 # Constants for hex modulo load balancing
 HEX_MODULO_BASE = 16  # Number of possible hex modulo values (0-15)
@@ -52,36 +46,6 @@ def hex_to_int(hex_str: str) -> int | None:
         return int(hex_str, 16)
     except (ValueError, TypeError):
         return None
-
-
-def parse_filemapper_params(dir_name: str, pattern: str) -> dict:
-    """
-    Parse FileMapper parameters from directory name.
-
-    Examples:
-        parse_filemapper_params("block_size_16_blocks_per_file_256",
-                               "block_size_{gpu_block_size}_blocks_per_file_{gpu_blocks_per_file}")
-        -> {"gpu_block_size": 16, "gpu_blocks_per_file": 256}
-    """
-    # Convert pattern to regex, replacing {X} with named capture groups
-    regex_pattern = pattern
-    param_names = re.findall(r"\{(\w+)\}", pattern)
-
-    for param in param_names:
-        regex_pattern = regex_pattern.replace(f"{{{param}}}", f"(?P<{param}>\\d+)")
-
-    match = re.match(regex_pattern, dir_name)
-    if not match:
-        return {}
-
-    # Convert matched values to integers
-    result = {}
-    for param in param_names:
-        value = match.group(param)
-        if value:
-            result[param] = int(value)
-
-    return result
 
 
 def get_hex_modulo_ranges(num_processes: int = 8) -> list[tuple[int, int]]:
@@ -116,134 +80,72 @@ def get_hex_modulo_ranges(num_processes: int = 8) -> list[tuple[int, int]]:
     return ranges
 
 
+def _iter_rank_dirs(cache_path: Path) -> Iterator[os.DirEntry]:
+    """
+    Recursively yield FileMapper rank directories under cache_path.
+
+    Since #585 the layout is <root>/<safe_model_name>_<sha256>_r<rank>/, where
+    <safe_model_name> contains '_'-flattened HuggingFace IDs like
+    'Qwen_Qwen3-7B'. Rank directories are recognized purely by the trailing
+    '_r<digits>' suffix on a directory name, regardless of how deep they sit.
+    """
+    stack: list[str] = [str(cache_path)]
+    while stack:
+        current = stack.pop()
+        for entry in safe_scandir(current):
+            # follow_symlinks=False: avoid unbounded recursion if a symlink
+            # cycle is present under the cache root.
+            if not entry.is_dir(follow_symlinks=False):
+                continue
+            if _RANK_DIR_RE.search(entry.name):
+                yield entry
+            else:
+                stack.append(entry.path)
+
+
 def stream_cache_files_with_mapper(cache_path: Path, hex_modulo_range: tuple[int, int] | None = None) -> Iterator[Path]:
     """
-    Stream cache files using FileMapper structure for canonical traversal.
+    Stream cache files under the collapsed FileMapper layout introduced in #585.
 
-    This function streams through FileMapper configurations in the cache directory
-    and uses FileMapper.base_path to traverse the canonical structure:
+    On-disk layout:
+        <root>/<safe_model_name>_<sha256-12>_r<rank>/<hhh>/<hh>_g<group_idx>/*.bin
 
-    {model}/block_size_{X}_blocks_per_file_{Y}/tp_{tp}_pp_size_{pp}_pcp_size_{pcp}/
-    rank_{rank}/{dtype}/{hhh}/{hh}/*.bin
+    The walker recognizes rank directories by the '_r<digits>' suffix, then
+    iterates the first-level hex bucket ({hhh}, three hex chars), filters by
+    hex_modulo_range, and yields *.bin files from any second-level bucket
+    underneath (typically {hh}_g{group_idx}, but kept agnostic so we don't
+    depend on the group-index encoding).
 
-    Yields path objects for .bin files in FileMapper structure
+    Yields Path objects.
     """
     if not cache_path.exists():
-        logger.warning(f"FileMapper: cache_path does not exist: {cache_path}")
+        logger.warning(f"cache_path does not exist: {cache_path}")
         return
 
-    if not FILEMAPPER_AVAILABLE:
-        # FileMapper not available - this should not happen if properly configured
-        # Fall back to vLLM structure
-        logger.warning("FileMapper: FILEMAPPER_AVAILABLE is False")
-        return
+    modulo_range_min, modulo_range_max = hex_modulo_range if hex_modulo_range else (0, HEX_MODULO_BASE - 1)
 
-    modulo_range_min, modulo_range_max = hex_modulo_range if hex_modulo_range else (0, 15)
-
-    # Iterate through models
-    for model_dir in safe_scandir(str(cache_path)):
-        if not model_dir.is_dir():
-            continue
-
-        model_name = model_dir.name
-
-        # Iterate through block_size_*_blocks_per_file_* directories
-        for block_config_dir in Path(model_dir.path).glob("block_size_*_blocks_per_file_*"):
-            if not block_config_dir.is_dir():
+    for rank_dir in _iter_rank_dirs(cache_path):
+        # Iterate first-level hex buckets ({hhh}, three hex chars).
+        for hex3_dir in safe_scandir(rank_dir.path):
+            if not hex3_dir.is_dir() or len(hex3_dir.name) != 3:
                 continue
 
-            # Parse: gpu_block_size, gpu_blocks_per_file from dirname
-            block_params = parse_filemapper_params(
-                block_config_dir.name,
-                "block_size_{gpu_block_size}_blocks_per_file_{gpu_blocks_per_file}",
-            )
-            if not block_params:
-                continue  # Malformed directory name, skip
+            # Apply hex modulo filtering for load balancing across crawlers.
+            hex_int = hex_to_int(hex3_dir.name)
+            if hex_int is None:
+                continue
+            hex_mod = hex_int % HEX_MODULO_BASE
+            if not (modulo_range_min <= hex_mod <= modulo_range_max):
+                continue
 
-            gpu_block_size = block_params.get("gpu_block_size")
-            gpu_blocks_per_file = block_params.get("gpu_blocks_per_file")
-
-            # Iterate through tp_*_pp_size_*_pcp_size_* directories
-            for parallel_config_dir in block_config_dir.glob("tp_*_pp_size_*_pcp_size_*"):
-                if not parallel_config_dir.is_dir():
+            # Iterate second-level buckets ({hh}_g{group_idx} or similar).
+            for hex2_dir in safe_scandir(hex3_dir.path):
+                if not hex2_dir.is_dir():
                     continue
 
-                # Parse: tp_size, pp_size, pcp_size from dirname
-                parallel_params = parse_filemapper_params(
-                    parallel_config_dir.name,
-                    "tp_{tp_size}_pp_size_{pp_size}_pcp_size_{pcp_size}",
-                )
-                if not parallel_params:
-                    continue  # Malformed directory name, skip
-
-                tp_size = parallel_params.get("tp_size")
-                pp_size = parallel_params.get("pp_size")
-                pcp_size = parallel_params.get("pcp_size")
-
-                # Iterate through rank_* directories
-                for rank_dir in parallel_config_dir.glob("rank_*"):
-                    if not rank_dir.is_dir():
-                        continue
-
-                    # Parse: rank from dirname
-                    rank_match = re.match(r"rank_(\d+)", rank_dir.name)
-                    if not rank_match:
-                        continue  # Malformed directory name, skip
-
-                    rank = int(rank_match.group(1))
-
-                    # Iterate through dtype directories
-                    for dtype_dir in safe_scandir(str(rank_dir)):
-                        if not dtype_dir.is_dir():
-                            continue
-
-                        dtype = dtype_dir.name
-
-                        # Create FileMapper instance to get canonical base_path
-                        try:
-                            mapper = FileMapper(
-                                root_dir=str(cache_path),
-                                model_name=model_name,
-                                gpu_block_size=gpu_block_size,
-                                gpu_blocks_per_file=gpu_blocks_per_file,
-                                tp_size=tp_size,
-                                pp_size=pp_size,
-                                pcp_size=pcp_size,
-                                rank=rank,
-                                dtype=dtype,
-                            )
-
-                            # FileMapper.base_path is a string, convert to Path
-                            base_path = Path(mapper.base_path)
-                            if not base_path.exists():
-                                continue
-
-                        except Exception as e:
-                            # FileMapper initialization failed, skip this configuration
-                            logger.warning(f"FileMapper: Failed to create FileMapper for {model_name}: {e}")
-                            continue
-
-                        # Iterate through hex folders (hhh) - first 3 hex digits
-                        for hex3_dir in safe_scandir(str(base_path)):
-                            if not hex3_dir.is_dir() or len(hex3_dir.name) != 3:
-                                continue
-
-                            # Apply hex modulo filtering for load balancing
-                            hex_int = hex_to_int(hex3_dir.name)
-                            if hex_int is not None and hex_modulo_range:
-                                hex_mod = hex_int % HEX_MODULO_BASE
-                                if not (modulo_range_min <= hex_mod <= modulo_range_max):
-                                    continue
-
-                            # Iterate through second hex level (hh) - next 2 hex digits
-                            for hex2_dir in safe_scandir(hex3_dir.path):
-                                if not hex2_dir.is_dir():
-                                    continue
-
-                                # Yield all .bin files
-                                for bin_file_entry in safe_scandir(hex2_dir.path):
-                                    if bin_file_entry.is_file() and bin_file_entry.name.endswith(".bin"):
-                                        yield Path(bin_file_entry.path)
+                for bin_file_entry in safe_scandir(hex2_dir.path):
+                    if bin_file_entry.is_file() and bin_file_entry.name.endswith(".bin"):
+                        yield Path(bin_file_entry.path)
 
 
 def crawler_process(
@@ -289,11 +191,6 @@ def crawler_process(
         f"Crawler P{process_num} hex_modulo_range: "
         f"{hex_modulo_range[0]}-{hex_modulo_range[1]} (hex mod {HEX_MODULO_BASE})"
     )
-
-    # Verify FileMapper is available
-    if not FILEMAPPER_AVAILABLE:
-        logger.error(f"Crawler P{process_num} FileMapper not available - cannot proceed")
-        return
 
     logger.info(f"Crawler P{process_num} using FileMapper cache structure")
 

--- a/kv_connectors/pvc_evictor/processes/crawler.py
+++ b/kv_connectors/pvc_evictor/processes/crawler.py
@@ -14,9 +14,6 @@ from utils.system import setup_logging
 # Module-level logger for functions
 logger = logging.getLogger(__name__)
 
-# Pattern for a rank-suffixed FileMapper base directory: <safe_model>_<sha>_r<rank>
-_RANK_DIR_RE = re.compile(r"_r\d+$")
-
 # Constants for hex modulo load balancing
 HEX_MODULO_BASE = 16  # Number of possible hex modulo values (0-15)
 
@@ -82,12 +79,11 @@ def get_hex_modulo_ranges(num_processes: int = 8) -> list[tuple[int, int]]:
 
 def _iter_rank_dirs(cache_path: Path) -> Iterator[os.DirEntry]:
     """
-    Recursively yield FileMapper rank directories under cache_path.
+    Recursively yield directories that directly contain first-level hex buckets.
 
-    Since #585 the layout is <root>/<safe_model_name>_<sha256>_r<rank>/, where
-    <safe_model_name> contains '_'-flattened HuggingFace IDs like
-    'Qwen_Qwen3-7B'. Rank directories are recognized purely by the trailing
-    '_r<digits>' suffix on a directory name, regardless of how deep they sit.
+    Supports both:
+    - New layout: <root>/<safe_model_name>_<sha256>_r<rank>/<hhh>/
+    - Old layout: <root>/<model>/.../rank_<rank>/<dtype>/<hhh>/
     """
     stack: list[str] = [str(cache_path)]
     while stack:
@@ -97,21 +93,35 @@ def _iter_rank_dirs(cache_path: Path) -> Iterator[os.DirEntry]:
             # cycle is present under the cache root.
             if not entry.is_dir(follow_symlinks=False):
                 continue
-            if _RANK_DIR_RE.search(entry.name):
+
+            # Detect if this directory directly contains valid first-level hex buckets.
+            # We check if any of its subdirectories are valid hex buckets (e.g., len 2, 3, or 4).
+            is_hex_parent = False
+            for sub_entry in safe_scandir(entry.path):
+                if sub_entry.is_dir() and len(sub_entry.name) in (2, 3, 4):
+                    if hex_to_int(sub_entry.name) is not None:
+                        is_hex_parent = True
+                        break
+
+            if is_hex_parent:
                 yield entry
             else:
                 stack.append(entry.path)
 
 
-def stream_cache_files_with_mapper(cache_path: Path, hex_modulo_range: tuple[int, int] | None = None) -> Iterator[Path]:
+def stream_cache_files_with_mapper(
+    cache_path: Path,
+    hex_modulo_range: tuple[int, int] | None = None,
+    hex_bucket_len: int = 3,
+) -> Iterator[Path]:
     """
     Stream cache files under the collapsed FileMapper layout introduced in #585.
 
     On-disk layout:
-        <root>/<safe_model_name>_<sha256-12>_r<rank>/<hhh>/<hh>_g<group_idx>/*.bin
+        <root>/<safe_model_name>_<sha256-12>_r<rank>/<hex_bucket_len-chars>/<hh>_g<group_idx>/*.bin
 
     The walker recognizes rank directories by the '_r<digits>' suffix, then
-    iterates the first-level hex bucket ({hhh}, three hex chars), filters by
+    iterates the first-level hex bucket (hex_bucket_len hex chars), filters by
     hex_modulo_range, and yields *.bin files from any second-level bucket
     underneath (typically {hh}_g{group_idx}, but kept agnostic so we don't
     depend on the group-index encoding).
@@ -125,9 +135,9 @@ def stream_cache_files_with_mapper(cache_path: Path, hex_modulo_range: tuple[int
     modulo_range_min, modulo_range_max = hex_modulo_range if hex_modulo_range else (0, HEX_MODULO_BASE - 1)
 
     for rank_dir in _iter_rank_dirs(cache_path):
-        # Iterate first-level hex buckets ({hhh}, three hex chars).
+        # Iterate first-level hex buckets (hex_bucket_len hex chars).
         for hex3_dir in safe_scandir(rank_dir.path):
-            if not hex3_dir.is_dir() or len(hex3_dir.name) != 3:
+            if not hex3_dir.is_dir() or len(hex3_dir.name) != hex_bucket_len:
                 continue
 
             # Apply hex modulo filtering for load balancing across crawlers.
@@ -212,7 +222,12 @@ def crawler_process(
     try:
         while not shutdown_event.is_set():
             # Stream files from assigned hex range using FileMapper
-            file_stream = stream_cache_files_with_mapper(cache_path, hex_modulo_range)
+            hex_bucket_len = config_dict.get("hex_bucket_len", 3)
+            file_stream = stream_cache_files_with_mapper(
+                cache_path,
+                hex_modulo_range,
+                hex_bucket_len=hex_bucket_len,
+            )
 
             for file_path in file_stream:
                 files_discovered += 1


### PR DESCRIPTION
After #585 collapsed the FileMapper layout to
`<root>/<safe_model_name>_<sha256-12>_r<rank>/<hhh>/<hh>_g<group_idx>/*.bin`, the crawler still walked the pre-#585 deep tree
(`block_size_*/tp_*_pp_size_*/rank_*/<dtype>/...`). Those paths no longer exist on disk, so the crawler discovered zero files and the evictor never freed any blocks.

This rewrites `stream_cache_files_with_mapper` to:

* find rank directories by their `_r<digits>` suffix anywhere under the cache root, instead of pattern-matching the deprecated deep tree;
* iterate the first-level hex bucket ({hhh}) and apply the existing hex_modulo_range sharding;
* yield .bin files from any second-level bucket underneath, leaving the `_g<group_idx>` encoding opaque so the walker doesn't need to understand kv-cache groups.

The new walker no longer instantiates `FileMapper` (it only inspects on-disk names), so the `FILEMAPPER_AVAILABLE` import guard and the matching early-exit in `crawler_process` are removed. This also unblocks running the evictor container without vllm installed, since the walker was the only consumer of the `from llmd_fs_backend.file_mapper import FileMapper` import — which transitively required vllm.

`parse_filemapper_params` is dropped along with its sole caller.