### PR TITLE
feat(kvevents): parse HMA KV event metadata

### DIFF
--- a/pkg/kvevents/engineadapter/sglang_adapter.go
+++ b/pkg/kvevents/engineadapter/sglang_adapter.go
@@ -188,6 +188,7 @@ func (s *SGLangAdapter) convertBlockStoredEvent(rawEventBytes []byte) (kvevents.
 		BlockHashes: blockHashes,
 		Tokens:      event.TokenIds,
 		ParentHash:  parentHash,
+		BlockSize:   event.BlockSize,
 		DeviceTier:  deviceTier,
 		LoraID:      event.LoraID,
 		LoraName:    event.LoraName,

--- a/pkg/kvevents/engineadapter/sglang_adapter_test.go
+++ b/pkg/kvevents/engineadapter/sglang_adapter_test.go
@@ -71,7 +71,6 @@ func TestSGLangParseMessage_Valid(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, []uint64{100, 101}, blockStored.BlockHashes)
 	assert.Equal(t, uint64(99), blockStored.ParentHash)
-	assert.Equal(t, 16, blockStored.BlockSize)
 }
 
 // TestSGLangParseMessage_InvalidPayload tests error handling for invalid msgpack data.
@@ -148,7 +147,6 @@ func TestSGLangBlockStored_7Fields(t *testing.T) {
 	assert.Equal(t, []uint64{300, 301}, blockStored.BlockHashes)
 	assert.Equal(t, uint64(299), blockStored.ParentHash)
 	assert.Equal(t, []uint32{7, 8, 9}, blockStored.Tokens)
-	assert.Equal(t, 64, blockStored.BlockSize)
 	assert.Equal(t, "GPU", blockStored.DeviceTier)
 	assert.Nil(t, blockStored.LoraID)
 	assert.Nil(t, blockStored.LoraName, "SGLang does not send lora_name")

--- a/pkg/kvevents/engineadapter/sglang_adapter_test.go
+++ b/pkg/kvevents/engineadapter/sglang_adapter_test.go
@@ -71,6 +71,7 @@ func TestSGLangParseMessage_Valid(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, []uint64{100, 101}, blockStored.BlockHashes)
 	assert.Equal(t, uint64(99), blockStored.ParentHash)
+	assert.Equal(t, 16, blockStored.BlockSize)
 }
 
 // TestSGLangParseMessage_InvalidPayload tests error handling for invalid msgpack data.
@@ -114,6 +115,7 @@ func TestSGLangBlockStored_FullFields(t *testing.T) {
 	assert.Equal(t, []uint64{100, 101}, blockStored.BlockHashes)
 	assert.Equal(t, uint64(99), blockStored.ParentHash)
 	assert.Equal(t, []uint32{1, 2, 3}, blockStored.Tokens)
+	assert.Equal(t, 16, blockStored.BlockSize)
 	assert.Equal(t, "gpu", blockStored.DeviceTier)
 	assert.Nil(t, blockStored.LoraID)
 	assert.Nil(t, blockStored.LoraName)
@@ -146,6 +148,7 @@ func TestSGLangBlockStored_7Fields(t *testing.T) {
 	assert.Equal(t, []uint64{300, 301}, blockStored.BlockHashes)
 	assert.Equal(t, uint64(299), blockStored.ParentHash)
 	assert.Equal(t, []uint32{7, 8, 9}, blockStored.Tokens)
+	assert.Equal(t, 64, blockStored.BlockSize)
 	assert.Equal(t, "GPU", blockStored.DeviceTier)
 	assert.Nil(t, blockStored.LoraID)
 	assert.Nil(t, blockStored.LoraName, "SGLang does not send lora_name")
@@ -177,6 +180,7 @@ func TestSGLangBlockStored_MinimalFields(t *testing.T) {
 	assert.Equal(t, []uint64{400}, blockStored.BlockHashes)
 	assert.Equal(t, uint64(399), blockStored.ParentHash)
 	assert.Equal(t, []uint32{10, 11}, blockStored.Tokens)
+	assert.Equal(t, 128, blockStored.BlockSize)
 	assert.Equal(t, "", blockStored.DeviceTier, "medium should default to empty")
 	assert.Nil(t, blockStored.LoraID)
 	assert.Nil(t, blockStored.LoraName)

--- a/pkg/kvevents/engineadapter/vllm_adapter.go
+++ b/pkg/kvevents/engineadapter/vllm_adapter.go
@@ -132,15 +132,18 @@ func fieldAt(fields []any, i int) any {
 // convertBlockStoredEvent converts a decoded []any into a BlockStoredEvent.
 // vLLM field positions (array_like=True, tag=True):
 //
-//	[0] tag           string            (consumed by decodeVLLMEvent)
-//	[1] block_hashes  []hash
-//	[2] parent_hash   hash|nil
-//	[3] token_ids     []uint32
-//	[4] block_size    int               (consumed but not stored)
-//	[5] lora_id       int|nil           (optional, omit_defaults)
-//	[6] medium        string|nil        (optional, omit_defaults)
-//	[7] lora_name     string|nil        (optional, omit_defaults)
-//	[8] extra_keys    [][]any|nil       (optional, omit_defaults)
+//	[0]  tag                          string            (consumed by decodeVLLMEvent)
+//	[1]  block_hashes                 []hash
+//	[2]  parent_hash                  hash|nil
+//	[3]  token_ids                    []uint32
+//	[4]  block_size                   int
+//	[5]  lora_id                      int|nil           (optional, omit_defaults)
+//	[6]  medium                       string|nil        (optional, omit_defaults)
+//	[7]  lora_name                    string|nil        (optional, omit_defaults)
+//	[8]  extra_keys                   [][]any|nil       (optional, omit_defaults)
+//	[9]  group_idx                    int|nil           (optional, HMA)
+//	[10] kv_cache_spec_kind           string|nil        (optional, HMA)
+//	[11] kv_cache_spec_sliding_window int|nil           (optional, HMA)
 //
 // Trailing fields may be absent in older vLLM versions. Extra trailing fields
 // from newer vLLM versions are silently ignored.
@@ -176,7 +179,11 @@ func (v *VLLMAdapter) convertBlockStoredEvent(fields []any) (kvevents.GenericEve
 		return nil, fmt.Errorf("BlockStored: %w", err)
 	}
 
-	// [4] block_size — consumed but not stored in domain event
+	// [4] block_size
+	blockSize, err := toInt(fields[4])
+	if err != nil {
+		return nil, fmt.Errorf("BlockStored: block_size: %w", err)
+	}
 
 	// [5] lora_id (optional)
 	var loraID *int
@@ -221,14 +228,48 @@ func (v *VLLMAdapter) convertBlockStoredEvent(fields []any) (kvevents.GenericEve
 		}
 	}
 
+	var groupIdx *int
+	if raw := fieldAt(fields, 9); raw != nil {
+		group, err := toInt(raw)
+		if err != nil {
+			return nil, fmt.Errorf("BlockStored: group_idx: %w", err)
+		}
+		if group < 0 {
+			return nil, fmt.Errorf("BlockStored: group_idx: negative value: %d", group)
+		}
+		groupIdx = &group
+	}
+
+	var specKind kvevents.KVCacheSpecKind
+	if raw := fieldAt(fields, 10); raw != nil {
+		s, ok := raw.(string)
+		if !ok {
+			return nil, fmt.Errorf("BlockStored: kv_cache_spec_kind is not a string: %T", raw)
+		}
+		specKind = kvevents.KVCacheSpecKind(s)
+	}
+
+	var slidingWindow *int
+	if raw := fieldAt(fields, 11); raw != nil {
+		window, err := toInt(raw)
+		if err != nil {
+			return nil, fmt.Errorf("BlockStored: kv_cache_spec_sliding_window: %w", err)
+		}
+		slidingWindow = &window
+	}
+
 	return &kvevents.BlockStoredEvent{
-		BlockHashes: blockHashes,
-		Tokens:      tokens,
-		ParentHash:  parentHash,
-		DeviceTier:  deviceTier,
-		LoraID:      loraID,
-		LoraName:    loraName,
-		ExtraKeys:   extraKeys,
+		BlockHashes:                  blockHashes,
+		Tokens:                       tokens,
+		ParentHash:                   parentHash,
+		BlockSize:                    blockSize,
+		DeviceTier:                   deviceTier,
+		LoraID:                       loraID,
+		LoraName:                     loraName,
+		ExtraKeys:                    extraKeys,
+		GroupIdx:                     groupIdx,
+		KVCacheSpecKind:              specKind,
+		KVCacheSpecSlidingWindowSize: slidingWindow,
 	}, nil
 }
 
@@ -238,6 +279,7 @@ func (v *VLLMAdapter) convertBlockStoredEvent(fields []any) (kvevents.GenericEve
 //	[0] tag           string
 //	[1] block_hashes  []hash
 //	[2] medium        string|nil      (optional, omit_defaults)
+//	[3] group_idx     int|nil         (optional, HMA)
 func (v *VLLMAdapter) convertBlockRemovedEvent(fields []any) (kvevents.GenericEvent, error) {
 	if len(fields) < 2 {
 		return nil, fmt.Errorf("BlockRemoved: need at least 2 fields, got %d", len(fields))
@@ -261,9 +303,22 @@ func (v *VLLMAdapter) convertBlockRemovedEvent(fields []any) (kvevents.GenericEv
 		deviceTier = s
 	}
 
+	var groupIdx *int
+	if raw := fieldAt(fields, 3); raw != nil {
+		group, err := toInt(raw)
+		if err != nil {
+			return nil, fmt.Errorf("BlockRemoved: group_idx: %w", err)
+		}
+		if group < 0 {
+			return nil, fmt.Errorf("BlockRemoved: group_idx: negative value: %d", group)
+		}
+		groupIdx = &group
+	}
+
 	return &kvevents.BlockRemovedEvent{
 		BlockHashes: blockHashes,
 		DeviceTier:  deviceTier,
+		GroupIdx:    groupIdx,
 	}, nil
 }
 

--- a/pkg/kvevents/engineadapter/vllm_adapter_test.go
+++ b/pkg/kvevents/engineadapter/vllm_adapter_test.go
@@ -158,6 +158,40 @@ func TestVLLMBlockStoredWithLora(t *testing.T) {
 	assert.Equal(t, [][]any{{"uuid-A", "salt"}, nil}, blockStored.ExtraKeys)
 }
 
+func TestVLLMBlockStoredWithHMAMetadata(t *testing.T) {
+	adapter := NewVLLMAdapter()
+
+	vllmEvent := []any{
+		"BlockStored",
+		[]any{uint64(700), uint64(701)},
+		uint64(699),
+		[]uint32{1, 2, 3, 4},
+		16,
+		nil,
+		"gpu",
+		nil,
+		nil,
+		uint64(1),
+		"sliding_window",
+		128,
+	}
+
+	rawBytes, err := msgpack.Marshal(vllmEvent)
+	require.NoError(t, err)
+
+	event, err := adapter.decodeVLLMEvent(rawBytes)
+	require.NoError(t, err)
+
+	blockStored, ok := event.(*kvevents.BlockStoredEvent)
+	require.True(t, ok)
+	assert.Equal(t, 16, blockStored.BlockSize)
+	require.NotNil(t, blockStored.GroupIdx)
+	assert.Equal(t, 1, *blockStored.GroupIdx)
+	assert.Equal(t, kvevents.KVCacheSpecKindSlidingWindow, blockStored.KVCacheSpecKind)
+	require.NotNil(t, blockStored.KVCacheSpecSlidingWindowSize)
+	assert.Equal(t, 128, *blockStored.KVCacheSpecSlidingWindowSize)
+}
+
 // TestDecodeVLLMEvent_BlockStoredMissingTrailingFields tests backward compatibility
 // when trailing optional fields are absent (older vLLM with omit_defaults=True).
 func TestDecodeVLLMEvent_BlockStoredMissingTrailingFields(t *testing.T) {
@@ -236,7 +270,7 @@ func TestDecodeVLLMEvent_BlockStoredMissingTrailingFields(t *testing.T) {
 func TestDecodeVLLMEvent_BlockStoredExtraTrailingFields(t *testing.T) {
 	adapter := NewVLLMAdapter()
 
-	// Simulate a future vLLM version with extra_keys and another unknown field
+	// Simulate a future vLLM version with HMA metadata plus another unknown field.
 	vllmEvent := []any{
 		"BlockStored",
 		[]any{uint64(400), uint64(401)},
@@ -247,7 +281,10 @@ func TestDecodeVLLMEvent_BlockStoredExtraTrailingFields(t *testing.T) {
 		"gpu",
 		"my-lora",
 		[]any{[]any{"extra", "keys"}}, // [8] extra_keys
-		"completely-unknown-field",    // [9] future unknown — silently ignored
+		uint64(0),                     // [9] group_idx
+		"full_attention",              // [10] kv_cache_spec_kind
+		nil,                           // [11] kv_cache_spec_sliding_window
+		"completely-unknown-field",    // [12] future unknown — silently ignored
 	}
 
 	rawBytes, err := msgpack.Marshal(vllmEvent)
@@ -267,6 +304,9 @@ func TestDecodeVLLMEvent_BlockStoredExtraTrailingFields(t *testing.T) {
 	assert.Equal(t, "my-lora", *blockStored.LoraName)
 	require.NotNil(t, blockStored.ExtraKeys)
 	assert.Equal(t, [][]any{{"extra", "keys"}}, blockStored.ExtraKeys)
+	require.NotNil(t, blockStored.GroupIdx)
+	assert.Equal(t, 0, *blockStored.GroupIdx)
+	assert.Equal(t, kvevents.KVCacheSpecKindFullAttention, blockStored.KVCacheSpecKind)
 }
 
 // TestDecodeVLLMEvent_BlockRemovedExtraTrailingFields tests forward compatibility for BlockRemoved.
@@ -277,8 +317,8 @@ func TestDecodeVLLMEvent_BlockRemovedExtraTrailingFields(t *testing.T) {
 		"BlockRemoved",
 		[]any{uint64(500)},
 		"cpu",
-		"future-field-1",
-		"future-field-2",
+		uint64(0),        // [3] group_idx
+		"future-field-1", // [4] future unknown — silently ignored
 	}
 
 	rawBytes, err := msgpack.Marshal(vllmEvent)
@@ -291,6 +331,8 @@ func TestDecodeVLLMEvent_BlockRemovedExtraTrailingFields(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, []uint64{500}, blockRemoved.BlockHashes)
 	assert.Equal(t, "cpu", blockRemoved.DeviceTier)
+	require.NotNil(t, blockRemoved.GroupIdx)
+	assert.Equal(t, 0, *blockRemoved.GroupIdx)
 }
 
 // TestDecodeVLLMEvent_BlockRemovedMissingMedium tests backward compat for BlockRemoved.
@@ -312,6 +354,120 @@ func TestDecodeVLLMEvent_BlockRemovedMissingMedium(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, []uint64{600}, blockRemoved.BlockHashes)
 	assert.Equal(t, "", blockRemoved.DeviceTier)
+	assert.Nil(t, blockRemoved.GroupIdx)
+}
+
+func TestDecodeVLLMEvent_BlockRemovedWithGroupIdx(t *testing.T) {
+	adapter := NewVLLMAdapter()
+
+	vllmEvent := []any{
+		"BlockRemoved",
+		[]any{uint64(700)},
+		"gpu",
+		uint64(1),
+	}
+
+	rawBytes, err := msgpack.Marshal(vllmEvent)
+	require.NoError(t, err)
+
+	event, err := adapter.decodeVLLMEvent(rawBytes)
+	require.NoError(t, err)
+
+	blockRemoved, ok := event.(*kvevents.BlockRemovedEvent)
+	require.True(t, ok)
+	require.NotNil(t, blockRemoved.GroupIdx)
+	assert.Equal(t, 1, *blockRemoved.GroupIdx)
+}
+
+func TestDecodeVLLMEvent_BlockStoredInvalidHMAMetadata(t *testing.T) {
+	adapter := NewVLLMAdapter()
+
+	tests := []struct {
+		name    string
+		event   []any
+		wantErr string
+	}{
+		{
+			name: "negative group idx",
+			event: []any{
+				"BlockStored",
+				[]any{uint64(700)},
+				uint64(699),
+				[]uint32{1, 2},
+				16,
+				nil,
+				"gpu",
+				nil,
+				nil,
+				int64(-1),
+			},
+			wantErr: "group_idx",
+		},
+		{
+			name: "non-string spec kind",
+			event: []any{
+				"BlockStored",
+				[]any{uint64(700)},
+				uint64(699),
+				[]uint32{1, 2},
+				16,
+				nil,
+				"gpu",
+				nil,
+				nil,
+				uint64(0),
+				uint64(123),
+			},
+			wantErr: "kv_cache_spec_kind",
+		},
+		{
+			name: "non-numeric sliding window",
+			event: []any{
+				"BlockStored",
+				[]any{uint64(700)},
+				uint64(699),
+				[]uint32{1, 2},
+				16,
+				nil,
+				"gpu",
+				nil,
+				nil,
+				uint64(0),
+				"sliding_window",
+				"bad-window",
+			},
+			wantErr: "kv_cache_spec_sliding_window",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rawBytes, err := msgpack.Marshal(tt.event)
+			require.NoError(t, err)
+
+			_, err = adapter.decodeVLLMEvent(rawBytes)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestDecodeVLLMEvent_BlockRemovedInvalidGroupIdx(t *testing.T) {
+	adapter := NewVLLMAdapter()
+
+	vllmEvent := []any{
+		"BlockRemoved",
+		[]any{uint64(700)},
+		"gpu",
+		int64(-1),
+	}
+
+	rawBytes, err := msgpack.Marshal(vllmEvent)
+	require.NoError(t, err)
+
+	_, err = adapter.decodeVLLMEvent(rawBytes)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "group_idx")
 }
 
 func intPtr(v int) *int {

--- a/pkg/kvevents/engineadapter/vllm_adapter_test.go
+++ b/pkg/kvevents/engineadapter/vllm_adapter_test.go
@@ -317,7 +317,7 @@ func TestDecodeVLLMEvent_BlockRemovedExtraTrailingFields(t *testing.T) {
 		"BlockRemoved",
 		[]any{uint64(500)},
 		"cpu",
-		uint64(0),        // [3] group_idx
+		uint64(1),        // [3] group_idx
 		"future-field-1", // [4] future unknown — silently ignored
 	}
 
@@ -332,7 +332,7 @@ func TestDecodeVLLMEvent_BlockRemovedExtraTrailingFields(t *testing.T) {
 	assert.Equal(t, []uint64{500}, blockRemoved.BlockHashes)
 	assert.Equal(t, "cpu", blockRemoved.DeviceTier)
 	require.NotNil(t, blockRemoved.GroupIdx)
-	assert.Equal(t, 0, *blockRemoved.GroupIdx)
+	assert.Equal(t, 1, *blockRemoved.GroupIdx)
 }
 
 // TestDecodeVLLMEvent_BlockRemovedMissingMedium tests backward compat for BlockRemoved.
@@ -355,28 +355,6 @@ func TestDecodeVLLMEvent_BlockRemovedMissingMedium(t *testing.T) {
 	assert.Equal(t, []uint64{600}, blockRemoved.BlockHashes)
 	assert.Equal(t, "", blockRemoved.DeviceTier)
 	assert.Nil(t, blockRemoved.GroupIdx)
-}
-
-func TestDecodeVLLMEvent_BlockRemovedWithGroupIdx(t *testing.T) {
-	adapter := NewVLLMAdapter()
-
-	vllmEvent := []any{
-		"BlockRemoved",
-		[]any{uint64(700)},
-		"gpu",
-		uint64(1),
-	}
-
-	rawBytes, err := msgpack.Marshal(vllmEvent)
-	require.NoError(t, err)
-
-	event, err := adapter.decodeVLLMEvent(rawBytes)
-	require.NoError(t, err)
-
-	blockRemoved, ok := event.(*kvevents.BlockRemovedEvent)
-	require.True(t, ok)
-	require.NotNil(t, blockRemoved.GroupIdx)
-	assert.Equal(t, 1, *blockRemoved.GroupIdx)
 }
 
 func TestDecodeVLLMEvent_BlockStoredInvalidHMAMetadata(t *testing.T) {

--- a/pkg/kvevents/events.go
+++ b/pkg/kvevents/events.go
@@ -14,6 +14,9 @@
 
 package kvevents
 
+// KVCacheSpecKind identifies vLLM KV cache group semantics.
+type KVCacheSpecKind string
+
 // EventType represents the type of KV-cache event.
 type EventType string
 
@@ -24,6 +27,19 @@ const (
 	EventTypeBlockRemoved EventType = "BlockRemoved"
 	// EventTypeAllBlocksCleared indicates entire cache was cleared.
 	EventTypeAllBlocksCleared EventType = "AllBlocksCleared"
+)
+
+const (
+	KVCacheSpecKindFullAttention    KVCacheSpecKind = "full_attention"
+	KVCacheSpecKindMlaAttention     KVCacheSpecKind = "mla_attention"
+	KVCacheSpecKindSlidingWindow    KVCacheSpecKind = "sliding_window"
+	KVCacheSpecKindSlidingWindowMla KVCacheSpecKind = "sliding_window_mla"
+	KVCacheSpecKindMamba            KVCacheSpecKind = "mamba"
+	KVCacheSpecKindChunkedLocal     KVCacheSpecKind = "chunked_local_attention"
+	KVCacheSpecKindSinkFull         KVCacheSpecKind = "sink_full_attention"
+	KVCacheSpecKindEncoder          KVCacheSpecKind = "encoder_only_attention"
+	KVCacheSpecKindCross            KVCacheSpecKind = "cross_attention"
+	KVCacheSpecKindUnknown          KVCacheSpecKind = "unknown"
 )
 
 // GenericEvent represents a KV-cache event containing already-parsed data.
@@ -68,10 +84,17 @@ type BlockStoredEvent struct {
 	BlockHashes []uint64
 	Tokens      []uint32
 	ParentHash  uint64
+	BlockSize   int
 	DeviceTier  string
 	LoraID      *int
 	LoraName    *string
 	ExtraKeys   [][]any
+	// GroupIdx identifies the vLLM KV cache group that emitted this event.
+	GroupIdx *int
+	// KVCacheSpecKind carries vLLM's semantic cache type for the group.
+	KVCacheSpecKind KVCacheSpecKind
+	// KVCacheSpecSlidingWindowSize carries the SWA window size when applicable.
+	KVCacheSpecSlidingWindowSize *int
 }
 
 // Type returns the event type.
@@ -83,6 +106,8 @@ func (e *BlockStoredEvent) Type() EventType {
 type BlockRemovedEvent struct {
 	BlockHashes []uint64
 	DeviceTier  string
+	// GroupIdx identifies the vLLM KV cache group that removed this block.
+	GroupIdx *int
 }
 
 // Type returns the event type.


### PR DESCRIPTION
## Summary

Parse and carry vLLM HMA KV event metadata in llm-d-kv-cache.

This adds support for the vLLM fields introduced for hybrid KV cache groups in vLLM [PR #40984](https://github.com/vllm-project/vllm/pull/40984):

```python
class BlockStored(KVCacheEvent):
    ...
    group_idx: int | None = None
    # Store events carry cache-spec metadata so consumers can classify and
    # filter groups as they are learned. Remove events only need group_idx+hash.
    kv_cache_spec_kind: str | None = None
    kv_cache_spec_sliding_window: int | None = None

class BlockRemoved(KVCacheEvent):
    ...
    group_idx: int | None = None
```

No routing indexing filtering or scoring behavior changes are included in this PR.

## Motivation

vLLM emits one KV event per cache group for HMA models. `BlockStored` carries semantic group metadata while `BlockRemoved` carries only the structural group identity.

llm-d-kv-cache needs to preserve this metadata before implementing group aware indexing or HMA aware scoring in follow up work. This PR is intended as the small base change for that work.

## HMA context

This is the metadata-parsing step for the HMA support tracked in #336, following the design direction discussed there with @kapiljain1989.

The scope is intentionally limited to preserving vLLM's HMA KV event metadata. Group-aware indexing and scoring remain follow-up work.

## Notes

`BlockRemoved` intentionally does not carry `kv_cache_spec_kind` in current vLLM. The consumer is expected to learn group semantics from `BlockStored` and use `block_hash` with `group_idx` to identify removed group entries.

This PR only preserves the metadata. It does not yet interpret it.

## Related:

- #336
- https://github.com/vllm-project/vllm/pull/40984