### PR TITLE
fix(make): use linux platform in Docker build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,9 +107,7 @@ e2e-test: e2e-test-uds ## Run end-to-end tests
 image-build-uds: check-container-tool ## Build the UDS tokenizer container image
 	@printf "\033[33;1m==== Building UDS tokenizer image $(UDS_TOKENIZER_IMAGE) ====\033[0m\n"
 	$(CONTAINER_TOOL) build \
-		--platform $(TARGETOS)/$(TARGETARCH) \
-		--build-arg TARGETOS=$(TARGETOS) \
-		--build-arg TARGETARCH=$(TARGETARCH) \
+		--platform linux/$(TARGETARCH) \
 		-t $(UDS_TOKENIZER_IMAGE) services/uds_tokenizer
 
 .PHONY: e2e-test-uds
@@ -179,9 +177,7 @@ build-uds: check-go download-zmq ## Build
 image-build: check-container-tool load-version-json ## Build Docker image
 	@printf "\033[33;1m==== Building Docker image $(IMG) ====\033[0m\n"
 	$(CONTAINER_TOOL) build \
-		--platform $(TARGETOS)/$(TARGETARCH) \
-		--build-arg TARGETOS=$(TARGETOS) \
-		--build-arg TARGETARCH=$(TARGETARCH) \
+		--platform linux/$(TARGETARCH) \
 		-t $(IMG) .
 .PHONY: image-push
 image-push: check-container-tool load-version-json ## Push Docker image $(IMG) to registry
@@ -573,9 +569,7 @@ run-example: ## Run the example with UDS tokenizer in Docker (e.g., make run-exa
 image-fs-backend-build: check-container-tool load-version-json ## Build the development container for the llmd_fs_backend connector
 	@printf "\033[33;1m==== Building development container $(FS_BACKEND_DEV_IMG) ====\033[0m\n"
 	$(CONTAINER_TOOL) build \
-		--platform $(TARGETOS)/$(TARGETARCH) \
-		--build-arg TARGETOS=$(TARGETOS) \
-		--build-arg TARGETARCH=$(TARGETARCH) \
+		--platform linux/$(TARGETARCH) \
 		-f kv_connectors/llmd_fs_backend/Dockerfile.dev \
 		-t $(FS_BACKEND_DEV_IMG) .
 


### PR DESCRIPTION
## Summary

On macOS, `TARGETOS` resolves to `darwin`, causing `docker build --platform darwin/arm64` to fail since base images only publish `linux/*` manifests.

CI was unaffected — it uses a separate buildx action with hardcoded `linux/*` platforms.

## Changes

- `--platform $(TARGETOS)/$(TARGETARCH)` → `--platform linux/$(TARGETARCH)` in all 3 Docker build targets
- Remove redundant `--build-arg TARGETOS/TARGETARCH` — Docker auto-injects these from `--platform` and Dockerfiles don't reference them

## Impact

| Environment | Before | After |
|------------|--------|-------|
| macOS | `darwin/*` → fails | `linux/*` → works |
| Linux | no change | no change |
| CI | no change | no change |