### PR TITLE
feat(kvevents): Track HMA group identity in kv cache index

### DIFF
--- a/pkg/kvcache/kvblock/hma.go
+++ b/pkg/kvcache/kvblock/hma.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvblock
+
+import "sync"
+
+// GroupID identifies a vLLM KV cache group.
+type GroupID int
+
+// GroupMetadata holds per-group KV cache spec info learned from BlockStored events.
+type GroupMetadata struct {
+	Kind              string
+	BlockSize         int
+	SlidingWindowSize *int
+}
+
+// GroupCatalog is a thread-safe catalog of per-pod KV cache group metadata.
+type GroupCatalog struct {
+	mu      sync.RWMutex
+	entries map[string]map[GroupID]GroupMetadata
+}
+
+// NewGroupCatalog creates a new, empty GroupCatalog.
+func NewGroupCatalog() *GroupCatalog {
+	return &GroupCatalog{
+		entries: make(map[string]map[GroupID]GroupMetadata),
+	}
+}
+
+// Learn records group metadata for a pod.
+func (c *GroupCatalog) Learn(podID string, g GroupID, meta GroupMetadata) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.entries[podID] == nil {
+		c.entries[podID] = make(map[GroupID]GroupMetadata)
+	}
+	c.entries[podID][g] = meta
+}
+
+// Get returns the metadata for a pod group.
+func (c *GroupCatalog) Get(podID string, g GroupID) (GroupMetadata, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	groups, ok := c.entries[podID]
+	if !ok {
+		return GroupMetadata{}, false
+	}
+	meta, ok := groups[g]
+	return meta, ok
+}

--- a/pkg/kvcache/kvblock/in_memory_test.go
+++ b/pkg/kvcache/kvblock/in_memory_test.go
@@ -222,18 +222,3 @@ func TestAddWithNilEngineKeys(t *testing.T) {
 	_, err = index.GetRequestKey(ctx, requestKey)
 	assert.Error(t, err, "GetRequestKey should fail since no engineKey mapping was created")
 }
-
-// TestPodEntryString tests the String() method with and without Annotation.
-func TestPodEntryString(t *testing.T) {
-	confirmed := PodEntry{PodIdentifier: "10.0.0.1:8080", DeviceTier: "gpu"}
-	assert.Equal(t, "10.0.0.1:8080@gpu", confirmed.String())
-
-	speculative := PodEntry{PodIdentifier: "10.0.0.1:8080", DeviceTier: "gpu", Speculative: true}
-	assert.Equal(t, "10.0.0.1:8080@gpu[speculative]", speculative.String())
-
-	group := PodEntry{PodIdentifier: "10.0.0.1:8080", DeviceTier: "gpu", HasGroup: true, GroupIdx: 1}
-	assert.Equal(t, "10.0.0.1:8080@gpu[group=1]", group.String())
-
-	notSpeculative := PodEntry{PodIdentifier: "10.0.0.1:8080", DeviceTier: "gpu", Speculative: false}
-	assert.Equal(t, "10.0.0.1:8080@gpu", notSpeculative.String())
-}

--- a/pkg/kvcache/kvblock/in_memory_test.go
+++ b/pkg/kvcache/kvblock/in_memory_test.go
@@ -231,6 +231,9 @@ func TestPodEntryString(t *testing.T) {
 	speculative := PodEntry{PodIdentifier: "10.0.0.1:8080", DeviceTier: "gpu", Speculative: true}
 	assert.Equal(t, "10.0.0.1:8080@gpu[speculative]", speculative.String())
 
+	group := PodEntry{PodIdentifier: "10.0.0.1:8080", DeviceTier: "gpu", HasGroup: true, GroupIdx: 1}
+	assert.Equal(t, "10.0.0.1:8080@gpu[group=1]", group.String())
+
 	notSpeculative := PodEntry{PodIdentifier: "10.0.0.1:8080", DeviceTier: "gpu", Speculative: false}
 	assert.Equal(t, "10.0.0.1:8080@gpu", notSpeculative.String())
 }

--- a/pkg/kvcache/kvblock/index.go
+++ b/pkg/kvcache/kvblock/index.go
@@ -180,6 +180,10 @@ type PodEntry struct {
 	DeviceTier string
 	// Speculative indicates the entry was added predictively before a KV event confirmed it.
 	Speculative bool
+	// HasGroup indicates GroupIdx identifies a vLLM KV cache group.
+	HasGroup bool
+	// GroupIdx identifies the vLLM KV cache group for HMA events.
+	GroupIdx GroupID
 }
 
 // String returns a string representation of the PodEntry.
@@ -187,6 +191,9 @@ func (e *PodEntry) String() string {
 	suffix := ""
 	if e.Speculative {
 		suffix = "[speculative]"
+	}
+	if e.HasGroup {
+		suffix += fmt.Sprintf("[group=%d]", e.GroupIdx)
 	}
 	return fmt.Sprintf("%s@%s%s", e.PodIdentifier, e.DeviceTier, suffix)
 }

--- a/pkg/kvcache/kvblock/index_test.go
+++ b/pkg/kvcache/kvblock/index_test.go
@@ -118,6 +118,26 @@ func testCommonIndexBehavior(t *testing.T, indexFactory func(t *testing.T) Index
 		index := indexFactory(t)
 		testEvictPreservesEngineMappingForOtherTiers(t, ctx, index)
 	})
+
+	t.Run("HMAGroupEntriesCoexist", func(t *testing.T) {
+		index := indexFactory(t)
+		testHMAGroupEntriesCoexist(t, ctx, index)
+	})
+
+	t.Run("HMAGroupLevelEvict", func(t *testing.T) {
+		index := indexFactory(t)
+		testHMAGroupLevelEvict(t, ctx, index)
+	})
+
+	t.Run("HMAGroupLevelEvictLastGroup", func(t *testing.T) {
+		index := indexFactory(t)
+		testHMAGroupLevelEvictLastGroup(t, ctx, index)
+	})
+
+	t.Run("LookupGroupPropagated", func(t *testing.T) {
+		index := indexFactory(t)
+		testLookupGroupPropagated(t, ctx, index)
+	})
 }
 
 // testBasicAddAndLookup tests basic Add and Lookup functionality.
@@ -790,4 +810,70 @@ func testEvictPreservesEngineMappingForOtherTiers(t *testing.T, ctx context.Cont
 	// Engine→request mapping should be gone.
 	_, err = index.GetRequestKey(ctx, engineKey)
 	assert.Error(t, err, "engine→request mapping should be removed after full eviction")
+}
+
+func testHMAGroupEntriesCoexist(t *testing.T, ctx context.Context, index Index) {
+	t.Helper()
+	engineKey := BlockHash(11111111)
+	requestKey := BlockHash(22222222)
+
+	pod0 := PodEntry{PodIdentifier: "pod-a", DeviceTier: "gpu", HasGroup: true, GroupIdx: 0}
+	err := index.Add(ctx, []BlockHash{engineKey}, []BlockHash{requestKey}, []PodEntry{pod0})
+	require.NoError(t, err)
+
+	pod1 := PodEntry{PodIdentifier: "pod-a", DeviceTier: "gpu", HasGroup: true, GroupIdx: 1}
+	err = index.Add(ctx, []BlockHash{engineKey}, []BlockHash{requestKey}, []PodEntry{pod1})
+	require.NoError(t, err)
+
+	podsPerKey, err := index.Lookup(ctx, []BlockHash{requestKey}, nil)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []PodEntry{pod0, pod1}, podsPerKey[requestKey])
+}
+
+func testHMAGroupLevelEvict(t *testing.T, ctx context.Context, index Index) {
+	t.Helper()
+	engineKey := BlockHash(33333333)
+	requestKey := BlockHash(44444444)
+
+	podG0 := PodEntry{PodIdentifier: "pod-b", DeviceTier: "gpu", HasGroup: true, GroupIdx: 0}
+	podG1 := PodEntry{PodIdentifier: "pod-b", DeviceTier: "gpu", HasGroup: true, GroupIdx: 1}
+	err := index.Add(ctx, []BlockHash{engineKey}, []BlockHash{requestKey}, []PodEntry{podG0, podG1})
+	require.NoError(t, err)
+
+	err = index.Evict(ctx, engineKey, EngineKey, []PodEntry{podG1})
+	require.NoError(t, err)
+
+	podsPerKey, err := index.Lookup(ctx, []BlockHash{requestKey}, nil)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []PodEntry{podG0}, podsPerKey[requestKey])
+}
+
+func testHMAGroupLevelEvictLastGroup(t *testing.T, ctx context.Context, index Index) {
+	t.Helper()
+	engineKey := BlockHash(66666666)
+	requestKey := BlockHash(77777777)
+
+	podG0 := PodEntry{PodIdentifier: "pod-d", DeviceTier: "gpu", HasGroup: true, GroupIdx: 0}
+	err := index.Add(ctx, []BlockHash{engineKey}, []BlockHash{requestKey}, []PodEntry{podG0})
+	require.NoError(t, err)
+
+	err = index.Evict(ctx, engineKey, EngineKey, []PodEntry{podG0})
+	require.NoError(t, err)
+
+	podsPerKey, err := index.Lookup(ctx, []BlockHash{requestKey}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, podsPerKey[requestKey], "entry should be gone after last group evicted")
+}
+
+func testLookupGroupPropagated(t *testing.T, ctx context.Context, index Index) {
+	t.Helper()
+	requestKey := BlockHash(88888888)
+	pod := PodEntry{PodIdentifier: "pod-e", DeviceTier: "gpu", HasGroup: true, GroupIdx: 2}
+	err := index.Add(ctx, nil, []BlockHash{requestKey}, []PodEntry{pod})
+	require.NoError(t, err)
+
+	podsPerKey, err := index.Lookup(ctx, []BlockHash{requestKey}, nil)
+	require.NoError(t, err)
+	require.Len(t, podsPerKey[requestKey], 1)
+	assert.Equal(t, pod, podsPerKey[requestKey][0])
 }

--- a/pkg/kvcache/kvblock/index_test.go
+++ b/pkg/kvcache/kvblock/index_test.go
@@ -119,24 +119,24 @@ func testCommonIndexBehavior(t *testing.T, indexFactory func(t *testing.T) Index
 		testEvictPreservesEngineMappingForOtherTiers(t, ctx, index)
 	})
 
-	t.Run("HMAGroupEntriesCoexist", func(t *testing.T) {
+	t.Run("GroupedEntriesCoexist", func(t *testing.T) {
 		index := indexFactory(t)
-		testHMAGroupEntriesCoexist(t, ctx, index)
+		testGroupedEntriesCoexist(t, ctx, index)
 	})
 
-	t.Run("HMAGroupLevelEvict", func(t *testing.T) {
+	t.Run("GroupedEvictRemovesOneGroup", func(t *testing.T) {
 		index := indexFactory(t)
-		testHMAGroupLevelEvict(t, ctx, index)
+		testGroupedEvictRemovesOneGroup(t, ctx, index)
 	})
 
-	t.Run("HMAGroupLevelEvictLastGroup", func(t *testing.T) {
+	t.Run("GroupedEvictRemovesLastGroup", func(t *testing.T) {
 		index := indexFactory(t)
-		testHMAGroupLevelEvictLastGroup(t, ctx, index)
+		testGroupedEvictRemovesLastGroup(t, ctx, index)
 	})
 
-	t.Run("LookupGroupPropagated", func(t *testing.T) {
+	t.Run("LookupPreservesGroupIdentity", func(t *testing.T) {
 		index := indexFactory(t)
-		testLookupGroupPropagated(t, ctx, index)
+		testLookupPreservesGroupIdentity(t, ctx, index)
 	})
 }
 
@@ -812,7 +812,7 @@ func testEvictPreservesEngineMappingForOtherTiers(t *testing.T, ctx context.Cont
 	assert.Error(t, err, "engine→request mapping should be removed after full eviction")
 }
 
-func testHMAGroupEntriesCoexist(t *testing.T, ctx context.Context, index Index) {
+func testGroupedEntriesCoexist(t *testing.T, ctx context.Context, index Index) {
 	t.Helper()
 	engineKey := BlockHash(11111111)
 	requestKey := BlockHash(22222222)
@@ -830,7 +830,7 @@ func testHMAGroupEntriesCoexist(t *testing.T, ctx context.Context, index Index) 
 	assert.ElementsMatch(t, []PodEntry{pod0, pod1}, podsPerKey[requestKey])
 }
 
-func testHMAGroupLevelEvict(t *testing.T, ctx context.Context, index Index) {
+func testGroupedEvictRemovesOneGroup(t *testing.T, ctx context.Context, index Index) {
 	t.Helper()
 	engineKey := BlockHash(33333333)
 	requestKey := BlockHash(44444444)
@@ -848,7 +848,7 @@ func testHMAGroupLevelEvict(t *testing.T, ctx context.Context, index Index) {
 	assert.ElementsMatch(t, []PodEntry{podG0}, podsPerKey[requestKey])
 }
 
-func testHMAGroupLevelEvictLastGroup(t *testing.T, ctx context.Context, index Index) {
+func testGroupedEvictRemovesLastGroup(t *testing.T, ctx context.Context, index Index) {
 	t.Helper()
 	engineKey := BlockHash(66666666)
 	requestKey := BlockHash(77777777)
@@ -865,7 +865,7 @@ func testHMAGroupLevelEvictLastGroup(t *testing.T, ctx context.Context, index In
 	assert.Empty(t, podsPerKey[requestKey], "entry should be gone after last group evicted")
 }
 
-func testLookupGroupPropagated(t *testing.T, ctx context.Context, index Index) {
+func testLookupPreservesGroupIdentity(t *testing.T, ctx context.Context, index Index) {
 	t.Helper()
 	requestKey := BlockHash(88888888)
 	pod := PodEntry{PodIdentifier: "pod-e", DeviceTier: "gpu", HasGroup: true, GroupIdx: 2}

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -18,6 +18,7 @@ package kvblock
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -187,12 +188,10 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 
 	// pipeline for single RTT
 	pipe := r.RedisClient.Pipeline()
-	results := make([]*redis.StringSliceCmd, len(requestKeys))
+	results := make([]*redis.MapStringStringCmd, len(requestKeys))
 
-	// queue an HKeys command for each key in the pipeline
 	for i, key := range requestKeys {
-		// HKeys gets all field names
-		results[i] = pipe.HKeys(ctx, key.String())
+		results[i] = pipe.HGetAll(ctx, key.String())
 	}
 
 	_, execErr := pipe.Exec(ctx)
@@ -205,7 +204,6 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 	for idx, cmd := range results {
 		key := requestKeys[idx]
 
-		// cmd.Result() returns the slice of strings (pod IDs) which is the first layer in the mapping
 		pods, cmdErr := cmd.Result()
 		if cmdErr != nil {
 			if !errors.Is(cmdErr, redis.Nil) {
@@ -217,16 +215,12 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 
 		var filteredPods []PodEntry
 		for _, p := range pods {
-			ip := strings.SplitN(p, "@", 2)[0]
-			if !filterPods || podIdentifierSet.Has(ip) {
-				tier := strings.SplitN(p, "@", 2)[1]
-				speculative := false
-				// Strip annotation suffix e.g. "gpu[speculative]" -> "gpu"
-				if idx := strings.Index(tier, "["); idx != -1 {
-					speculative = strings.Contains(tier[idx:], "speculative")
-					tier = tier[:idx]
-				}
-				filteredPods = append(filteredPods, PodEntry{PodIdentifier: ip, DeviceTier: tier, Speculative: speculative})
+			pod, ok := parseRedisPodValue(p)
+			if !ok {
+				continue
+			}
+			if !filterPods || podIdentifierSet.Has(pod.PodIdentifier) {
+				filteredPods = append(filteredPods, pod)
 			}
 		}
 
@@ -270,7 +264,7 @@ func (r *RedisIndex) Add(ctx context.Context, engineKeys, requestKeys []BlockHas
 	for _, requestKey := range requestKeys {
 		redisKey := requestKey.String()
 		for _, entry := range entries {
-			pipe.HSet(ctx, redisKey, entry.String(), "")
+			pipe.HSet(ctx, redisKey, redisPodField(entry), redisPodValue(entry))
 		}
 	}
 
@@ -324,7 +318,7 @@ func (r *RedisIndex) evictPodsFromRequestKey(ctx context.Context, requestKey Blo
 	pipe := r.RedisClient.Pipeline()
 
 	for _, entry := range entries {
-		pipe.HDel(ctx, redisKey, entry.String())
+		pipe.HDel(ctx, redisKey, redisPodField(entry))
 	}
 
 	if _, err := pipe.Exec(ctx); err != nil {
@@ -337,6 +331,53 @@ func (r *RedisIndex) evictPodsFromRequestKey(ctx context.Context, requestKey Blo
 	}
 
 	return nil
+}
+
+type redisPodValuePayload struct {
+	PodIdentifier string  `json:"pod"`
+	DeviceTier    string  `json:"tier"`
+	Speculative   bool    `json:"speculative"`
+	HasGroup      bool    `json:"hasGroup"`
+	GroupIdx      GroupID `json:"groupIdx"`
+}
+
+func redisPodField(entry PodEntry) string {
+	group := "_"
+	if entry.HasGroup {
+		group = strconv.Itoa(int(entry.GroupIdx))
+	}
+	return strings.Join([]string{
+		entry.PodIdentifier,
+		entry.DeviceTier,
+		strconv.FormatBool(entry.Speculative),
+		group,
+	}, "\x00")
+}
+
+func redisPodValue(entry PodEntry) string {
+	value, _ := json.Marshal(redisPodValuePayload{
+		PodIdentifier: entry.PodIdentifier,
+		DeviceTier:    entry.DeviceTier,
+		Speculative:   entry.Speculative,
+		HasGroup:      entry.HasGroup,
+		GroupIdx:      entry.GroupIdx,
+	})
+	return string(value)
+}
+
+func parseRedisPodValue(s string) (PodEntry, bool) {
+	var field redisPodValuePayload
+	if err := json.Unmarshal([]byte(s), &field); err != nil {
+		return PodEntry{}, false
+	}
+
+	return PodEntry{
+		PodIdentifier: field.PodIdentifier,
+		DeviceTier:    field.DeviceTier,
+		Speculative:   field.Speculative,
+		HasGroup:      field.HasGroup,
+		GroupIdx:      field.GroupIdx,
+	}, true
 }
 
 // getRequestKeys returns all request keys mapped to the given engine key.

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -188,10 +188,10 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 
 	// pipeline for single RTT
 	pipe := r.RedisClient.Pipeline()
-	results := make([]*redis.MapStringStringCmd, len(requestKeys))
+	results := make([]*redis.StringSliceCmd, len(requestKeys))
 
 	for i, key := range requestKeys {
-		results[i] = pipe.HGetAll(ctx, key.String())
+		results[i] = pipe.HKeys(ctx, key.String())
 	}
 
 	_, execErr := pipe.Exec(ctx)
@@ -215,7 +215,7 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 
 		var filteredPods []PodEntry
 		for _, p := range pods {
-			pod, ok := parseRedisPodValue(p)
+			pod, ok := parseRedisPodField(p)
 			if !ok {
 				continue
 			}
@@ -264,11 +264,11 @@ func (r *RedisIndex) Add(ctx context.Context, engineKeys, requestKeys []BlockHas
 	for _, requestKey := range requestKeys {
 		redisKey := requestKey.String()
 		for _, entry := range entries {
-			value, err := redisPodValue(entry)
+			field, err := redisPodField(entry)
 			if err != nil {
 				return err
 			}
-			pipe.HSet(ctx, redisKey, redisPodField(entry), value)
+			pipe.HSet(ctx, redisKey, field, "")
 		}
 	}
 
@@ -322,7 +322,11 @@ func (r *RedisIndex) evictPodsFromRequestKey(ctx context.Context, requestKey Blo
 	pipe := r.RedisClient.Pipeline()
 
 	for _, entry := range entries {
-		pipe.HDel(ctx, redisKey, redisPodField(entry))
+		field, err := redisPodField(entry)
+		if err != nil {
+			return err
+		}
+		pipe.HDel(ctx, redisKey, field)
 	}
 
 	if _, err := pipe.Exec(ctx); err != nil {
@@ -337,20 +341,7 @@ func (r *RedisIndex) evictPodsFromRequestKey(ctx context.Context, requestKey Blo
 	return nil
 }
 
-func redisPodField(entry PodEntry) string {
-	group := "_"
-	if entry.HasGroup {
-		group = strconv.Itoa(int(entry.GroupIdx))
-	}
-	return strings.Join([]string{
-		entry.PodIdentifier,
-		entry.DeviceTier,
-		strconv.FormatBool(entry.Speculative),
-		group,
-	}, "\x00")
-}
-
-func redisPodValue(entry PodEntry) (string, error) {
+func redisPodField(entry PodEntry) (string, error) {
 	value, err := json.Marshal(entry)
 	if err != nil {
 		return "", fmt.Errorf("failed to encode pod entry for Redis: %w", err)
@@ -358,7 +349,7 @@ func redisPodValue(entry PodEntry) (string, error) {
 	return string(value), nil
 }
 
-func parseRedisPodValue(s string) (PodEntry, bool) {
+func parseRedisPodField(s string) (PodEntry, bool) {
 	var entry PodEntry
 	if err := json.Unmarshal([]byte(s), &entry); err != nil {
 		return PodEntry{}, false

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -264,7 +264,11 @@ func (r *RedisIndex) Add(ctx context.Context, engineKeys, requestKeys []BlockHas
 	for _, requestKey := range requestKeys {
 		redisKey := requestKey.String()
 		for _, entry := range entries {
-			pipe.HSet(ctx, redisKey, redisPodField(entry), redisPodValue(entry))
+			value, err := redisPodValue(entry)
+			if err != nil {
+				return err
+			}
+			pipe.HSet(ctx, redisKey, redisPodField(entry), value)
 		}
 	}
 
@@ -333,14 +337,6 @@ func (r *RedisIndex) evictPodsFromRequestKey(ctx context.Context, requestKey Blo
 	return nil
 }
 
-type redisPodValuePayload struct {
-	PodIdentifier string  `json:"pod"`
-	DeviceTier    string  `json:"tier"`
-	Speculative   bool    `json:"speculative"`
-	HasGroup      bool    `json:"hasGroup"`
-	GroupIdx      GroupID `json:"groupIdx"`
-}
-
 func redisPodField(entry PodEntry) string {
 	group := "_"
 	if entry.HasGroup {
@@ -354,30 +350,21 @@ func redisPodField(entry PodEntry) string {
 	}, "\x00")
 }
 
-func redisPodValue(entry PodEntry) string {
-	value, _ := json.Marshal(redisPodValuePayload{
-		PodIdentifier: entry.PodIdentifier,
-		DeviceTier:    entry.DeviceTier,
-		Speculative:   entry.Speculative,
-		HasGroup:      entry.HasGroup,
-		GroupIdx:      entry.GroupIdx,
-	})
-	return string(value)
+func redisPodValue(entry PodEntry) (string, error) {
+	value, err := json.Marshal(entry)
+	if err != nil {
+		return "", fmt.Errorf("failed to encode pod entry for Redis: %w", err)
+	}
+	return string(value), nil
 }
 
 func parseRedisPodValue(s string) (PodEntry, bool) {
-	var field redisPodValuePayload
-	if err := json.Unmarshal([]byte(s), &field); err != nil {
+	var entry PodEntry
+	if err := json.Unmarshal([]byte(s), &entry); err != nil {
 		return PodEntry{}, false
 	}
 
-	return PodEntry{
-		PodIdentifier: field.PodIdentifier,
-		DeviceTier:    field.DeviceTier,
-		Speculative:   field.Speculative,
-		HasGroup:      field.HasGroup,
-		GroupIdx:      field.GroupIdx,
-	}, true
+	return entry, true
 }
 
 // getRequestKeys returns all request keys mapped to the given engine key.

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -190,7 +190,9 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 	pipe := r.RedisClient.Pipeline()
 	results := make([]*redis.StringSliceCmd, len(requestKeys))
 
+	// queue an HKeys command for each key in the pipeline
 	for i, key := range requestKeys {
+		// HKeys gets all field names
 		results[i] = pipe.HKeys(ctx, key.String())
 	}
 
@@ -204,6 +206,7 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 	for idx, cmd := range results {
 		key := requestKeys[idx]
 
+		// cmd.Result() returns the slice of strings (pod IDs) which is the first layer in the mapping
 		pods, cmdErr := cmd.Result()
 		if cmdErr != nil {
 			if !errors.Is(cmdErr, redis.Nil) {

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -215,7 +215,7 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 
 		var filteredPods []PodEntry
 		for _, p := range pods {
-			pod, ok := parseRedisPodField(p)
+			pod, ok := decodeRedisPodField(p)
 			if !ok {
 				continue
 			}
@@ -264,7 +264,7 @@ func (r *RedisIndex) Add(ctx context.Context, engineKeys, requestKeys []BlockHas
 	for _, requestKey := range requestKeys {
 		redisKey := requestKey.String()
 		for _, entry := range entries {
-			field, err := redisPodField(entry)
+			field, err := encodeRedisPodField(entry)
 			if err != nil {
 				return err
 			}
@@ -322,7 +322,7 @@ func (r *RedisIndex) evictPodsFromRequestKey(ctx context.Context, requestKey Blo
 	pipe := r.RedisClient.Pipeline()
 
 	for _, entry := range entries {
-		field, err := redisPodField(entry)
+		field, err := encodeRedisPodField(entry)
 		if err != nil {
 			return err
 		}
@@ -341,7 +341,7 @@ func (r *RedisIndex) evictPodsFromRequestKey(ctx context.Context, requestKey Blo
 	return nil
 }
 
-func redisPodField(entry PodEntry) (string, error) {
+func encodeRedisPodField(entry PodEntry) (string, error) {
 	value, err := json.Marshal(entry)
 	if err != nil {
 		return "", fmt.Errorf("failed to encode pod entry for Redis: %w", err)
@@ -349,9 +349,9 @@ func redisPodField(entry PodEntry) (string, error) {
 	return string(value), nil
 }
 
-func parseRedisPodField(s string) (PodEntry, bool) {
+func decodeRedisPodField(field string) (PodEntry, bool) {
 	var entry PodEntry
-	if err := json.Unmarshal([]byte(s), &entry); err != nil {
+	if err := json.Unmarshal([]byte(field), &entry); err != nil {
 		return PodEntry{}, false
 	}
 

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -87,6 +87,7 @@ func DefaultConfig() *Config {
 
 // Pool is a sharded worker pool that processes events from ZMQ subscribers.
 // It ensures that events for the same PodIdentifier are processed in order.
+// Pool is stateless — all key mappings are delegated to the Index.
 type Pool struct {
 	queues         []workqueue.TypedRateLimitingInterface[*RawMessage]
 	concurrency    int // can replace use with len(queues)

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -87,13 +87,13 @@ func DefaultConfig() *Config {
 
 // Pool is a sharded worker pool that processes events from ZMQ subscribers.
 // It ensures that events for the same PodIdentifier are processed in order.
-// Pool is stateless — all key mappings are delegated to the Index.
 type Pool struct {
 	queues         []workqueue.TypedRateLimitingInterface[*RawMessage]
 	concurrency    int // can replace use with len(queues)
 	index          kvblock.Index
 	tokenProcessor kvblock.TokenProcessor
 	adapter        EngineAdapter
+	groupCatalog   *kvblock.GroupCatalog
 	wg             sync.WaitGroup
 }
 
@@ -113,6 +113,7 @@ func NewPool(cfg *Config, index kvblock.Index, tokenProcessor kvblock.TokenProce
 		index:          index,
 		tokenProcessor: tokenProcessor,
 		adapter:        adapter,
+		groupCatalog:   kvblock.NewGroupCatalog(),
 	}
 
 	for i := 0; i < p.concurrency; i++ {
@@ -312,8 +313,18 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 				effectiveModelName = *ev.LoraName
 			}
 
-			// Create PodEntry for this specific event's device tier
+			// Create PodEntry for this specific event's device tier.
 			podEntries := []kvblock.PodEntry{{PodIdentifier: podIdentifier, DeviceTier: deviceTier}}
+			if ev.GroupIdx != nil {
+				g := kvblock.GroupID(*ev.GroupIdx)
+				p.groupCatalog.Learn(podIdentifier, g, kvblock.GroupMetadata{
+					Kind:              string(ev.KVCacheSpecKind),
+					BlockSize:         ev.BlockSize,
+					SlidingWindowSize: ev.KVCacheSpecSlidingWindowSize,
+				})
+				podEntries[0].HasGroup = true
+				podEntries[0].GroupIdx = g
+			}
 
 			engineKeys := make([]kvblock.BlockHash, len(ev.BlockHashes))
 			for i, hash := range ev.BlockHashes {
@@ -407,8 +418,12 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 				deviceTier = strings.ToLower(ev.DeviceTier)
 			}
 
-			// Create PodEntry for this specific event's device tier
+			// Create PodEntry for this specific event's device tier.
 			podEntries := []kvblock.PodEntry{{PodIdentifier: podIdentifier, DeviceTier: deviceTier}}
+			if ev.GroupIdx != nil {
+				podEntries[0].HasGroup = true
+				podEntries[0].GroupIdx = kvblock.GroupID(*ev.GroupIdx)
+			}
 
 			// Iterate over the hashes and evict each key.
 			// The Index handles engine->request key resolution internally for both

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -123,6 +123,11 @@ func NewPool(cfg *Config, index kvblock.Index, tokenProcessor kvblock.TokenProce
 	return p
 }
 
+// GroupCatalog returns the KV cache group metadata learned from events.
+func (p *Pool) GroupCatalog() *kvblock.GroupCatalog {
+	return p.groupCatalog
+}
+
 // Start begins the worker pool.
 // It is non-blocking.
 func (p *Pool) Start(ctx context.Context) {

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -653,6 +653,113 @@ func TestBlockStoredEvent_EvictionOrderGPUThenCPU(t *testing.T) {
 	assert.Error(t, err, "engine→request mapping should be removed after full eviction")
 }
 
+func TestHMAGroupMetadataAndEntryOnBlockStored(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, idx, tp := newTestPool(t, 16)
+
+	tokens := makeTokens(64)
+	engineKeys := makeEngineKeys(4, 800)
+	groupIdx := 0
+	slidingWindow := 128
+
+	batch := &EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes:                  engineKeys,
+				Tokens:                       tokens,
+				ParentHash:                   0,
+				GroupIdx:                     &groupIdx,
+				KVCacheSpecKind:              KVCacheSpecKindSlidingWindow,
+				KVCacheSpecSlidingWindowSize: &slidingWindow,
+				BlockSize:                    16,
+			},
+		},
+	}
+	pool.processEventBatch(ctx, batch, "pod-hma", "test-model")
+
+	meta, ok := pool.groupCatalog.Get("pod-hma", kvblock.GroupID(0))
+	require.True(t, ok)
+	assert.Equal(t, string(KVCacheSpecKindSlidingWindow), meta.Kind)
+	assert.Equal(t, 16, meta.BlockSize)
+	require.NotNil(t, meta.SlidingWindowSize)
+	assert.Equal(t, 128, *meta.SlidingWindowSize)
+
+	canonicalKeys, err := tp.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "test-model", nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, canonicalKeys)
+
+	result, err := idx.Lookup(ctx, canonicalKeys, nil)
+	require.NoError(t, err)
+	for _, ck := range canonicalKeys {
+		entries := result[ck]
+		require.Len(t, entries, 1, "each canonical key should have one entry")
+		assert.True(t, entries[0].HasGroup)
+		assert.Equal(t, kvblock.GroupID(0), entries[0].GroupIdx)
+	}
+}
+
+// TestHMAGroupLevelEviction_BlockRemoved verifies that a BlockRemoved event with GroupIdx
+// performs a group-level eviction, leaving other groups intact.
+func TestHMAGroupLevelEviction_BlockRemoved(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, idx, tp := newTestPool(t, 16)
+
+	tokens := makeTokens(64)
+	engineKeys := makeEngineKeys(4, 850)
+
+	// Store two groups for the same block (simulates two BlockStored events)
+	for _, g := range []int{0, 1} {
+		gIdx := g
+		batch := &EventBatch{
+			Events: []GenericEvent{
+				&BlockStoredEvent{
+					BlockHashes:     engineKeys,
+					Tokens:          tokens,
+					ParentHash:      0,
+					GroupIdx:        &gIdx,
+					KVCacheSpecKind: KVCacheSpecKindFullAttention,
+					BlockSize:       16,
+				},
+			},
+		}
+		pool.processEventBatch(ctx, batch, "pod-hma", "test-model")
+	}
+
+	canonicalKeys, err := tp.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "test-model", nil)
+	require.NoError(t, err)
+
+	// Verify both groups present
+	result, err := idx.Lookup(ctx, canonicalKeys, nil)
+	require.NoError(t, err)
+	for _, ck := range canonicalKeys {
+		entries := result[ck]
+		require.Len(t, entries, 2)
+		assert.ElementsMatch(t, []kvblock.GroupID{0, 1}, []kvblock.GroupID{entries[0].GroupIdx, entries[1].GroupIdx})
+	}
+
+	// Evict group 0 only
+	evictGroupIdx := 0
+	removeBatch := &EventBatch{
+		Events: []GenericEvent{
+			&BlockRemovedEvent{
+				BlockHashes: engineKeys,
+				GroupIdx:    &evictGroupIdx,
+			},
+		},
+	}
+	pool.processEventBatch(ctx, removeBatch, "pod-hma", "test-model")
+
+	// Group 1 should remain; group 0 should be gone
+	result, err = idx.Lookup(ctx, canonicalKeys, nil)
+	require.NoError(t, err)
+	for _, ck := range canonicalKeys {
+		entries := result[ck]
+		require.Len(t, entries, 1, "pod should still be present after partial eviction")
+		assert.True(t, entries[0].HasGroup)
+		assert.Equal(t, kvblock.GroupID(1), entries[0].GroupIdx)
+	}
+}
+
 // TestCanonicalWritePath_PartialBlockDrop verifies that tokens fewer than the canonical block
 // size produce zero canonical keys and the event is silently skipped.
 func TestCanonicalWritePath_PartialBlockDrop(t *testing.T) {

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -677,7 +677,7 @@ func TestHMAGroupMetadataAndEntryOnBlockStored(t *testing.T) {
 	}
 	pool.processEventBatch(ctx, batch, "pod-hma", "test-model")
 
-	meta, ok := pool.groupCatalog.Get("pod-hma", kvblock.GroupID(0))
+	meta, ok := pool.GroupCatalog().Get("pod-hma", kvblock.GroupID(0))
 	require.True(t, ok)
 	assert.Equal(t, string(KVCacheSpecKindSlidingWindow), meta.Kind)
 	assert.Equal(t, 16, meta.BlockSize)


### PR DESCRIPTION
This adds the group-presence layer for HMA using the KV event metadata parsed in #612.

## Summary
The change keeps a single index and preserves the group id as part of the indexed pod entry identity.

That lets `add` and `remove` of cache entries stay exact across the existing index implementations, while allowing `BlockStored` events to record group metadata for later scorer work.

## What changed:

  - keep one flat index, with group identity on each indexed entry
  - learn HMA group metadata from events at runtime
  - make removals exact per group

This intentionally does not add hybrid scoring yet. The scorer can build on the exposed GroupCatalog and grouped index entries in a focused follow-up.