### PR TITLE
fix(pvc_evictor): clean up empty directories after batch file deletion

### DIFF
--- a/kv_connectors/pvc_evictor/processes/deleter.py
+++ b/kv_connectors/pvc_evictor/processes/deleter.py
@@ -3,6 +3,7 @@
 import contextlib
 import logging
 import multiprocessing
+import os
 import subprocess
 import time
 from pathlib import Path
@@ -13,11 +14,52 @@ from utils.system import setup_logging
 PARTIAL_BATCH_TIMEOUT_SECONDS = 5.0  # Process partial batch after N seconds of inactivity
 
 
-def delete_batch(file_paths: list[str], dry_run: bool, logger: logging.Logger) -> tuple[int, int]:
+def cleanup_empty_dirs(file_paths: list[str], cache_path: Path, logger: logging.Logger) -> int:
+    """
+    Remove empty directories left behind after file deletion.
+
+    Walks from each deleted file's parent directory upward, removing empty
+    directories until reaching cache_path or a non-empty directory.
+    Uses os.rmdir which only succeeds on empty directories.
+
+    Returns the number of directories removed.
+    """
+    dirs_removed = 0
+    cache_path_str = str(cache_path)
+
+    parents_seen: set[str] = set()
+    for path_str in file_paths:
+        parent = str(Path(path_str).parent)
+        if parent not in parents_seen:
+            parents_seen.add(parent)
+
+    for dir_path_str in sorted(parents_seen, key=len, reverse=True):
+        current = dir_path_str
+        while current.startswith(cache_path_str) and current != cache_path_str:
+            if not os.path.isdir(current):
+                current = str(Path(current).parent)
+                continue
+            try:
+                os.rmdir(current)
+                dirs_removed += 1
+            except OSError:
+                break
+            current = str(Path(current).parent)
+
+    if dirs_removed > 0:
+        logger.debug(f"Cleaned up {dirs_removed} empty directories")
+
+    return dirs_removed
+
+
+def delete_batch(
+    file_paths: list[str], dry_run: bool, logger: logging.Logger, cache_path: Path | None = None
+) -> tuple[int, int]:
     """
     Delete a batch of files using xargs rm -f (batch deletion).
 
     If xargs fails, logs error and skips the batch (files will be retried in next cycle).
+    When cache_path is provided, empty parent directories are cleaned up after deletion.
 
     Returns: (files_deleted, bytes_freed)
     """
@@ -58,6 +100,8 @@ def delete_batch(file_paths: list[str], dry_run: bool, logger: logging.Logger) -
         )
 
         if result.returncode == 0:
+            if cache_path is not None:
+                cleanup_empty_dirs(valid_paths, cache_path, logger)
             return len(valid_paths), total_bytes
         else:
             # Log error and skip batch - files will be retried in next cycle
@@ -90,6 +134,7 @@ def delete_file_batch(
     total_bytes_freed: int,
     prev_batch_time: float | None,
     result_queue: multiprocessing.Queue,
+    cache_path: Path | None = None,
 ) -> tuple[int, int, float]:
     """
     Process a batch of files for deletion and report progress to main process.
@@ -97,7 +142,7 @@ def delete_file_batch(
     Returns: (updated_total_files_deleted, updated_total_bytes_freed, batch_start_time)
     """
     batch_start_time = time.time()
-    deleted, freed = delete_batch(batch, dry_run, logger)
+    deleted, freed = delete_batch(batch, dry_run, logger, cache_path)
 
     total_files_deleted += deleted
     total_bytes_freed += freed
@@ -165,6 +210,7 @@ def deleter_process(
                                 total_bytes_freed,
                                 prev_batch_time,
                                 result_queue,
+                                cache_path,
                             )
                             current_batch = []
 
@@ -200,6 +246,7 @@ def deleter_process(
                             total_bytes_freed,
                             prev_batch_time,
                             result_queue,
+                            cache_path,
                         )
                         current_batch = []
                         last_batch_check_time = current_time
@@ -221,7 +268,7 @@ def deleter_process(
 
         # Delete remaining batch on shutdown
         if current_batch:
-            deleted, freed = delete_batch(current_batch, dry_run, logger)
+            deleted, freed = delete_batch(current_batch, dry_run, logger, cache_path)
             total_files_deleted += deleted
             total_bytes_freed += freed
 

--- a/kv_connectors/pvc_evictor/tests/test_deleter.py
+++ b/kv_connectors/pvc_evictor/tests/test_deleter.py
@@ -1,0 +1,165 @@
+# Copyright 2026 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add pvc_evictor root to path so imports work without installing
+PVC_EVICTOR_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PVC_EVICTOR_ROOT))
+
+from processes.deleter import cleanup_empty_dirs, delete_batch
+
+
+@pytest.fixture
+def cache_tree(tmp_path):
+    """Create a realistic FileMapper cache directory structure.
+
+    Layout:
+        <tmp>/cache/model_abc123_r0/0a1/0a_g0/block_0.bin
+        <tmp>/cache/model_abc123_r0/0a1/0a_g0/block_1.bin
+        <tmp>/cache/model_abc123_r0/0a1/0b_g1/block_2.bin
+        <tmp>/cache/model_abc123_r0/ff0/ff_g0/block_3.bin
+    """
+    cache_path = tmp_path / "cache"
+    dirs = [
+        cache_path / "model_abc123_r0" / "0a1" / "0a_g0",
+        cache_path / "model_abc123_r0" / "0a1" / "0b_g1",
+        cache_path / "model_abc123_r0" / "ff0" / "ff_g0",
+    ]
+    for d in dirs:
+        d.mkdir(parents=True)
+
+    files = [
+        dirs[0] / "block_0.bin",
+        dirs[0] / "block_1.bin",
+        dirs[1] / "block_2.bin",
+        dirs[2] / "block_3.bin",
+    ]
+    for f in files:
+        f.write_bytes(b"\x00" * 128)
+
+    return cache_path, files
+
+
+class TestCleanupEmptyDirs:
+    def test_removes_leaf_and_parent_dirs(self, cache_tree):
+        cache_path, files = cache_tree
+        # Delete all files in 0a_g0
+        for f in files[:2]:
+            f.unlink()
+
+        logger = logging.getLogger("test")
+        removed = cleanup_empty_dirs(
+            [str(f) for f in files[:2]], cache_path, logger
+        )
+
+        assert removed > 0
+        # 0a_g0 should be gone (was the only directory with those files)
+        assert not (cache_path / "model_abc123_r0" / "0a1" / "0a_g0").exists()
+        # 0a1 should still exist because 0b_g1 still has a file
+        assert (cache_path / "model_abc123_r0" / "0a1").exists()
+
+    def test_removes_entire_branch_when_empty(self, cache_tree):
+        cache_path, files = cache_tree
+        # Delete the only file under ff0/ff_g0
+        files[3].unlink()
+
+        logger = logging.getLogger("test")
+        removed = cleanup_empty_dirs([str(files[3])], cache_path, logger)
+
+        # ff_g0, ff0 should both be removed (both empty after deletion)
+        assert not (cache_path / "model_abc123_r0" / "ff0" / "ff_g0").exists()
+        assert not (cache_path / "model_abc123_r0" / "ff0").exists()
+        # model_abc123_r0 should still exist (0a1 branch still has files)
+        assert (cache_path / "model_abc123_r0").exists()
+        assert removed >= 2
+
+    def test_stops_at_cache_root(self, cache_tree):
+        cache_path, files = cache_tree
+        # Delete all files
+        for f in files:
+            f.unlink()
+
+        logger = logging.getLogger("test")
+        cleanup_empty_dirs([str(f) for f in files], cache_path, logger)
+
+        # cache_path itself must not be removed
+        assert cache_path.exists()
+
+    def test_no_error_on_nonempty_dirs(self, cache_tree):
+        cache_path, files = cache_tree
+        # Only delete one of two files in 0a_g0
+        files[0].unlink()
+
+        logger = logging.getLogger("test")
+        removed = cleanup_empty_dirs([str(files[0])], cache_path, logger)
+
+        # 0a_g0 still has block_1.bin so nothing should be removed
+        assert removed == 0
+        assert (cache_path / "model_abc123_r0" / "0a1" / "0a_g0").exists()
+
+    def test_no_error_on_already_removed_dirs(self, cache_tree):
+        cache_path, files = cache_tree
+        # Delete files and manually remove directory before calling cleanup
+        files[3].unlink()
+        os.rmdir(str(cache_path / "model_abc123_r0" / "ff0" / "ff_g0"))
+
+        logger = logging.getLogger("test")
+        removed = cleanup_empty_dirs([str(files[3])], cache_path, logger)
+
+        # ff_g0 was already gone, but ff0 should still be cleaned up
+        assert not (cache_path / "model_abc123_r0" / "ff0").exists()
+        assert removed >= 1
+
+
+class TestDeleteBatchWithCleanup:
+    def test_delete_batch_cleans_empty_dirs(self, cache_tree):
+        cache_path, files = cache_tree
+        # Delete the single file under ff0/ff_g0
+        deleted, freed = delete_batch(
+            [str(files[3])], dry_run=False,
+            logger=logging.getLogger("test"), cache_path=cache_path,
+        )
+
+        assert deleted == 1
+        assert freed > 0
+        assert not (cache_path / "model_abc123_r0" / "ff0").exists()
+
+    def test_delete_batch_dry_run_preserves_dirs(self, cache_tree):
+        cache_path, files = cache_tree
+        deleted, _ = delete_batch(
+            [str(files[3])], dry_run=True,
+            logger=logging.getLogger("test"), cache_path=cache_path,
+        )
+
+        assert deleted == 1
+        # Dry run should not delete the file or directory
+        assert files[3].exists()
+        assert (cache_path / "model_abc123_r0" / "ff0" / "ff_g0").exists()
+
+    def test_delete_batch_without_cache_path_skips_cleanup(self, cache_tree):
+        cache_path, files = cache_tree
+        deleted, freed = delete_batch(
+            [str(files[3])], dry_run=False,
+            logger=logging.getLogger("test"),
+        )
+
+        assert deleted == 1
+        # Without cache_path, empty directories are not cleaned up
+        assert (cache_path / "model_abc123_r0" / "ff0" / "ff_g0").exists()


### PR DESCRIPTION
## Summary

- Add bottom-up empty directory cleanup after each successful batch file deletion in the deleter process
- After `xargs rm` completes, walk from each deleted file's parent directory upward, removing empty directories until reaching the cache root
- Uses `os.rmdir` which only succeeds on empty directories, so concurrent file creation by other processes is safe

Fixes #614

## Details

The pvc_evictor's deleter process removes `.bin` cache files via `xargs rm -f` but leaves behind the nested directory tree created by the FileMapper (`<model>_<sha>_r<rank>/<hhh>/<hh>_g<group_idx>/`). Over time, hundreds of thousands of empty directories accumulate and the crawler must traverse all of them, degrading file discovery performance.

The `cleanup_empty_dirs()` function collects unique parent directories from the deleted file paths, sorts them deepest first (longest path first), and walks upward attempting `os.rmdir` on each level. The walk stops at the cache root boundary or at the first non-empty directory. Directories that were already removed by a concurrent process or a previous iteration are skipped without error.

The `cache_path` parameter is optional to maintain backward compatibility. All existing call sites in `deleter_process` now pass `cache_path` through.

## Test plan

- [x] Unit tests for `cleanup_empty_dirs` covering: leaf + parent removal, full branch removal, cache root boundary, non-empty directories, already-removed directories
- [x] Unit tests for `delete_batch` integration: cleanup with cache_path, dry run preserves dirs, no cache_path skips cleanup
- [x] All 8 tests pass locally