### PR TITLE
Add CPU fs backend tests to CI

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -44,6 +44,25 @@ jobs:
       - name: Run unit tests
         run: make unit-test
 
+  unit-test-fs-backend-cpu:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest msgpack pyzmq
+
+      - name: Run CPU-safe FS backend unit tests
+        run: make unit-test-fs-backend-cpu
+
   e2e-test:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ BUILDER := $(shell command -v buildah >/dev/null 2>&1 && echo buildah || echo $(
 UDS_TOKENIZER_IMAGE ?= llm-d-uds-tokenizer:e2e-test
 FS_BACKEND_NAME ?= llmd-fs-backend
 FS_BACKEND_DEV_IMG ?= $(IMAGE_TAG_BASE)/$(FS_BACKEND_NAME):$(DEV_VERSION)
+FS_BACKEND_DIR := kv_connectors/llmd_fs_backend
 
 # go source files
 SRC = $(shell find . -type f -name '*.go')
@@ -76,6 +77,11 @@ unit-test-uds: check-go download-zmq ## Run unit tests
 unit-test-race: check-go download-zmq ## Run unit tests with Go race detector enabled
 	@printf "\033[33;1m==== Running unit tests with race detector ====\033[0m\n"
 	@go test -v -race -count=1 ./pkg/...
+
+.PHONY: unit-test-fs-backend-cpu
+unit-test-fs-backend-cpu: ## Run CPU-safe FS backend unit tests
+	@printf "\033[33;1m==== Running CPU-safe FS backend unit tests ====\033[0m\n"
+	@cd $(FS_BACKEND_DIR) && $(PYTHON_EXE) -m pytest tests/test_storage_events.py -v -s
 
 .PHONY: e2e-test
 e2e-test: e2e-test-uds ## Run end-to-end tests

--- a/kv_connectors/llmd_fs_backend/tests/conftest.py
+++ b/kv_connectors/llmd_fs_backend/tests/conftest.py
@@ -16,14 +16,13 @@
 import gc
 import sys
 import time
+from functools import cache
 from pathlib import Path
 
 # Add tests directory to path so test modules can import each other
 sys.path.insert(0, str(Path(__file__).parent))
 
 import pytest
-import torch
-from vllm.config import VllmConfig, set_current_vllm_config
 
 
 def pytest_addoption(parser):
@@ -35,20 +34,51 @@ def pytest_addoption(parser):
     parser.addoption("--obj-ca_bundle", default=None)
 
 
-@pytest.fixture(scope="session", autouse=True)
-def require_cuda():
-    """Skip all tests in this session if CUDA is not available."""
-    if not torch.cuda.is_available():
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "cpu_safe: test does not require CUDA and can run in CPU-only CI",
+    )
+
+
+def _is_cpu_safe(request):
+    return request.node.get_closest_marker("cpu_safe") is not None
+
+
+@cache
+def _torch_for_cuda_tests():
+    return pytest.importorskip("torch", reason="torch is required for CUDA tests")
+
+
+@cache
+def _cuda_is_available():
+    return _torch_for_cuda_tests().cuda.is_available()
+
+
+@pytest.fixture(autouse=True)
+def require_cuda(request):
+    """Skip CUDA-dependent tests when CUDA is not available."""
+    if _is_cpu_safe(request):
+        return
+
+    if not _cuda_is_available():
         pytest.skip("CUDA not available")
 
 
 @pytest.fixture(autouse=True)
-def cuda_teardown():
+def cuda_teardown(request):
     """Ensure CUDA and C++ thread-pool resources from one test are fully
     released before the next test starts. Without this, async destructors
     can cause 'cudaErrorUnknown' or stale file-open errors in subsequent tests.
     """
     yield
+    if _is_cpu_safe(request):
+        return
+
+    if not _cuda_is_available():
+        return
+    torch = _torch_for_cuda_tests()
+
     gc.collect()  # force Python GC to call C++ destructors immediately
     torch.cuda.synchronize()  # surface any async CUDA errors in the right test
     torch.cuda.empty_cache()  # free cached allocations so next test starts clean
@@ -61,6 +91,9 @@ def default_vllm_config():
     that use get_current_vllm_config() outside of a full engine context.
     This matches vLLM's internal test fixture pattern.
     """
+    vllm_config = pytest.importorskip(
+        "vllm.config", reason="vLLM is required for this test"
+    )
     # Use empty VllmConfig() which provides sensible defaults
-    with set_current_vllm_config(VllmConfig()):
+    with vllm_config.set_current_vllm_config(vllm_config.VllmConfig()):
         yield

--- a/kv_connectors/llmd_fs_backend/tests/test_storage_events.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_storage_events.py
@@ -20,8 +20,11 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import msgpack
+import pytest
 
 CONNECTOR_ROOT = Path(__file__).resolve().parents[1]
+
+pytestmark = pytest.mark.cpu_safe
 
 
 class PrepareStoreOutput:


### PR DESCRIPTION
## Summary
- add a CPU-safe FS backend unit-test target for storage event tests
- skip CUDA/vLLM setup for tests marked with the new cpu_safe pytest marker
- wire the CPU-safe FS backend tests into the main CI workflow on ubuntu-latest with Python 3.12

Fixes #572

## Testing
- uv run --python 3.12 --with pytest --with msgpack --with pyzmq make unit-test-fs-backend-cpu PYTHON_EXE=python
- uv run --with ruff ruff check kv_connectors/llmd_fs_backend/tests/conftest.py kv_connectors/llmd_fs_backend/tests/test_storage_events.py