### PR TITLE
fs_backend: add get_offload_block_hash to storage_events test stub

### DIFF
--- a/kv_connectors/llmd_fs_backend/tests/test_storage_events.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_storage_events.py
@@ -118,6 +118,7 @@ def load_storage_event_modules():
             OffloadKey=object,
             PrepareStoreOutput=PrepareStoreOutput,
             ReqContext=object,
+            get_offload_block_hash=lambda key: key,
         ),
     }
 


### PR DESCRIPTION
## Summary
- Commit 8cf550e (#604) added `get_offload_block_hash` to `llmd_fs_backend/manager.py`'s imports, but the in-test stub of `vllm.v1.kv_offload.base` in `tests/test_storage_events.py` was not updated.
- Collection of `tests/test_storage_events.py` now fails with: `ImportError: cannot import name 'get_offload_block_hash' from 'vllm.v1.kv_offload.base' (unknown location)`. The "unknown location" suffix comes from the synthetic `types.ModuleType` stub having no `__file__`.
- Add an identity stub (`lambda key: key`) so the import resolves; existing assertions pass plain ints as keys (e.g. `complete_store([11, 22], ...)` expecting `stored_calls == [[11, 22]]`), so identity is the right shape.

## Test plan
- `pytest tests/test_storage_events.py` — 7 passed