### PR TITLE
feat(evictor): implement background empty directory cleanup process

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ run:
   tests: true
 output:
   formats:
-    text:
+    - format: colored-line-number
       path: stdout
       print-linter-name: true
       print-issued-lines: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ run:
   tests: true
 output:
   formats:
-    - format: colored-line-number
+    text:
       path: stdout
       print-linter-name: true
       print-issued-lines: false

--- a/kv_connectors/pvc_evictor/CONFIGURATION.md
+++ b/kv_connectors/pvc_evictor/CONFIGURATION.md
@@ -26,6 +26,18 @@ All configuration is done through environment variables. These can be set direct
 | `DELETION_BATCH_SIZE` | int | `100` | > 0 | Files per deletion batch (deleter process) |
 | `FILE_ACCESS_TIME_THRESHOLD_MINUTES` | float | `60.0` | >= 0 | Skip files accessed within this time (minutes) |
 
+### Empty Directory Cleanup
+
+| Variable | Type | Default | Valid Values | Description |
+|----------|------|---------|--------------|-------------|
+| `ENABLE_DIR_CLEANUP` | bool | `true` | true/false | Run the background folder-cleaner process (P(N+3)) that removes empty cache directories left behind after file deletion |
+| `DIR_CLEANUP_TTL_SECONDS` | float | `120.0` | >= 0 | Skip queueing empty directories modified within this window, to avoid racing a writer that just created a bucket and is about to populate it |
+
+The crawler and deleter discover empty directories and hand them to the
+folder cleaner, which removes them with `os.rmdir` (a no-op if a file lands
+in the directory first). Set `ENABLE_DIR_CLEANUP=false` to disable the
+process entirely.
+
 ### Safety Configuration
 
 | Variable | Type | Default | Description |

--- a/kv_connectors/pvc_evictor/config.py
+++ b/kv_connectors/pvc_evictor/config.py
@@ -18,6 +18,8 @@ DEFAULT_DELETION_BATCH_SIZE = 100
 DEFAULT_FILE_ACCESS_TIME_THRESHOLD_MINUTES = 60.0
 DEFAULT_HEX_BUCKET_LEN = 3
 DEFAULT_STORAGE_EVENTS_ENDPOINT = ""
+DEFAULT_ENABLE_DIR_CLEANUP = True
+DEFAULT_DIR_CLEANUP_TTL_SECONDS = 120.0
 
 
 @dataclass
@@ -39,6 +41,10 @@ class Config:
     deletion_batch_size: int  # Files per deletion batch (default: 100)
     file_access_time_threshold_minutes: float  # Skip files accessed within this time (default: 60.0 minutes)
     hex_bucket_len: int  # Number of hex chars in the first-level bucket directory (default: 3)
+    enable_dir_cleanup: bool = DEFAULT_ENABLE_DIR_CLEANUP  # Enable empty directory cleanup in background
+    # Skip queueing empty dirs modified within this window, to avoid racing a writer
+    # that just created a bucket and is about to populate it (default: 120s)
+    dir_cleanup_ttl_seconds: float = DEFAULT_DIR_CLEANUP_TTL_SECONDS
     # log_file_path: Optional file logging for persistent log storage and debugging
     log_file_path: str | None = None  # Optional file path to write logs to (default: None, stdout only)
     storage_events_endpoint: str = ""  # Storage events publisher endpoint
@@ -59,6 +65,8 @@ class Config:
             "file_access_time_threshold_minutes": self.file_access_time_threshold_minutes,
             "hex_bucket_len": self.hex_bucket_len,
             "storage_events_endpoint": self.storage_events_endpoint,
+            "enable_dir_cleanup": self.enable_dir_cleanup,
+            "dir_cleanup_ttl_seconds": self.dir_cleanup_ttl_seconds,
         }
 
     @classmethod
@@ -85,4 +93,6 @@ class Config:
             ),
             hex_bucket_len=int(float(os.getenv("HEX_BUCKET_LEN", str(DEFAULT_HEX_BUCKET_LEN)))),
             storage_events_endpoint=os.getenv("STORAGE_EVENTS_ENDPOINT", str(DEFAULT_STORAGE_EVENTS_ENDPOINT)),
+            enable_dir_cleanup=os.getenv("ENABLE_DIR_CLEANUP", str(DEFAULT_ENABLE_DIR_CLEANUP)).lower() == "true",
+            dir_cleanup_ttl_seconds=float(os.getenv("DIR_CLEANUP_TTL_SECONDS", str(DEFAULT_DIR_CLEANUP_TTL_SECONDS))),
         )

--- a/kv_connectors/pvc_evictor/evictor.py
+++ b/kv_connectors/pvc_evictor/evictor.py
@@ -21,6 +21,7 @@ from config import Config
 from processes.activator import activator_process
 from processes.crawler import crawler_process, get_hex_modulo_ranges
 from processes.deleter import deleter_process
+from processes.folder_cleaner import folder_cleaner_process
 from utils.logging_helpers import (
     AGGREGATED_LOGGING_INTERVAL_SECONDS,
     log_aggregated_stats,
@@ -55,13 +56,20 @@ class PVCEvictor:
         self.result_queue = multiprocessing.Queue()  # Deleter → Main
         self.shutdown_event = multiprocessing.Event()  # All processes check this
 
+        # Folder Cleanup background Queue
+        if config.enable_dir_cleanup:
+            self.folder_queue = multiprocessing.Queue(maxsize=config.file_queue_maxsize)
+        else:
+            self.folder_queue = None
+
         # Convert Config to dict for pickling (needed for multiprocessing)
         self.config_dict = self.config.to_dict()
 
-        self.logger.info(
-            f"PVC Cleanup Service (N+2-Process Architecture: "
-            f"{config.num_crawler_processes + 2} total processes) initialized"
-        )
+        total_procs = config.num_crawler_processes + 2
+        if config.enable_dir_cleanup:
+            total_procs += 1
+
+        self.logger.info(f"PVC Cleanup Service (N+2-Process Architecture: {total_procs} total processes) initialized")
         self.logger.info(f"  Mount Path: {config.pvc_mount_path}")
         self.logger.info(f"  Cache Directory: {config.cache_directory}")
         self.logger.info(f"  Crawler Processes: {config.num_crawler_processes} (P1-P{config.num_crawler_processes})")
@@ -69,6 +77,9 @@ class PVCEvictor:
         deleter_process_num = config.num_crawler_processes + 2
         self.logger.info(f"  Activator Process: P{activator_process_num} (monitoring every {config.logger_interval}s)")
         self.logger.info(f"  Deleter Process: P{deleter_process_num} (batch size: {config.deletion_batch_size})")
+        if config.enable_dir_cleanup:
+            cleaner_process_num = config.num_crawler_processes + 3
+            self.logger.info(f"  Folder Cleaner Process: P{cleaner_process_num} (background empty-dir removal)")
         self.logger.info(f"  Cleanup Threshold: {config.cleanup_threshold}%")
         self.logger.info(f"  Target Threshold: {config.target_threshold}%")
         self.logger.info(
@@ -124,6 +135,8 @@ class PVCEvictor:
     def run(self):
         """Main coordination loop - spawns and manages all processes."""
         total_processes = self.config.num_crawler_processes + 2
+        if self.config.enable_dir_cleanup:
+            total_processes += 1
         self.logger.info(f"Starting {total_processes}-process evictor service...")
 
         cache_path = Path(self.config.pvc_mount_path) / self.config.cache_directory
@@ -146,6 +159,7 @@ class PVCEvictor:
                     self.deletion_queue,
                     self.result_queue,
                     self.shutdown_event,
+                    self.folder_queue,
                 ),
                 name=f"Crawler-P{i + 1}",
             )
@@ -192,17 +206,37 @@ class PVCEvictor:
                 self.deletion_queue,
                 self.result_queue,
                 self.shutdown_event,
+                self.folder_queue,
             ),
             name=f"Deleter-P{deleter_process_num}",
         )
         deleter_process_obj.start()
         self.logger.info(f"Started deleter P{deleter_process_num}")
 
+        # Spawn P(N+3): Folder Cleaner background process (if enabled)
+        folder_cleaner_process_obj = None
+        if self.config.enable_dir_cleanup:
+            cleaner_process_num = self.config.num_crawler_processes + 3
+            folder_cleaner_process_obj = multiprocessing.Process(
+                target=folder_cleaner_process,
+                args=(
+                    cleaner_process_num,
+                    self.folder_queue,
+                    self.result_queue,
+                    self.shutdown_event,
+                    self.config_dict,
+                ),
+                name=f"FolderCleaner-P{cleaner_process_num}",
+            )
+            folder_cleaner_process_obj.start()
+            self.logger.info(f"Started folder cleaner P{cleaner_process_num}")
+
         # Monitor processes and handle results
         # Aggregated logging state
         crawler_stats = {}  # {process_num: {stats_dict}}
         activator_stats = {}  # {process_num: {stats_dict}}
         deleter_stats = {}  # {process_num: {stats_dict}}
+        folder_cleaner_stats = {}  # {process_num: {stats_dict}}
         last_aggregated_log_time = time.time()
 
         try:
@@ -231,6 +265,9 @@ class PVCEvictor:
                     elif result_type == "activator_stats":
                         process_num, stats = data
                         activator_stats[process_num] = stats
+                    elif result_type == "folder_cleaner_stats":
+                        process_num, stats = data
+                        folder_cleaner_stats[process_num] = stats
 
                     # Periodically log aggregated stats
                     current_time = time.time()
@@ -242,6 +279,7 @@ class PVCEvictor:
                             deleter_stats,
                             self.config.cleanup_threshold,
                             self.config.target_threshold,
+                            folder_cleaner_stats,
                         )
                         last_aggregated_log_time = current_time
 
@@ -280,10 +318,31 @@ class PVCEvictor:
                                 self.deletion_queue,
                                 self.result_queue,
                                 self.shutdown_event,
+                                self.folder_queue,
                             ),
                             name=f"Deleter-P{deleter_process_num}",
                         )
                         deleter_process_obj.start()
+
+                    if (
+                        self.config.enable_dir_cleanup
+                        and folder_cleaner_process_obj
+                        and not folder_cleaner_process_obj.is_alive()
+                    ):
+                        cleaner_process_num = self.config.num_crawler_processes + 3
+                        self.logger.error(f"Folder Cleaner P{cleaner_process_num} died, restarting...")
+                        folder_cleaner_process_obj = multiprocessing.Process(
+                            target=folder_cleaner_process,
+                            args=(
+                                cleaner_process_num,
+                                self.folder_queue,
+                                self.result_queue,
+                                self.shutdown_event,
+                                self.config_dict,
+                            ),
+                            name=f"FolderCleaner-P{cleaner_process_num}",
+                        )
+                        folder_cleaner_process_obj.start()
 
                     time.sleep(1.0)
 
@@ -315,6 +374,14 @@ class PVCEvictor:
                 deleter_process_obj.terminate()
                 deleter_process_obj.join(timeout=5)
 
+            if self.config.enable_dir_cleanup and folder_cleaner_process_obj:
+                cleaner_process_num = self.config.num_crawler_processes + 3
+                folder_cleaner_process_obj.join(timeout=10)
+                if folder_cleaner_process_obj.is_alive():
+                    self.logger.warning(f"Folder Cleaner P{cleaner_process_num} did not terminate, forcing...")
+                    folder_cleaner_process_obj.terminate()
+                    folder_cleaner_process_obj.join(timeout=5)
+
             self.logger.info("All processes stopped")
 
 
@@ -333,10 +400,15 @@ def main():
             print(f"ERROR: {e}", flush=True)
             sys.exit(1)
 
+        total_procs = config.num_crawler_processes + 2
+        if config.enable_dir_cleanup:
+            total_procs += 1
+
         print(
             f"Configuration loaded: PVC={config.pvc_mount_path}, "
             f"Crawlers={config.num_crawler_processes}, "
-            f"Total Processes={config.num_crawler_processes + 2}",
+            f"DirCleanup={config.enable_dir_cleanup}, "
+            f"Total Processes={total_procs}",
             flush=True,
         )
 

--- a/kv_connectors/pvc_evictor/helm/templates/deployment.yaml
+++ b/kv_connectors/pvc_evictor/helm/templates/deployment.yaml
@@ -67,7 +67,13 @@ spec:
           value: {{ .Values.config.deletionBatchSize | quote }}
         - name: FILE_ACCESS_TIME_THRESHOLD_MINUTES
           value: {{ .Values.config.fileAccessTimeThresholdMinutes | quote }}
-        
+
+        # Empty Directory Cleanup
+        - name: ENABLE_DIR_CLEANUP
+          value: {{ .Values.config.enableDirCleanup | quote }}
+        - name: DIR_CLEANUP_TTL_SECONDS
+          value: {{ .Values.config.dirCleanupTtlSeconds | quote }}
+
         # Safety Configuration
         - name: DRY_RUN
           value: {{ .Values.config.dryRun | quote }}

--- a/kv_connectors/pvc_evictor/helm/values.yaml
+++ b/kv_connectors/pvc_evictor/helm/values.yaml
@@ -72,7 +72,14 @@ config:
   deletionBatchSize: 100
   # Skip files accessed within this time (minutes)
   fileAccessTimeThresholdMinutes: 60
-  
+
+  # Empty Directory Cleanup
+  # Run the background folder cleaner that removes empty cache directories
+  enableDirCleanup: true
+  # Skip queueing empty dirs modified within this window (seconds), to avoid
+  # racing a writer that just created a bucket and is about to populate it
+  dirCleanupTtlSeconds: 120
+
   # Safety Configuration
   # Set to true for testing without actual deletions
   dryRun: false

--- a/kv_connectors/pvc_evictor/processes/crawler.py
+++ b/kv_connectors/pvc_evictor/processes/crawler.py
@@ -1,11 +1,13 @@
 """Crawler process for discovering and queuing cache files."""
 
+import contextlib
 import logging
 import multiprocessing
 import os
 import time
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 
 from utils.logging_helpers import send_stats_to_queue
 from utils.system import setup_logging
@@ -107,10 +109,53 @@ def _iter_rank_dirs(cache_path: Path) -> Iterator[os.DirEntry]:
                 stack.append(entry.path)
 
 
+def is_dir_empty(dir_path: str) -> bool:
+    """Check if a directory is completely empty."""
+    try:
+        with os.scandir(dir_path) as entries:
+            for _ in entries:
+                return False
+        return True
+    except (OSError, PermissionError):
+        return False
+
+
+def queue_folder(
+    folder_path: str,
+    folder_queue: Any,
+    on_empty_folder_discovered: Any,
+    min_age_seconds: float = 0.0,
+):
+    """Offer an empty folder to the background cleaner.
+
+    Skips folders modified within ``min_age_seconds`` to avoid racing a writer
+    that just created the directory and is about to populate it. The cleaner
+    only rmdir's empty directories, so this age guard is defense-in-depth on
+    top of that: it keeps freshly-created, about-to-be-written buckets out of
+    the cleanup queue entirely. A folder filtered out here is simply
+    re-evaluated on the next crawl sweep.
+    """
+    if min_age_seconds > 0.0:
+        try:
+            if time.time() - os.stat(folder_path).st_mtime < min_age_seconds:
+                return
+        except OSError:
+            # Vanished or unreadable - nothing to clean up.
+            return
+    if on_empty_folder_discovered:
+        on_empty_folder_discovered(folder_path)
+    if folder_queue is not None:
+        with contextlib.suppress(Exception):
+            folder_queue.put_nowait(folder_path)
+
+
 def stream_cache_files_with_mapper(
     cache_path: Path,
     hex_modulo_range: tuple[int, int] | None = None,
     hex_bucket_len: int = 3,
+    on_empty_folder_discovered: Any = None,
+    folder_queue: Any = None,
+    dir_cleanup_ttl_seconds: float = 0.0,
 ) -> Iterator[Path]:
     """
     Stream cache files under the collapsed FileMapper layout introduced in #585.
@@ -124,6 +169,9 @@ def stream_cache_files_with_mapper(
     underneath (typically {hh}_g{group_idx}, but kept agnostic so we don't
     depend on the group-index encoding).
 
+    Empty directories encountered along the way are offered to the folder
+    cleaner via folder_queue, subject to the dir_cleanup_ttl_seconds age guard.
+
     Yields Path objects.
     """
     if not cache_path.exists():
@@ -133,9 +181,21 @@ def stream_cache_files_with_mapper(
     modulo_range_min, modulo_range_max = hex_modulo_range if hex_modulo_range else (0, HEX_MODULO_BASE - 1)
 
     for rank_dir in _iter_rank_dirs(cache_path):
+        # If the rank directory itself is empty, queue it!
+        if is_dir_empty(rank_dir.path):
+            queue_folder(rank_dir.path, folder_queue, on_empty_folder_discovered, dir_cleanup_ttl_seconds)
+            continue
+
+        has_hex3_dirs = False
         # Iterate first-level hex buckets (hex_bucket_len hex chars).
         for hex3_dir in safe_scandir(rank_dir.path):
             if not hex3_dir.is_dir() or len(hex3_dir.name) != hex_bucket_len:
+                continue
+            has_hex3_dirs = True
+
+            # If the hex3 directory itself is empty, queue it!
+            if is_dir_empty(hex3_dir.path):
+                queue_folder(hex3_dir.path, folder_queue, on_empty_folder_discovered, dir_cleanup_ttl_seconds)
                 continue
 
             # Apply hex modulo filtering for load balancing across crawlers.
@@ -146,14 +206,27 @@ def stream_cache_files_with_mapper(
             if not (modulo_range_min <= hex_mod <= modulo_range_max):
                 continue
 
+            has_hex2_dirs = False
             # Iterate second-level buckets ({hh}_g{group_idx} or similar).
             for hex2_dir in safe_scandir(hex3_dir.path):
                 if not hex2_dir.is_dir():
                     continue
+                has_hex2_dirs = True
 
+                has_bin_files = False
                 for bin_file_entry in safe_scandir(hex2_dir.path):
                     if bin_file_entry.is_file() and bin_file_entry.name.endswith(".bin"):
+                        has_bin_files = True
                         yield Path(bin_file_entry.path)
+
+                if not has_bin_files:
+                    queue_folder(hex2_dir.path, folder_queue, on_empty_folder_discovered, dir_cleanup_ttl_seconds)
+
+            if not has_hex2_dirs:
+                queue_folder(hex3_dir.path, folder_queue, on_empty_folder_discovered, dir_cleanup_ttl_seconds)
+
+        if not has_hex3_dirs:
+            queue_folder(rank_dir.path, folder_queue, on_empty_folder_discovered, dir_cleanup_ttl_seconds)
 
 
 def crawler_process(
@@ -165,6 +238,7 @@ def crawler_process(
     file_queue: multiprocessing.Queue,
     result_queue: multiprocessing.Queue,
     shutdown_event: multiprocessing.Event,
+    folder_queue: Any = None,
 ):
     """
     Crawler process (P1-PN): Discovers files and queues them for deletion.
@@ -206,6 +280,7 @@ def crawler_process(
     files_queued = 0
     files_skipped = 0
     files_skipped_stat_error = 0
+    empty_folders_queued = 0
     stat_error_samples = []  # Store first few stat errors for logging
     max_stat_error_samples = 3
     last_stats_send_time = time.time()
@@ -217,6 +292,12 @@ def crawler_process(
         except Exception:
             return 0
 
+    def on_empty_folder(*args, **kwargs):
+        # Counts empty dirs this crawler discovered and handed to the folder
+        # cleaner; the cleaner performs the actual rmdir.
+        nonlocal empty_folders_queued
+        empty_folders_queued += 1
+
     try:
         while not shutdown_event.is_set():
             # Stream files from assigned hex range using FileMapper
@@ -225,6 +306,9 @@ def crawler_process(
                 cache_path,
                 hex_modulo_range,
                 hex_bucket_len=hex_bucket_len,
+                on_empty_folder_discovered=on_empty_folder,
+                folder_queue=folder_queue,
+                dir_cleanup_ttl_seconds=config_dict.get("dir_cleanup_ttl_seconds", 0.0),
             )
 
             for file_path in file_stream:
@@ -318,6 +402,7 @@ def crawler_process(
                     "files_queued": files_queued,
                     "files_skipped": files_skipped,
                     "files_skipped_stat_error": files_skipped_stat_error,
+                    "empty_folders_queued": empty_folders_queued,
                     "queue_size": queue_size,
                     "deletion_active": deletion_event.is_set(),
                 },
@@ -328,6 +413,8 @@ def crawler_process(
         logger.exception(f"Crawler P{process_num} error: {e}")
     finally:
         logger.info(
-            f"Crawler P{process_num} stopping - discovered {files_discovered}, queued {files_queued}, "
-            f"skipped {files_skipped} (access_time), skipped_stat_error {files_skipped_stat_error}"
+            f"Crawler P{process_num} stopping - discovered {files_discovered}, "
+            f"queued {files_queued}, skipped {files_skipped} (access_time), "
+            f"skipped_stat_error {files_skipped_stat_error}, "
+            f"queued {empty_folders_queued} empty folders for cleanup"
         )

--- a/kv_connectors/pvc_evictor/processes/deleter.py
+++ b/kv_connectors/pvc_evictor/processes/deleter.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 import time
 from pathlib import Path
+from typing import Any
 
 from utils.system import setup_logging
 
@@ -73,11 +74,19 @@ def extract_model_name(file_path: str, cache_path: str) -> str | None:
     return model_name
 
 
-def delete_batch(file_paths: list[str], dry_run: bool, logger: logging.Logger) -> tuple[int, int, list[str]]:
+def delete_batch(
+    file_paths: list[str],
+    dry_run: bool,
+    logger: logging.Logger,
+    folder_queue: Any = None,
+) -> tuple[int, int, list[str]]:
     """
     Delete a batch of files using xargs rm -f (batch deletion).
 
     If xargs fails, logs error and skips the batch (files will be retried in next cycle).
+
+    On success, the parent directory of each deleted file is offered to
+    folder_queue (if provided) so the folder cleaner can reap it once empty.
 
     Returns: (files_deleted, bytes_freed, deleted_paths)
     """
@@ -118,6 +127,13 @@ def delete_batch(file_paths: list[str], dry_run: bool, logger: logging.Logger) -
         )
 
         if result.returncode == 0:
+            # Offer each freshly-emptied parent directory to the folder cleaner.
+            # We just removed these files, so the parent is a deletion candidate;
+            # os.rmdir in the cleaner is a no-op if another file lands there first.
+            if folder_queue is not None:
+                for parent in {str(Path(f).parent) for f in valid_paths}:
+                    with contextlib.suppress(Exception):
+                        folder_queue.put_nowait(parent)
             return len(valid_paths), total_bytes, valid_paths
         else:
             # Log error and skip batch - files will be retried in next cycle
@@ -150,6 +166,7 @@ def delete_file_batch(
     total_bytes_freed: int,
     prev_batch_time: float | None,
     result_queue: multiprocessing.Queue,
+    folder_queue: Any = None,
     event_publisher=None,
     cache_path=None,
 ) -> tuple[int, int, float]:
@@ -159,7 +176,7 @@ def delete_file_batch(
     Returns: (updated_total_files_deleted, updated_total_bytes_freed, batch_start_time)
     """
     batch_start_time = time.time()
-    deleted, freed, deleted_paths = delete_batch(batch, dry_run, logger)
+    deleted, freed, deleted_paths = delete_batch(batch, dry_run, logger, folder_queue=folder_queue)
 
     if deleted_paths and event_publisher is not None and cache_path is not None:
         model_hashes = {}
@@ -196,6 +213,7 @@ def deleter_process(
     file_queue: multiprocessing.Queue,
     result_queue: multiprocessing.Queue,
     shutdown_event: multiprocessing.Event,
+    folder_queue: Any = None,
 ):
     """
     Deleter process (P(N+2)): Deletes files (when deletion_event is set) from queue in batches.
@@ -262,6 +280,7 @@ def deleter_process(
                                 total_bytes_freed,
                                 prev_batch_time,
                                 result_queue,
+                                folder_queue,
                                 event_publisher,
                                 cache_path,
                             )
@@ -299,6 +318,7 @@ def deleter_process(
                             total_bytes_freed,
                             prev_batch_time,
                             result_queue,
+                            folder_queue,
                             event_publisher,
                             cache_path,
                         )
@@ -331,6 +351,7 @@ def deleter_process(
                 total_bytes_freed,
                 prev_batch_time,
                 result_queue,
+                folder_queue,
                 event_publisher,
                 cache_path,
             )
@@ -342,4 +363,5 @@ def deleter_process(
             f"Deleter P{process_num} stopping - deleted {total_files_deleted} files, "
             f"{total_bytes_freed / (1024**3):.2f}GB"
         )
-        result_queue.put(("done", total_files_deleted, total_bytes_freed), timeout=1.0)
+        with contextlib.suppress(Exception):
+            result_queue.put(("done", total_files_deleted, total_bytes_freed), timeout=1.0)

--- a/kv_connectors/pvc_evictor/processes/folder_cleaner.py
+++ b/kv_connectors/pvc_evictor/processes/folder_cleaner.py
@@ -1,0 +1,75 @@
+"""Folder cleaner process for background empty directory deletion."""
+
+import contextlib
+import logging
+import os
+import time
+from typing import Any
+
+from utils.logging_helpers import send_stats_to_queue
+from utils.system import setup_logging
+
+
+def folder_cleaner_process(
+    process_num: int,
+    folder_queue: Any,
+    result_queue: Any,
+    shutdown_event: Any,
+    config_dict: dict,
+):
+    """
+    Background process that pulls directory paths from folder_queue
+    and attempts to delete them using os.rmdir.
+
+    Only deletes folders when they are empty; fails silently on non-empty folders.
+    """
+    log_file = config_dict.get("log_file_path")
+    setup_logging(config_dict["log_level"], process_num, log_file)
+    logger = logging.getLogger(f"folder_cleaner_{process_num}")
+
+    logger.info(f"Folder Cleaner background process P{process_num} started")
+
+    folders_deleted = 0
+    last_report_time = time.time()
+
+    try:
+        while not shutdown_event.is_set():
+            try:
+                # Pull directory path from queue (block up to 1 second)
+                try:
+                    d_str = folder_queue.get(timeout=1.0)
+                except Exception:
+                    continue
+
+                # Attempt to delete empty directory
+                try:
+                    os.rmdir(d_str)
+                    folders_deleted += 1
+                    logger.debug(f"Purged empty folder: {d_str}")
+                except OSError:
+                    # Directory not empty yet, skip silently
+                    pass
+
+                # Periodically report progress (every 30 seconds)
+                last_report_time = send_stats_to_queue(
+                    result_queue,
+                    "folder_cleaner_stats",
+                    process_num,
+                    {"folders_purged": folders_deleted},
+                    last_report_time,
+                    interval=30.0,
+                )
+
+            except Exception as e:
+                logger.exception(f"Folder Cleaner P{process_num} encountered error: {e}")
+                time.sleep(1.0)
+
+    except Exception as e:
+        logger.exception(f"Folder Cleaner P{process_num} critical failure: {e}")
+    finally:
+        logger.info(f"Folder Cleaner P{process_num} stopping - total empty folders purged: {folders_deleted}")
+        with contextlib.suppress(Exception):
+            result_queue.put(
+                ("folder_cleaner_stats", process_num, {"folders_purged": folders_deleted}),
+                timeout=1.0,
+            )

--- a/kv_connectors/pvc_evictor/processes/folder_cleaner.py
+++ b/kv_connectors/pvc_evictor/processes/folder_cleaner.py
@@ -4,10 +4,50 @@ import contextlib
 import logging
 import os
 import time
+from pathlib import Path
 from typing import Any
 
 from utils.logging_helpers import send_stats_to_queue
 from utils.system import setup_logging
+
+
+def cleanup_empty_dirs(paths: list[str], cache_path: Path, logger: logging.Logger) -> int:
+    """
+    Remove empty directories left behind after file deletion.
+
+    Walks from each path (or its parent directory if it's a file) upward,
+    removing empty directories until reaching cache_path or a non-empty directory.
+    Uses os.rmdir which only succeeds on empty directories.
+
+    Returns the number of directories removed.
+    """
+    dirs_removed = 0
+    cache_path_str = str(cache_path)
+
+    parents_seen: set[str] = set()
+    for path_str in paths:
+        path = Path(path_str)
+        parent = str(path.parent) if path_str.endswith(".bin") or (path.exists() and path.is_file()) else path_str
+        if parent not in parents_seen:
+            parents_seen.add(parent)
+
+    for dir_path_str in sorted(parents_seen, key=len, reverse=True):
+        current = dir_path_str
+        while current.startswith(cache_path_str) and current != cache_path_str:
+            if not os.path.isdir(current):
+                current = str(Path(current).parent)
+                continue
+            try:
+                os.rmdir(current)
+                dirs_removed += 1
+            except OSError:
+                break
+            current = str(Path(current).parent)
+
+    if dirs_removed > 0:
+        logger.debug(f"Cleaned up {dirs_removed} empty directories")
+
+    return dirs_removed
 
 
 def folder_cleaner_process(
@@ -29,6 +69,7 @@ def folder_cleaner_process(
 
     logger.info(f"Folder Cleaner background process P{process_num} started")
 
+    cache_path = Path(config_dict["pvc_mount_path"]) / config_dict["cache_directory"]
     folders_deleted = 0
     last_report_time = time.time()
 
@@ -41,14 +82,14 @@ def folder_cleaner_process(
                 except Exception:
                     continue
 
-                # Attempt to delete empty directory
+                # Attempt to delete empty directory and its parents upward
                 try:
-                    os.rmdir(d_str)
-                    folders_deleted += 1
-                    logger.debug(f"Purged empty folder: {d_str}")
-                except OSError:
-                    # Directory not empty yet, skip silently
-                    pass
+                    removed = cleanup_empty_dirs([d_str], cache_path, logger)
+                    if removed > 0:
+                        folders_deleted += removed
+                        logger.debug(f"Purged {removed} empty folders starting from: {d_str}")
+                except Exception as e:
+                    logger.error(f"Error cleaning up folder {d_str}: {e}")
 
                 # Periodically report progress (every 30 seconds)
                 last_report_time = send_stats_to_queue(

--- a/kv_connectors/pvc_evictor/tests/test_deleter.py
+++ b/kv_connectors/pvc_evictor/tests/test_deleter.py
@@ -190,9 +190,11 @@ def test_delete_file_batch_publishes_events_grouped_by_model(tmp_path, monkeypat
     logger = logging.getLogger("test_deleter")
     queue = FakeQueue()
 
-    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (len(paths), 1024, list(paths)))
+    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log, **kwargs: (len(paths), 1024, list(paths)))
 
-    delete_file_batch(files, False, logger, "P1", 0, 0, None, queue, publisher, str(cache_path))
+    delete_file_batch(
+        files, False, logger, "P1", 0, 0, None, queue, event_publisher=publisher, cache_path=str(cache_path)
+    )
 
     assert len(publisher.calls) == 2
     publisher.calls.sort(key=lambda x: x[0])
@@ -213,9 +215,11 @@ def test_delete_file_batch_no_events_when_publisher_is_none(monkeypatch):
     queue = FakeQueue()
     logger = logging.getLogger("test_deleter")
 
-    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (1, 512, list(paths)))
+    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log, **kwargs: (1, 512, list(paths)))
 
-    total_deleted, total_freed, _ = delete_file_batch(files, False, logger, "P1", 0, 0, None, queue, None, None)
+    total_deleted, total_freed, _ = delete_file_batch(
+        files, False, logger, "P1", 0, 0, None, queue, event_publisher=None, cache_path=None
+    )
 
     assert total_deleted == 1
     assert total_freed == 512
@@ -230,9 +234,11 @@ def test_delete_file_batch_no_events_when_nothing_deleted(tmp_path, monkeypatch)
     queue = FakeQueue()
     logger = logging.getLogger("test_deleter")
 
-    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (0, 0, []))
+    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log, **kwargs: (0, 0, []))
 
-    delete_file_batch(files, False, logger, "P1", 0, 0, None, queue, publisher, str(cache_path))
+    delete_file_batch(
+        files, False, logger, "P1", 0, 0, None, queue, event_publisher=publisher, cache_path=str(cache_path)
+    )
 
     assert publisher.calls == []
 
@@ -246,10 +252,10 @@ def test_delete_file_batch_publish_failure_is_fail_open(tmp_path, monkeypatch):
     queue = FakeQueue()
     logger = logging.getLogger("test_deleter")
 
-    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (1, 512, list(paths)))
+    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log, **kwargs: (1, 512, list(paths)))
 
     total_deleted, total_freed, _ = delete_file_batch(
-        files, False, logger, "P1", 0, 0, None, queue, publisher, str(cache_path)
+        files, False, logger, "P1", 0, 0, None, queue, event_publisher=publisher, cache_path=str(cache_path)
     )
 
     assert total_deleted == 1
@@ -270,9 +276,11 @@ def test_delete_file_batch_skips_unparsable_paths(tmp_path, monkeypatch):
     queue = FakeQueue()
     logger = logging.getLogger("test_deleter")
 
-    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (len(paths), 1024, list(paths)))
+    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log, **kwargs: (len(paths), 1024, list(paths)))
 
-    delete_file_batch(files, False, logger, "P1", 0, 0, None, queue, publisher, str(cache_path))
+    delete_file_batch(
+        files, False, logger, "P1", 0, 0, None, queue, event_publisher=publisher, cache_path=str(cache_path)
+    )
 
     assert len(publisher.calls) == 1
     model, hashes = publisher.calls[0]
@@ -289,10 +297,10 @@ def test_delete_file_batch_no_events_on_dry_run(tmp_path, monkeypatch):
     queue = FakeQueue()
     logger = logging.getLogger("test_deleter")
 
-    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log: (len(paths), 0, []))
+    monkeypatch.setattr(_deleter, "delete_batch", lambda paths, dry, log, **kwargs: (len(paths), 0, []))
 
     total_deleted, total_freed, _ = delete_file_batch(
-        files, True, logger, "P1", 0, 0, None, queue, publisher, str(cache_path)
+        files, True, logger, "P1", 0, 0, None, queue, event_publisher=publisher, cache_path=str(cache_path)
     )
 
     assert total_deleted == len(files)

--- a/kv_connectors/pvc_evictor/tests/test_folder_cleaner.py
+++ b/kv_connectors/pvc_evictor/tests/test_folder_cleaner.py
@@ -1,0 +1,152 @@
+import logging
+import os
+import queue
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add pvc_evictor root to path so imports work without installing
+PVC_EVICTOR_ROOT = Path(__file__).resolve().parents[1]
+if str(PVC_EVICTOR_ROOT) not in sys.path:
+    sys.path.insert(0, str(PVC_EVICTOR_ROOT))
+
+from processes.deleter import delete_batch  # noqa: E402
+from processes.folder_cleaner import cleanup_empty_dirs  # noqa: E402
+
+
+@pytest.fixture
+def cache_tree(tmp_path):
+    """Create a realistic FileMapper cache directory structure.
+
+    Layout:
+        <tmp>/cache/model_abc123_r0/0a1/0a_g0/block_0.bin
+        <tmp>/cache/model_abc123_r0/0a1/0a_g0/block_1.bin
+        <tmp>/cache/model_abc123_r0/0a1/0b_g1/block_2.bin
+        <tmp>/cache/model_abc123_r0/ff0/ff_g0/block_3.bin
+    """
+    cache_path = tmp_path / "cache"
+    dirs = [
+        cache_path / "model_abc123_r0" / "0a1" / "0a_g0",
+        cache_path / "model_abc123_r0" / "0a1" / "0b_g1",
+        cache_path / "model_abc123_r0" / "ff0" / "ff_g0",
+    ]
+    for d in dirs:
+        d.mkdir(parents=True)
+
+    files = [
+        dirs[0] / "block_0.bin",
+        dirs[0] / "block_1.bin",
+        dirs[1] / "block_2.bin",
+        dirs[2] / "block_3.bin",
+    ]
+    for f in files:
+        f.write_bytes(b"\x00" * 128)
+
+    return cache_path, files
+
+
+class TestCleanupEmptyDirs:
+    def test_removes_leaf_and_parent_dirs(self, cache_tree):
+        cache_path, files = cache_tree
+        # Delete all files in 0a_g0
+        for f in files[:2]:
+            f.unlink()
+
+        logger = logging.getLogger("test")
+        removed = cleanup_empty_dirs([str(f) for f in files[:2]], cache_path, logger)
+
+        assert removed > 0
+        # 0a_g0 should be gone (was the only directory with those files)
+        assert not (cache_path / "model_abc123_r0" / "0a1" / "0a_g0").exists()
+        # 0a1 should still exist because 0b_g1 still has a file
+        assert (cache_path / "model_abc123_r0" / "0a1").exists()
+
+    def test_removes_entire_branch_when_empty(self, cache_tree):
+        cache_path, files = cache_tree
+        # Delete the only file under ff0/ff_g0
+        files[3].unlink()
+
+        logger = logging.getLogger("test")
+        removed = cleanup_empty_dirs([str(files[3])], cache_path, logger)
+
+        # ff_g0, ff0 should both be removed (both empty after deletion)
+        assert not (cache_path / "model_abc123_r0" / "ff0" / "ff_g0").exists()
+        assert not (cache_path / "model_abc123_r0" / "ff0").exists()
+        # model_abc123_r0 should still exist (0a1 branch still has files)
+        assert (cache_path / "model_abc123_r0").exists()
+        assert removed >= 2
+
+    def test_stops_at_cache_root(self, cache_tree):
+        cache_path, files = cache_tree
+        # Delete all files
+        for f in files:
+            f.unlink()
+
+        logger = logging.getLogger("test")
+        cleanup_empty_dirs([str(f) for f in files], cache_path, logger)
+
+        # cache_path itself must not be removed
+        assert cache_path.exists()
+
+    def test_no_error_on_nonempty_dirs(self, cache_tree):
+        cache_path, files = cache_tree
+        # Only delete one of two files in 0a_g0
+        files[0].unlink()
+
+        logger = logging.getLogger("test")
+        removed = cleanup_empty_dirs([str(files[0])], cache_path, logger)
+
+        # 0a_g0 still has block_1.bin so nothing should be removed
+        assert removed == 0
+        assert (cache_path / "model_abc123_r0" / "0a1" / "0a_g0").exists()
+
+    def test_no_error_on_already_removed_dirs(self, cache_tree):
+        cache_path, files = cache_tree
+        # Delete files and manually remove directory before calling cleanup
+        files[3].unlink()
+        os.rmdir(str(cache_path / "model_abc123_r0" / "ff0" / "ff_g0"))
+
+        logger = logging.getLogger("test")
+        removed = cleanup_empty_dirs([str(files[3])], cache_path, logger)
+
+        # ff_g0 was already gone, but ff0 should still be cleaned up
+        assert not (cache_path / "model_abc123_r0" / "ff0").exists()
+        assert removed >= 1
+
+
+class TestDeleteBatchWithFolderQueue:
+    def test_delete_batch_queues_parent_dirs(self, cache_tree):
+        cache_path, files = cache_tree
+        folder_queue = queue.Queue()
+
+        # Delete the single file under ff0/ff_g0
+        deleted, freed, deleted_paths = delete_batch(
+            [str(files[3])],
+            dry_run=False,
+            logger=logging.getLogger("test"),
+            folder_queue=folder_queue,
+        )
+
+        assert deleted == 1
+        assert freed > 0
+        assert deleted_paths == [str(files[3])]
+        # Parent folder should have been offered to folder_queue
+        assert folder_queue.get_nowait() == str(files[3].parent)
+        assert folder_queue.empty()
+
+    def test_delete_batch_dry_run_does_not_queue(self, cache_tree):
+        cache_path, files = cache_tree
+        folder_queue = queue.Queue()
+
+        deleted, freed, deleted_paths = delete_batch(
+            [str(files[3])],
+            dry_run=True,
+            logger=logging.getLogger("test"),
+            folder_queue=folder_queue,
+        )
+
+        assert deleted == 1
+        assert freed == 0
+        assert deleted_paths == []
+        assert folder_queue.empty()

--- a/kv_connectors/pvc_evictor/utils/logging_helpers.py
+++ b/kv_connectors/pvc_evictor/utils/logging_helpers.py
@@ -49,6 +49,7 @@ def log_aggregated_stats(
     deleter_stats: dict[int, dict[str, Any]],
     cleanup_threshold: float,
     target_threshold: float,
+    folder_cleaner_stats: dict[int, dict[str, Any]] | None = None,
 ) -> None:
     """
     Log aggregated statistics from all processes in a unified format.
@@ -60,8 +61,9 @@ def log_aggregated_stats(
         deleter_stats: Dictionary mapping process_num to deleter statistics
         cleanup_threshold: Cleanup threshold percentage for display
         target_threshold: Target threshold percentage for display
+        folder_cleaner_stats: Dictionary mapping process_num to folder cleaner statistics
     """
-    if not crawler_stats and not activator_stats and not deleter_stats:
+    if not crawler_stats and not activator_stats and not deleter_stats and not folder_cleaner_stats:
         return
 
     # Build aggregated log message
@@ -72,16 +74,25 @@ def log_aggregated_stats(
         total_files_discovered = sum(stats.get("files_discovered", 0) for stats in crawler_stats.values())
         total_files_queued = sum(stats.get("files_queued", 0) for stats in crawler_stats.values())
         total_files_skipped = sum(stats.get("files_skipped", 0) for stats in crawler_stats.values())
+        total_stat_errors = sum(stats.get("files_skipped_stat_error", 0) for stats in crawler_stats.values())
+        current_queue_size = max((stats.get("queue_size", 0) for stats in crawler_stats.values()), default=0)
         log_lines.append(f"Crawlers: {len(crawler_stats)} active")
+        log_lines.append(f"  Current deletion queue depth: {current_queue_size}")
         log_lines.append(f"  Total files discovered: {total_files_discovered}")
         log_lines.append(f"  Total files queued: {total_files_queued}")
+        total_empty_folders_queued = sum(stats.get("empty_folders_queued", 0) for stats in crawler_stats.values())
+        log_lines.append(f"  Total empty folders queued for cleanup: {total_empty_folders_queued}")
         log_lines.append(f"  Total files skipped (hot): {total_files_skipped}")
+        log_lines.append(f"  Total stat errors: {total_stat_errors}")
         for process_num in sorted(crawler_stats.keys()):
             stats = crawler_stats[process_num]
             log_lines.append(
                 f"  P{process_num}: discovered={stats.get('files_discovered', 0)}, "
                 f"queued={stats.get('files_queued', 0)}, "
-                f"skipped={stats.get('files_skipped', 0)}"
+                f"empty_folders_queued={stats.get('empty_folders_queued', 0)}, "
+                f"skipped={stats.get('files_skipped', 0)}, "
+                f"stat_errors={stats.get('files_skipped_stat_error', 0)}, "
+                f"queue_size={stats.get('queue_size', 0)}"
             )
 
     # Activator stats
@@ -106,6 +117,15 @@ def log_aggregated_stats(
             log_lines.append(f"Deleter P{process_num}:")
             log_lines.append(f"  Files deleted: {files_deleted}")
             log_lines.append(f"  Space freed: {gb_freed:.2f}GB")
+
+    # Folder Cleaner stats
+    if folder_cleaner_stats:
+        total_purged = sum(stats.get("folders_purged", 0) for stats in folder_cleaner_stats.values())
+        log_lines.append(f"Folder Cleaners: {len(folder_cleaner_stats)} active")
+        log_lines.append(f"  Total empty folders purged: {total_purged}")
+        for process_num in sorted(folder_cleaner_stats.keys()):
+            stats = folder_cleaner_stats[process_num]
+            log_lines.append(f"  P{process_num}: purged={stats.get('folders_purged', 0)}")
 
     log_lines.append("=" * 21)
 

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -362,7 +362,12 @@ func (r *RedisIndex) getRequestKeys(ctx context.Context, engineKey BlockHash) ([
 
 // GetRequestKey returns the last request key (highest score) associated with the given engineKey.
 func (r *RedisIndex) GetRequestKey(ctx context.Context, engineKey BlockHash) (BlockHash, error) {
-	vals, err := r.RedisClient.ZRevRange(ctx, redisEngineKey(engineKey), 0, 0).Result()
+	vals, err := r.RedisClient.ZRangeArgs(ctx, redis.ZRangeArgs{
+		Key:   redisEngineKey(engineKey),
+		Start: 0,
+		Stop:  0,
+		Rev:   true,
+	}).Result()
 	if err != nil {
 		return EmptyBlockHash, err
 	}

--- a/pkg/kvcache/kvblock/traced_index_test.go
+++ b/pkg/kvcache/kvblock/traced_index_test.go
@@ -149,10 +149,12 @@ func TestTracedIndexAddAndEvictSpansRecordErrors(t *testing.T) {
 	expectedErr := errors.New("index operation failed")
 	tracedIdx := kvblock.NewTracedIndex(&failingIndex{err: expectedErr})
 
-	err := tracedIdx.Add(ctx, nil, []kvblock.BlockHash{1}, []kvblock.PodEntry{{PodIdentifier: "pod1", DeviceTier: "gpu"}})
+	err := tracedIdx.Add(ctx, nil, []kvblock.BlockHash{1},
+		[]kvblock.PodEntry{{PodIdentifier: "pod1", DeviceTier: "gpu"}})
 	require.ErrorIs(t, err, expectedErr)
 
-	err = tracedIdx.Evict(ctx, kvblock.BlockHash(1), kvblock.RequestKey, []kvblock.PodEntry{{PodIdentifier: "pod1", DeviceTier: "gpu"}})
+	err = tracedIdx.Evict(ctx, kvblock.BlockHash(1), kvblock.RequestKey,
+		[]kvblock.PodEntry{{PodIdentifier: "pod1", DeviceTier: "gpu"}})
 	require.ErrorIs(t, err, expectedErr)
 
 	spans := spanRecorder.Ended()

--- a/tests/e2e/uds_tokenizer/uds_e2e_suite_test.go
+++ b/tests/e2e/uds_tokenizer/uds_e2e_suite_test.go
@@ -73,7 +73,6 @@ func (s *UDSTokenizerSuite) SetupSuite() {
 	s.T().Logf("TCP tokenizer container started; gRPC at %s", s.grpcAddress)
 }
 
-//nolint:gocritic // nonamedreturns linter takes precedence
 func (s *UDSTokenizerSuite) launchContainer(imageName string) (*testcontainers.DockerContainer, string) {
 	ctx := context.Background()
 
@@ -176,7 +175,8 @@ func (s *UDSTokenizerSuite) addEntriesToIndex(
 	s.Require().NotEmpty(engineKeys)
 	s.Require().NotEmpty(requestKeys)
 
-	err := s.kvBlockIndex.Add(s.T().Context(), engineKeys, requestKeys, utils.SliceMap(podList, func(pod string) kvblock.PodEntry {
+	err := s.kvBlockIndex.Add(s.T().Context(), engineKeys, requestKeys,
+		utils.SliceMap(podList, func(pod string) kvblock.PodEntry {
 		return kvblock.PodEntry{
 			PodIdentifier: pod,
 			DeviceTier:    "gpu",

--- a/tests/e2e/uds_tokenizer/uds_e2e_suite_test.go
+++ b/tests/e2e/uds_tokenizer/uds_e2e_suite_test.go
@@ -23,8 +23,9 @@ import (
 	"os"
 	"testing"
 	"time"
-	container "github.com/moby/moby/api/types/container"
+
 	"github.com/go-logr/logr/testr"
+	container "github.com/moby/moby/api/types/container"
 	"github.com/stretchr/testify/suite"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -73,6 +74,7 @@ func (s *UDSTokenizerSuite) SetupSuite() {
 	s.T().Logf("TCP tokenizer container started; gRPC at %s", s.grpcAddress)
 }
 
+//nolint:gocritic // nonamedreturns linter takes precedence
 func (s *UDSTokenizerSuite) launchContainer(imageName string) (*testcontainers.DockerContainer, string) {
 	ctx := context.Background()
 
@@ -175,8 +177,7 @@ func (s *UDSTokenizerSuite) addEntriesToIndex(
 	s.Require().NotEmpty(engineKeys)
 	s.Require().NotEmpty(requestKeys)
 
-	err := s.kvBlockIndex.Add(s.T().Context(), engineKeys, requestKeys,
-		utils.SliceMap(podList, func(pod string) kvblock.PodEntry {
+	err := s.kvBlockIndex.Add(s.T().Context(), engineKeys, requestKeys, utils.SliceMap(podList, func(pod string) kvblock.PodEntry {
 		return kvblock.PodEntry{
 			PodIdentifier: pod,
 			DeviceTier:    "gpu",

--- a/tests/e2e/uds_tokenizer/uds_e2e_suite_test.go
+++ b/tests/e2e/uds_tokenizer/uds_e2e_suite_test.go
@@ -23,8 +23,7 @@ import (
 	"os"
 	"testing"
 	"time"
-
-	"github.com/docker/docker/api/types/container"
+	container "github.com/moby/moby/api/types/container"
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/suite"
 	"github.com/testcontainers/testcontainers-go"


### PR DESCRIPTION
Description
After cache files are deleted, empty subdirectories (representing shard buckets and models) are left behind on the shared storage mount. Over time, this results in directory bloat.

This PR introduces an asynchronous background cleanup process to automatically purge empty cache directories as files are evicted, ensuring a clean storage footprint.

Key Changes
**Asynchronous Folder Cleaner (folder_cleaner.py)**: Added a dedicated background process folder_cleaner_process that consumes directory paths from a multiprocessing queue (folder_queue) and purges them using os.rmdir. Because os.rmdir naturally fails on non-empty directories, this is completely safe and skips directories containing remaining block files or active caches.
**Deleter Integration (deleter.py)**: Integrated the deleter_process to extract the parent directory of every successfully deleted cache .bin file and queue it for background cleanup.
**Orchestrator Support (evictor.py)**: Updated the main evictor launcher to spin up, monitor, and gracefully shut down the new cleaner process and handle its multiprocessing queues.
**Telemetry & Aggregated Logging (logging_helpers.py)**: Added live tracking and aggregated statistics output for the directory cleaner process (e.g., tracking active queue depth, total folders deleted, and status outputs).

Fixes #614 