### PR TITLE
ci: refresh ghcr :latest tag on stable GitHub Release

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -11,6 +11,10 @@ inputs:
     required: false
     description: Newline-separated additional image tags to apply to the same build
     default: ''
+  latest:
+    required: false
+    description: Also tag the built image as `:latest`. Set to 'true' for stable release builds only; leave 'false' for dev/PR/pre-release builds so the floating `latest` tag is not overwritten by a non-release artifact.
+    default: 'false'
   github-token:
     required: true
     description: GitHub token for login
@@ -50,12 +54,16 @@ runs:
           echo "Additional tags:"
           printf '%s\n' "${ADDITIONAL_TAGS}"
         fi
+        if [ "${LATEST}" = "true" ]; then
+          echo "Also tagging as: latest"
+        fi
         echo "Registry: ${REGISTRY}"
       shell: bash
       env:
         IMAGE_NAME: ${{ inputs.image-name }}
         TAG: ${{ inputs.tag }}
         ADDITIONAL_TAGS: ${{ inputs.additional-tags }}
+        LATEST: ${{ inputs.latest }}
         REGISTRY: ${{ inputs.registry }}
 
     - name: Build image and push
@@ -71,6 +79,9 @@ runs:
             TAG_ARGS+=(-t "${REGISTRY}/${IMAGE_NAME}:${extra_tag}")
           done <<< "${ADDITIONAL_TAGS}"
         fi
+        if [ "${LATEST}" = "true" ]; then
+          TAG_ARGS+=(-t "${REGISTRY}/${IMAGE_NAME}:latest")
+        fi
         docker buildx build \
           --platform ${PLATFORM} \
           ${DOCKERFILE_ARG} \
@@ -83,5 +94,6 @@ runs:
         IMAGE_NAME: ${{ inputs.image-name }}
         TAG: ${{ inputs.tag }}
         ADDITIONAL_TAGS: ${{ inputs.additional-tags }}
+        LATEST: ${{ inputs.latest }}
         CONTEXT: ${{ inputs.context }}
         PLATFORM: ${{ inputs.platform }}

--- a/.github/workflows/ci-release-uds-tokenizer.yaml
+++ b/.github/workflows/ci-release-uds-tokenizer.yaml
@@ -44,6 +44,9 @@ jobs:
         with:
           tag: ${{ steps.tag.outputs.tag }}
           additional-tags: ${{ steps.vllm.outputs.tag }}
+          # Only refresh `:latest` on a real (non-prerelease) GitHub Release so
+          # tag-only pushes and manual dispatches do not bump the floating tag.
+          latest: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}
           image-name: llm-d-uds-tokenizer
           registry: ghcr.io/${{ github.repository_owner }}
           github-token: ${{ secrets.GHCR_TOKEN }}

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -40,6 +40,9 @@ jobs:
         uses: ./.github/actions/docker-build-and-push
         with:
           tag: ${{ steps.tag.outputs.tag }}
+          # Only refresh `:latest` on a real (non-prerelease) GitHub Release so
+          # tag-only pushes and manual dispatches do not bump the floating tag.
+          latest: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}
           image-name: ${{ steps.version.outputs.project_name }}
           registry: ghcr.io/${{ github.repository_owner }}
           github-token: ${{ secrets.GHCR_TOKEN }}


### PR DESCRIPTION
## Summary

- Add a `latest` input (default `false`) to `.github/actions/docker-build-and-push`; when `true`, the build is additionally tagged as `:latest`.
- Wire `ci-release.yaml` and `ci-release-uds-tokenizer.yaml` to set `latest: true` only when the triggering event is a non-prerelease GitHub Release.

Fixes #581.

## Why

Previously the release workflows only pushed the immutable `vX.Y.Z` tag (and `vllm-v*` for the UDS tokenizer), so the floating `:latest` tag on ghcr.io was never refreshed by automation after the initial manual push. That left `ghcr.io/llm-d/llm-d-uds-tokenizer:latest` pointing at a 29-day-old build while `v0.8.0` had been published 9 days earlier (see #581 for the version skew vs. sibling components whose `:latest` stayed current).

The condition `github.event_name == 'release' && github.event.release.prerelease == false` matches what `llm-d-inference-scheduler` and `llm-d-router` do via their shared `docker-build-and-push` action — those repos do not exhibit the stale-`:latest` problem. Dev / PR / pre-release / `workflow_dispatch` builds keep the default `false` so the floating tag is never bumped by a non-release artifact.

## Verified end-to-end on a fork

I ran the modified workflow on `yankay/llm-d-kv-cache` against a tiny Alpine Dockerfile (single platform, to keep the build short — the tag-handling logic is what we are exercising, and it is independent of the image contents).

| # | Trigger | Workflow run | Expected | Observed on `ghcr.io/yankay/llm-d-uds-tokenizer` |
|---|---|---|---|---|
| 1 | `push` tag `v0.0.1-smoke` | [run 26761478862](https://github.com/yankay/llm-d-kv-cache/actions/runs/26761478862) ✅ | `v0.0.1-smoke` + `vllm-smoke`, no `:latest` | tags = `[v0.0.1-smoke, vllm-smoke]`, `HEAD /manifests/latest` → `404 Not Found` ✅ |
| 2 | GitHub Release `v0.0.2-smoke` (non-prerelease) | [run 26761545714](https://github.com/yankay/llm-d-kv-cache/actions/runs/26761545714) ✅ | adds `v0.0.2-smoke` + `:latest` | tags now include `latest`, manifest digest matches `v0.0.2-smoke` ✅ |

So the new `latest` input behaves as advertised: it is skipped on tag-only pushes (matching today's behavior, which is exactly what caused the staleness — no longer a regression risk) and is applied on a real release.

## Test plan

- [x] `yamllint` / `python -c "yaml.safe_load(...)"` on all three edited files
- [x] Fork smoke: tag-push does not bump `:latest` (case 1 above)
- [x] Fork smoke: non-prerelease GitHub Release does bump `:latest` (case 2 above)
- [ ] Maintainer review of the conditional expression
- [ ] Next stable release republishes `:latest` correctly