### PR TITLE
feat(kvblock): invalidate KV index on AllBlocksCleared via eager delete

### DIFF
--- a/pkg/kvcache/kvblock/cost_aware_memory.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory.go
@@ -57,16 +57,7 @@ func NewCostAwareMemoryIndex(cfg *CostAwareMemoryIndexConfig) (*CostAwareMemoryI
 	}
 
 	// Parse the size string to get byte value using go-humanize
-
 	sizeBytes, err := humanize.ParseBytes(cfg.Size)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize cost aware index: %w", err)
-	}
-	cache, err := ristretto.NewCache(&ristretto.Config[string, *CostPodCache]{
-		NumCounters: defaultNumCounters, // number of keys to track.
-		MaxCost:     int64(sizeBytes),   // #nosec G115 , maximum cost of cache
-		BufferItems: defaultBufferItems, // number of keys per Get buffer.
-	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize cost aware index: %w", err)
 	}
@@ -76,11 +67,30 @@ func NewCostAwareMemoryIndex(cfg *CostAwareMemoryIndexConfig) (*CostAwareMemoryI
 		return nil, fmt.Errorf("failed to initialize in-memory engine key map: %w", err)
 	}
 
-	return &CostAwareMemoryIndex{
-		data:        cache,
+	index := &CostAwareMemoryIndex{
 		requestKeys: requestKeys,
 		keyIndex:    make(map[string]struct{}),
-	}, nil
+	}
+
+	// OnEvict/OnReject fire from ristretto's processing goroutine whenever an entry
+	// leaves the cost cache (cost-based eviction or admission rejection). Pruning
+	// keyIndex there keeps it bounded to the live cost-cache set instead of growing
+	// with every key ever added. The callback takes keyIndexMu only — never mu —
+	// because Add holds mu while blocking in data.Wait(), which is what drains the
+	// buffer that triggers these callbacks; taking mu here would deadlock.
+	cache, err := ristretto.NewCache(&ristretto.Config[string, *CostPodCache]{
+		NumCounters: defaultNumCounters, // number of keys to track.
+		MaxCost:     int64(sizeBytes),   // #nosec G115 , maximum cost of cache
+		BufferItems: defaultBufferItems, // number of keys per Get buffer.
+		OnEvict:     index.onCostCacheRemoval,
+		OnReject:    index.onCostCacheRemoval,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize cost aware index: %w", err)
+	}
+	index.data = cache
+
+	return index, nil
 }
 
 // CostAwareMemoryIndex implements the Index interface using Ristretto cache for cost-aware memory management.
@@ -96,11 +106,50 @@ type CostAwareMemoryIndex struct {
 	// requestKeys holds the mapping of engine keys to request keys.
 	requestKeys *lru.Cache[BlockHash, []BlockHash]
 	// keyIndex tracks live request-key strings so Clear can enumerate them
-	// (ristretto exposes no iteration). Guarded by mu; entries are pruned in Clear
-	// when a key is found already gone from the cost cache (ristretto evicted it).
+	// (ristretto exposes no iteration). Kept bounded to the live cost-cache set by
+	// onCostCacheRemoval, which prunes a key when ristretto evicts or rejects it.
+	// Guarded by keyIndexMu (not mu) so the ristretto callback can prune without
+	// deadlocking against Add's data.Wait().
 	keyIndex map[string]struct{}
+	// keyIndexMu guards keyIndex independently of mu.
+	keyIndexMu sync.Mutex
 	// mu protects concurrent access to the index operations
 	mu sync.RWMutex
+}
+
+// onCostCacheRemoval prunes keyIndex when ristretto evicts or rejects an entry.
+// It runs on ristretto's processing goroutine, so it must take keyIndexMu only —
+// never mu. The Item carries only the hashed key, so it recovers the original
+// request-key string from the cached value's key field.
+func (m *CostAwareMemoryIndex) onCostCacheRemoval(item *ristretto.Item[*CostPodCache]) {
+	if item == nil || item.Value == nil || item.Value.key == "" {
+		return
+	}
+	m.removeKeyIndex(item.Value.key)
+}
+
+func (m *CostAwareMemoryIndex) addKeyIndex(keyStr string) {
+	m.keyIndexMu.Lock()
+	m.keyIndex[keyStr] = struct{}{}
+	m.keyIndexMu.Unlock()
+}
+
+func (m *CostAwareMemoryIndex) removeKeyIndex(keyStr string) {
+	m.keyIndexMu.Lock()
+	delete(m.keyIndex, keyStr)
+	m.keyIndexMu.Unlock()
+}
+
+// snapshotKeyIndex returns a copy of the live request keys so Clear can scan them
+// without holding keyIndexMu (or mu) for the whole pass.
+func (m *CostAwareMemoryIndex) snapshotKeyIndex() []string {
+	m.keyIndexMu.Lock()
+	defer m.keyIndexMu.Unlock()
+	keys := make([]string, 0, len(m.keyIndex))
+	for k := range m.keyIndex {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 func (m *CostAwareMemoryIndex) MaxCost() int64 {
@@ -112,6 +161,10 @@ type CostPodCache struct {
 	cache sync.Map // map[PodEntry]struct{}
 	// size tracks the number of entries in cache for O(1) Len().
 	size atomic.Int64
+	// key is the request-key string this cache is stored under. It is captured so
+	// the ristretto OnEvict/OnReject callback can prune keyIndex — the callback's
+	// Item carries only the hashed key, not the original string.
+	key string
 }
 
 // Add adds a PodEntry to the cache.
@@ -208,7 +261,7 @@ func (m *CostAwareMemoryIndex) Add(ctx context.Context, engineKeys, requestKeys 
 		keyStr := requestKey.String()
 		podCache, found := m.data.Get(keyStr)
 		if !found {
-			podCache = &CostPodCache{}
+			podCache = &CostPodCache{key: keyStr}
 		}
 
 		for _, entry := range entries {
@@ -218,7 +271,7 @@ func (m *CostAwareMemoryIndex) Add(ctx context.Context, engineKeys, requestKeys 
 		// Calculate the actual cost for this cache entry
 		cost := podCache.CalculateByteSize(keyStr)
 		m.data.Set(keyStr, podCache, cost)
-		m.keyIndex[keyStr] = struct{}{}
+		m.addKeyIndex(keyStr)
 		traceLogger.Info("added pods to key", "requestKey", requestKey, "pods", entries, "cost-bytes", cost)
 	}
 	m.data.Wait()
@@ -344,7 +397,7 @@ func (m *CostAwareMemoryIndex) evictPodsFromRequestKey(
 
 	if podCache.Len() == 0 {
 		m.data.Del(keyStr)
-		delete(m.keyIndex, keyStr)
+		m.removeKeyIndex(keyStr)
 		traceLogger.Info("removed requestKey from index as no pods remain", "requestKey", requestKey)
 	} else if podCacheLenBefore != podCache.Len() {
 		m.data.Set(keyStr, podCache, podCache.CalculateByteSize(keyStr))
@@ -353,23 +406,50 @@ func (m *CostAwareMemoryIndex) evictPodsFromRequestKey(
 }
 
 // Clear removes every entry for the pod from the index, across all device tiers.
-// O(N) over the index, but Clear is rare and off the Lookup/Add hot path.
+// It is O(N) over the index but runs off the Lookup/Add hot path at a coarse
+// cadence. The scan is chunked: it snapshots the request keys, then processes them
+// in fixed-size chunks, each taking mu only briefly, so a Clear never blocks
+// Lookup (which takes mu.RLock) for the whole pass. The trade is atomicity — a
+// concurrent Lookup may see the pod cleared from some keys but not yet from
+// others; that is acceptable since the pod's cache is cold post-reset and a stale
+// hit only costs a cache miss.
+//
+// The engineKey->requestKey mapping (requestKeys) is intentionally left untouched:
+// it is LRU-bounded, self-heals when the pod re-Adds the same prefixes, and any
+// stale mapping resolves to an emptied request key that correctly breaks the
+// prefix chain in Lookup. Reverse-pruning it would need an O(M) scan for no
+// correctness gain.
 func (m *CostAwareMemoryIndex) Clear(ctx context.Context, podIdentifier string) error {
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.CostAwareMemoryIndex.Clear")
+
+	keys := m.snapshotKeyIndex()
+
+	const clearChunkSize = 1024
+	for start := 0; start < len(keys); start += clearChunkSize {
+		end := min(start+clearChunkSize, len(keys))
+		m.clearChunk(podIdentifier, keys[start:end])
+	}
+
+	m.data.Wait()
+	traceLogger.Info("cleared pod from index", "pod", podIdentifier, "scanned", len(keys))
+	return nil
+}
+
+// clearChunk removes the pod's entries from one chunk of request keys under a
+// single mu hold, bounding how long Clear blocks the Lookup/Add path.
+func (m *CostAwareMemoryIndex) clearChunk(podIdentifier string, keys []string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.CostAwareMemoryIndex.Clear")
-
-	for keyStr := range m.keyIndex {
+	for _, keyStr := range keys {
 		podCache, found := m.data.Get(keyStr)
 		if !found || podCache == nil {
-			delete(m.keyIndex, keyStr) // ristretto evicted it under us; drop the stale key
+			m.removeKeyIndex(keyStr) // ristretto dropped it under us; drop the stale key
 			continue
 		}
 
 		// Collect-then-delete: sync.Map.Range tolerates deletes by f, but collecting
 		// first keeps the deletion explicit and the iteration simple.
-		lenBefore := podCache.Len()
 		var matched []PodEntry
 		podCache.cache.Range(func(k, _ any) bool {
 			if entry, ok := k.(PodEntry); ok && entry.PodIdentifier == podIdentifier {
@@ -377,6 +457,11 @@ func (m *CostAwareMemoryIndex) Clear(ctx context.Context, podIdentifier string) 
 			}
 			return true
 		})
+		if len(matched) == 0 {
+			continue
+		}
+
+		lenBefore := podCache.Len()
 		for _, entry := range matched {
 			podCache.Delete(entry)
 		}
@@ -384,15 +469,11 @@ func (m *CostAwareMemoryIndex) Clear(ctx context.Context, podIdentifier string) 
 		switch {
 		case podCache.Len() == 0:
 			m.data.Del(keyStr)
-			delete(m.keyIndex, keyStr)
+			m.removeKeyIndex(keyStr)
 		case podCache.Len() != lenBefore:
 			m.data.Set(keyStr, podCache, podCache.CalculateByteSize(keyStr))
 		}
 	}
-
-	m.data.Wait()
-	traceLogger.Info("cleared pod from index", "pod", podIdentifier)
-	return nil
 }
 
 // GetRequestKey returns the last request key (highest index in the chain) associated with the given engineKey.

--- a/pkg/kvcache/kvblock/cost_aware_memory.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory.go
@@ -79,6 +79,7 @@ func NewCostAwareMemoryIndex(cfg *CostAwareMemoryIndexConfig) (*CostAwareMemoryI
 	return &CostAwareMemoryIndex{
 		data:        cache,
 		requestKeys: requestKeys,
+		keyIndex:    make(map[string]struct{}),
 	}, nil
 }
 
@@ -94,6 +95,10 @@ type CostAwareMemoryIndex struct {
 	data *ristretto.Cache[string, *CostPodCache]
 	// requestKeys holds the mapping of engine keys to request keys.
 	requestKeys *lru.Cache[BlockHash, []BlockHash]
+	// keyIndex tracks live request-key strings so Clear can enumerate them
+	// (ristretto exposes no iteration). Guarded by mu; entries are pruned in Clear
+	// when a key is found already gone from the cost cache (ristretto evicted it).
+	keyIndex map[string]struct{}
 	// mu protects concurrent access to the index operations
 	mu sync.RWMutex
 }
@@ -213,6 +218,7 @@ func (m *CostAwareMemoryIndex) Add(ctx context.Context, engineKeys, requestKeys 
 		// Calculate the actual cost for this cache entry
 		cost := podCache.CalculateByteSize(keyStr)
 		m.data.Set(keyStr, podCache, cost)
+		m.keyIndex[keyStr] = struct{}{}
 		traceLogger.Info("added pods to key", "requestKey", requestKey, "pods", entries, "cost-bytes", cost)
 	}
 	m.data.Wait()
@@ -338,11 +344,55 @@ func (m *CostAwareMemoryIndex) evictPodsFromRequestKey(
 
 	if podCache.Len() == 0 {
 		m.data.Del(keyStr)
+		delete(m.keyIndex, keyStr)
 		traceLogger.Info("removed requestKey from index as no pods remain", "requestKey", requestKey)
 	} else if podCacheLenBefore != podCache.Len() {
 		m.data.Set(keyStr, podCache, podCache.CalculateByteSize(keyStr))
 		traceLogger.Info("evicted pods from key", "requestKey", requestKey, "engineKey", engineKey, "pods", entries)
 	}
+}
+
+// Clear removes every entry for the pod from the index, across all device tiers.
+// O(N) over the index, but Clear is rare and off the Lookup/Add hot path.
+func (m *CostAwareMemoryIndex) Clear(ctx context.Context, podIdentifier string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.CostAwareMemoryIndex.Clear")
+
+	for keyStr := range m.keyIndex {
+		podCache, found := m.data.Get(keyStr)
+		if !found || podCache == nil {
+			delete(m.keyIndex, keyStr) // ristretto evicted it under us; drop the stale key
+			continue
+		}
+
+		// Collect-then-delete: sync.Map.Range tolerates deletes by f, but collecting
+		// first keeps the deletion explicit and the iteration simple.
+		lenBefore := podCache.Len()
+		var matched []PodEntry
+		podCache.cache.Range(func(k, _ any) bool {
+			if entry, ok := k.(PodEntry); ok && entry.PodIdentifier == podIdentifier {
+				matched = append(matched, entry)
+			}
+			return true
+		})
+		for _, entry := range matched {
+			podCache.Delete(entry)
+		}
+
+		switch {
+		case podCache.Len() == 0:
+			m.data.Del(keyStr)
+			delete(m.keyIndex, keyStr)
+		case podCache.Len() != lenBefore:
+			m.data.Set(keyStr, podCache, podCache.CalculateByteSize(keyStr))
+		}
+	}
+
+	m.data.Wait()
+	traceLogger.Info("cleared pod from index", "pod", podIdentifier)
+	return nil
 }
 
 // GetRequestKey returns the last request key (highest index in the chain) associated with the given engineKey.

--- a/pkg/kvcache/kvblock/cost_aware_memory_internal_test.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory_internal_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvblock
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/llm-d/llm-d-kv-cache/pkg/utils/logging"
+)
+
+// TestCostAwareKeyIndexBoundedUnderEviction verifies keyIndex does not grow with
+// every key ever added. keyIndex exists only so Clear can enumerate keys (ristretto
+// has no iteration); without pruning it would defeat the cost cache's memory bound.
+// The OnEvict/OnReject callback prunes keyIndex whenever ristretto drops an entry,
+// so after adding N keys to a cache sized for ~2, keyIndex tracks the live set, not N.
+func TestCostAwareKeyIndexBoundedUnderEviction(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(t.Context())
+
+	// Size the cache to hold only a couple of single-entry keys.
+	probe := &CostPodCache{}
+	probe.Add(PodEntry{PodIdentifier: "pod", DeviceTier: "gpu"})
+	oneKeyCost := probe.CalculateByteSize(BlockHash(1).String())
+
+	cfg := DefaultCostAwareMemoryIndexConfig()
+	cfg.Size = fmt.Sprintf("%d", 2*oneKeyCost) // room for ~2 keys
+
+	index, err := NewCostAwareMemoryIndex(cfg)
+	require.NoError(t, err)
+
+	const n = 1000
+	for i := uint64(0); i < n; i++ {
+		key := BlockHash(i + 1)
+		require.NoError(t, index.Add(ctx,
+			[]BlockHash{key}, []BlockHash{key},
+			[]PodEntry{{PodIdentifier: "pod", DeviceTier: "gpu"}}))
+	}
+
+	index.keyIndexMu.Lock()
+	got := len(index.keyIndex)
+	index.keyIndexMu.Unlock()
+
+	t.Logf("keyIndex size after %d adds into a ~2-key cache: %d", n, got)
+	// Must stay near the live cost-cache set, not grow with every Add.
+	assert.Less(t, got, n/10, "keyIndex should be pruned on eviction/rejection, not retain every key")
+}

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -312,6 +312,37 @@ func (m *InMemoryIndex) evictPodsFromRequestKey(requestKey, engineKey BlockHash,
 	currentCache.mu.Unlock()
 }
 
+// Clear removes every entry for the pod from the index, across all device tiers.
+// O(N) over the index, but Clear is rare and off the Lookup/Add hot path. Reuses
+// evictPodsFromRequestKey for race-safe removal.
+func (m *InMemoryIndex) Clear(ctx context.Context, podIdentifier string) error {
+	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.InMemoryIndex.Clear")
+
+	for _, requestKey := range m.data.Keys() {
+		// Peek so a clear does not promote LRU recency on keys it scans.
+		podCache, found := m.data.Peek(requestKey)
+		if !found || podCache == nil {
+			continue
+		}
+
+		podCache.mu.Lock()
+		var matched []PodEntry
+		for _, entry := range podCache.cache.Keys() {
+			if entry.PodIdentifier == podIdentifier {
+				matched = append(matched, entry)
+			}
+		}
+		podCache.mu.Unlock()
+
+		if len(matched) > 0 {
+			m.evictPodsFromRequestKey(requestKey, EmptyBlockHash, matched, traceLogger)
+		}
+	}
+
+	traceLogger.Info("cleared pod from index", "pod", podIdentifier)
+	return nil
+}
+
 // GetRequestKey returns the last request key (highest index in the chain) associated with the given engineKey.
 // This is what Pool uses for parent hash resolution.
 // Returns an error if the engineKey mapping is missing (e.g., already evicted).

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -314,7 +314,13 @@ func (m *InMemoryIndex) evictPodsFromRequestKey(requestKey, engineKey BlockHash,
 
 // Clear removes every entry for the pod from the index, across all device tiers.
 // O(N) over the index, but Clear is rare and off the Lookup/Add hot path. Reuses
-// evictPodsFromRequestKey for race-safe removal.
+// evictPodsFromRequestKey for race-safe removal, and holds no global lock — only
+// each PodCache's mu, briefly — so it does not stall Lookup.
+//
+// The engineKey->requestKey mapping (engineToRequestKeys) is intentionally left
+// untouched: it is LRU-bounded, self-heals when the pod re-Adds the same prefixes,
+// and any stale mapping resolves to an emptied request key that correctly breaks
+// the prefix chain in Lookup.
 func (m *InMemoryIndex) Clear(ctx context.Context, podIdentifier string) error {
 	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.InMemoryIndex.Clear")
 

--- a/pkg/kvcache/kvblock/index.go
+++ b/pkg/kvcache/kvblock/index.go
@@ -146,6 +146,12 @@ type Index interface {
 	Evict(ctx context.Context, key BlockHash, keyType KeyType, entries []PodEntry) error
 	// GetRequestKey returns the requestKey associated with the given engineKey.
 	GetRequestKey(ctx context.Context, engineKey BlockHash) (BlockHash, error)
+	// Clear removes all index entries for the given pod, across every device tier.
+	// It backs the AllBlocksCleared KV-event (a vLLM prefix-cache reset, e.g. after
+	// an RLHF weight update), which is pod-wide — vLLM emits it with no tier. Clear is
+	// O(N) over the index but runs off the Lookup/Add hot path, at a coarse cadence
+	// (typically once per weight sync).
+	Clear(ctx context.Context, podIdentifier string) error
 }
 
 // KeyType indicates whether a key passed to Evict is an engine key or a request key.

--- a/pkg/kvcache/kvblock/index_test.go
+++ b/pkg/kvcache/kvblock/index_test.go
@@ -138,6 +138,101 @@ func testCommonIndexBehavior(t *testing.T, indexFactory func(t *testing.T) Index
 		index := indexFactory(t)
 		testLookupPreservesGroupIdentity(t, ctx, index)
 	})
+
+	t.Run("ClearBasic", func(t *testing.T) {
+		index := indexFactory(t)
+		testClearBasic(t, ctx, index)
+	})
+
+	t.Run("ClearIsolatesOtherPods", func(t *testing.T) {
+		index := indexFactory(t)
+		testClearIsolatesOtherPods(t, ctx, index)
+	})
+
+	t.Run("ClearAllTiers", func(t *testing.T) {
+		index := indexFactory(t)
+		testClearAllTiers(t, ctx, index)
+	})
+
+	t.Run("ClearThenReAdd", func(t *testing.T) {
+		index := indexFactory(t)
+		testClearThenReAdd(t, ctx, index)
+	})
+}
+
+// testClearBasic verifies Clear makes all of a pod's entries invisible to Lookup.
+func testClearBasic(t *testing.T, ctx context.Context, index Index) {
+	t.Helper()
+	pod := PodEntry{PodIdentifier: "pod-clear", DeviceTier: "gpu"}
+	key := BlockHash(0xC1EA0001)
+
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{key}, []PodEntry{pod}))
+
+	hits, err := index.Lookup(ctx, []BlockHash{key}, sets.Set[string]{})
+	require.NoError(t, err)
+	assert.Len(t, hits[key], 1, "pod should be visible before Clear")
+
+	require.NoError(t, index.Clear(ctx, pod.PodIdentifier))
+
+	hits, err = index.Lookup(ctx, []BlockHash{key}, sets.Set[string]{})
+	require.NoError(t, err)
+	assert.Empty(t, hits[key], "pod must not be visible after Clear")
+}
+
+// testClearIsolatesOtherPods verifies Clear for one pod leaves another pod intact.
+func testClearIsolatesOtherPods(t *testing.T, ctx context.Context, index Index) {
+	t.Helper()
+	podA := PodEntry{PodIdentifier: "pod-A", DeviceTier: "gpu"}
+	podB := PodEntry{PodIdentifier: "pod-B", DeviceTier: "gpu"}
+	key := BlockHash(0xC1EA0002)
+
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{key}, []PodEntry{podA, podB}))
+	require.NoError(t, index.Clear(ctx, podA.PodIdentifier))
+
+	hits, err := index.Lookup(ctx, []BlockHash{key}, sets.Set[string]{})
+	require.NoError(t, err)
+	assert.Len(t, hits[key], 1, "podB must survive clearing podA")
+	assert.Equal(t, podB, hits[key][0])
+}
+
+// testClearAllTiers verifies Clear is pod-wide: it removes the pod across every
+// device tier and entry variant (including HMA-grouped entries), while leaving
+// a different pod on the same tier intact.
+func testClearAllTiers(t *testing.T, ctx context.Context, index Index) {
+	t.Helper()
+	gpu := PodEntry{PodIdentifier: "pod-tiers", DeviceTier: "gpu"}
+	cpu := PodEntry{PodIdentifier: "pod-tiers", DeviceTier: "cpu"}
+	grouped := PodEntry{PodIdentifier: "pod-tiers", DeviceTier: "gpu", HasGroup: true, GroupIdx: 1}
+	other := PodEntry{PodIdentifier: "pod-other", DeviceTier: "gpu"}
+	key := BlockHash(0xC1EA0003)
+
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{key}, []PodEntry{gpu, cpu, grouped, other}))
+
+	require.NoError(t, index.Clear(ctx, "pod-tiers"))
+
+	hits, err := index.Lookup(ctx, []BlockHash{key}, sets.Set[string]{})
+	require.NoError(t, err)
+	assert.Len(t, hits[key], 1, "all tiers and group variants of pod-tiers must be cleared; pod-other survives")
+	assert.Equal(t, other, hits[key][0])
+}
+
+// testClearThenReAdd verifies a pod re-added after Clear is visible again.
+func testClearThenReAdd(t *testing.T, ctx context.Context, index Index) {
+	t.Helper()
+	pod := PodEntry{PodIdentifier: "pod-readd", DeviceTier: "gpu"}
+	key := BlockHash(0xC1EA0004)
+
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{key}, []PodEntry{pod}))
+	require.NoError(t, index.Clear(ctx, pod.PodIdentifier))
+
+	hits, err := index.Lookup(ctx, []BlockHash{key}, sets.Set[string]{})
+	require.NoError(t, err)
+	assert.Empty(t, hits[key], "pod must be invisible right after Clear")
+
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{key}, []PodEntry{pod}))
+	hits, err = index.Lookup(ctx, []BlockHash{key}, sets.Set[string]{})
+	require.NoError(t, err)
+	assert.Len(t, hits[key], 1, "re-added pod must be visible after Clear")
 }
 
 // testBasicAddAndLookup tests basic Add and Lookup functionality.

--- a/pkg/kvcache/kvblock/instrumented_index.go
+++ b/pkg/kvcache/kvblock/instrumented_index.go
@@ -68,6 +68,10 @@ func (m *instrumentedIndex) GetRequestKey(ctx context.Context, engineKey BlockHa
 	return m.next.GetRequestKey(ctx, engineKey)
 }
 
+func (m *instrumentedIndex) Clear(ctx context.Context, podIdentifier string) error {
+	return m.next.Clear(ctx, podIdentifier)
+}
+
 func recordHitMetrics(keyToPods map[BlockHash][]PodEntry) {
 	podCount := make(map[string]int)
 	for _, pods := range keyToPods {

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -407,3 +407,61 @@ func (r *RedisIndex) GetRequestKey(ctx context.Context, engineKey BlockHash) (Bl
 func redisEngineKey(engineKey BlockHash) string {
 	return "engine:" + engineKey.String()
 }
+
+// Clear removes every hash field for the pod across all request-key hashes and
+// device tiers. Each field is a JSON-encoded PodEntry, so matching decodes the
+// field and compares PodIdentifier — catching every tier, group, and speculative
+// variant. It pages the keyspace with SCAN (skipping engine: keys), HDELs the
+// pod's fields, and prunes now-empty hashes. O(keyspace), but Clear is rare and
+// off the Lookup/Add hot path. Because it deletes from the shared store, it is
+// correct for multi-replica deployments with no cross-process coordination.
+func (r *RedisIndex) Clear(ctx context.Context, podIdentifier string) error {
+	logger := log.FromContext(ctx).WithName("kvblock.RedisIndex.Clear")
+
+	const scanBatch int64 = 1024
+	removed := 0
+	var cursor uint64
+	for {
+		keys, next, err := r.RedisClient.Scan(ctx, cursor, "*", scanBatch).Result()
+		if err != nil {
+			return fmt.Errorf("clear scan failed: %w", err)
+		}
+		for _, key := range keys {
+			if strings.HasPrefix(key, "engine:") {
+				continue // engine:<hash> ZSETs hold no pod fields
+			}
+
+			fields, err := r.RedisClient.HKeys(ctx, key).Result()
+			if err != nil {
+				return fmt.Errorf("clear hkeys failed for %s: %w", key, err)
+			}
+
+			var stale []string
+			for _, field := range fields {
+				if entry, ok := decodeRedisPodField(field); ok && entry.PodIdentifier == podIdentifier {
+					stale = append(stale, field)
+				}
+			}
+			if len(stale) == 0 {
+				continue
+			}
+
+			if err := r.RedisClient.HDel(ctx, key, stale...).Err(); err != nil {
+				return fmt.Errorf("clear hdel failed for %s: %w", key, err)
+			}
+			removed += len(stale)
+
+			if err := pruneRequestKeyScript.Run(ctx, r.RedisClient, []string{key}).Err(); err != nil &&
+				!errors.Is(err, redis.Nil) {
+				return fmt.Errorf("clear prune failed for %s: %w", key, err)
+			}
+		}
+
+		if cursor = next; cursor == 0 {
+			break
+		}
+	}
+
+	logger.Info("cleared pod from index", "pod", podIdentifier, "removed", removed)
+	return nil
+}

--- a/pkg/kvcache/kvblock/traced_index.go
+++ b/pkg/kvcache/kvblock/traced_index.go
@@ -123,6 +123,10 @@ func (t *tracedIndex) GetRequestKey(ctx context.Context, engineKey BlockHash) (B
 	return t.next.GetRequestKey(ctx, engineKey)
 }
 
+func (t *tracedIndex) Clear(ctx context.Context, podIdentifier string) error {
+	return t.next.Clear(ctx, podIdentifier)
+}
+
 func keyTypeLabel(keyType KeyType) string {
 	switch keyType {
 	case EngineKey:

--- a/pkg/kvcache/kvblock/traced_index_test.go
+++ b/pkg/kvcache/kvblock/traced_index_test.go
@@ -227,3 +227,7 @@ func (f *failingIndex) Evict(context.Context, kvblock.BlockHash, kvblock.KeyType
 func (f *failingIndex) GetRequestKey(context.Context, kvblock.BlockHash) (kvblock.BlockHash, error) {
 	return kvblock.EmptyBlockHash, f.err
 }
+
+func (f *failingIndex) Clear(context.Context, string) error {
+	return f.err
+}

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -449,6 +449,14 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 				"deviceTier", ev.DeviceTier,
 				"modelName", modelName)
 
+			// AllBlocksCleared is pod-wide: vLLM reset its entire prefix cache
+			// (e.g. after an RLHF weight update), so drop every entry for this pod
+			// across all tiers. vLLM emits the event with no tier annotation.
+			if err := p.index.Clear(ctx, podIdentifier); err != nil {
+				debugLogger.Error(err, "Failed to clear pod from index",
+					"podIdentifier", podIdentifier)
+			}
+
 		default:
 			debugLogger.Info("Unknown event", "podIdentifier", podIdentifier, "event", genericEvent)
 		}

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -451,7 +451,15 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 
 			// AllBlocksCleared is pod-wide: vLLM reset its entire prefix cache
 			// (e.g. after an RLHF weight update), so drop every entry for this pod
-			// across all tiers. vLLM emits the event with no tier annotation.
+			// across all tiers. vLLM and SGLang both emit it with no tier annotation.
+			// Index.Clear cannot scope by tier, so if an engine ever starts setting
+			// DeviceTier (a tier-scoped reset), this would over-wipe the other tiers.
+			// Surface that here so the regression does not pass silently.
+			if ev.DeviceTier != "" {
+				debugLogger.Info("AllBlocksCleared carried a device tier; clearing all tiers "+
+					"anyway (tier-scoped clear is not supported)",
+					"podIdentifier", podIdentifier, "deviceTier", ev.DeviceTier)
+			}
 			if err := p.index.Clear(ctx, podIdentifier); err != nil {
 				debugLogger.Error(err, "Failed to clear pod from index",
 					"podIdentifier", podIdentifier)

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -786,3 +786,42 @@ func TestCanonicalWritePath_PartialBlockDrop(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result[kvblock.BlockHash(1)])
 }
+
+// TestAllBlocksCleared_Dispatch verifies the pool wires AllBlocksCleared to
+// Index.Clear: the event drops every entry for the emitting pod and leaves
+// other pods untouched.
+func TestAllBlocksCleared_Dispatch(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, idx, tp := newTestPool(t, 16)
+
+	// Same tokens from two pods -> both pods land on the same canonical keys.
+	tokens := makeTokens(64)
+	storeBatch := func(base uint64) *EventBatch {
+		return &EventBatch{
+			Events: []GenericEvent{
+				&BlockStoredEvent{
+					BlockHashes: makeEngineKeys(4, base),
+					Tokens:      tokens,
+					ParentHash:  0,
+				},
+			},
+		}
+	}
+	pool.processEventBatch(ctx, storeBatch(500), "pod-cleared", "test-model")
+	pool.processEventBatch(ctx, storeBatch(900), "pod-kept", "test-model")
+
+	canonicalKeys, err := tp.TokensToKVBlockKeys(
+		kvblock.EmptyBlockHash, tokens, "test-model", nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, canonicalKeys)
+
+	clearBatch := &EventBatch{Events: []GenericEvent{&AllBlocksClearedEvent{}}}
+	pool.processEventBatch(ctx, clearBatch, "pod-cleared", "test-model")
+
+	for _, ck := range canonicalKeys {
+		result, err := idx.Lookup(ctx, []kvblock.BlockHash{ck}, nil)
+		require.NoError(t, err)
+		require.Len(t, result[ck], 1, "only the surviving pod should remain on key %s", ck)
+		assert.Equal(t, "pod-kept", result[ck][0].PodIdentifier)
+	}
+}


### PR DESCRIPTION
Wire the AllBlocksCleared KV-event to a new Index.Clear(podIdentifier) that eagerly removes the pod's entries across all device tiers. vLLM emits AllBlocksCleared only from reset_prefix_cache() — a pod-wide prefix-cache reset (with no tier) that, in RL rollouts, fires once per weight sync inside a drain/barrier (the engine is paused and the cache is cold afterward regardless). That cadence and slack make an O(N) clear off the hot path the right trade: it adds zero steady-state cost to the Lookup/Add paths (the index's hottest path), unlike a per-entry generation filter.

- Index.Clear(ctx, podIdentifier): pod-wide, all tiers. A string arg (not a PodEntry) so the signature cannot imply tier scoping the event never carries.
- InMemory: iterate keys, reuse evictPodsFromRequestKey for race-safe removal.
- CostAware: add a keyIndex set (ristretto has no iteration); prune on clear/evict.
- Redis/Valkey: SCAN + HDEL the pod's "<pod>@" fields + prune empty hashes; deletes from the shared store, so it is correct across replicas without cross-process coordination.
- pool.go: AllBlocksCleared now calls index.Clear (was a no-op log).
- Shared interface tests: basic clear, pod isolation, all-tiers, re-add.