### PR TITLE
docs(fs-backend): note upstreaming into vLLM multi-tier offloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,11 @@ graph TD
  Demonstrates how the KV-Cache libraries handles KV-Events through both an offline example with a dummy ZMQ publisher and an online example using a vLLM Helm chart.
 
 ## Connectors & Utilities
+* [**PVC Evictor**](kv_connectors/pvc_evictor/README.md):
+  Kubernetes-side utility that automatically manages disk space for the offloading connector's KV-cache storage on PVCs.
 
 * [**llmd-fs-backend**](kv_connectors/llmd_fs_backend/README.md):
   Storage backend for vLLM's `OffloadingConnector` — moves KV-cache blocks between GPU and shared storage (local disk, shared filesystem, or object store). Pre-built wheels are published via the project's pip index; see the connector README for install instructions and configuration.
-* [**PVC Evictor**](kv_connectors/pvc_evictor/README.md):
-  Kubernetes-side utility that automatically manages disk space for the offloading connector's KV-cache storage on PVCs.
+  > [!IMPORTANT]
+  > **Now upstreamed into vLLM.** `llmd-fs-connector==0.22` (llm-d v0.8 / vLLM v0.22) is the **final release** — llmd-fs-backend is now the FS tier of vLLM's multi-tier offloading connector (`TieringOffloadingSpec`). All new features and support continue there; see the [vLLM KV offloading guide](https://github.com/vllm-project/vllm/pull/44415).
+

--- a/kv_connectors/llmd_fs_backend/README.md
+++ b/kv_connectors/llmd_fs_backend/README.md
@@ -1,5 +1,17 @@
 # llmd-fs-backend README
 
+> [!IMPORTANT]
+> **This connector has moved into vLLM.** As of **llm-d v0.8 / vLLM v0.22**,
+> **`llmd-fs-connector==0.22` is the final release** of the standalone llm-d FS connector.
+>
+> **The filesystem offloading logic is now upstreamed into vLLM** as the FS tier of the
+> **multi-tier offloading connector** (`TieringOffloadingSpec`). All new features, fixes,
+> and support continue there. See the
+> [vLLM KV offloading guide](https://github.com/vllm-project/vllm/pull/44415).
+>
+> This repository remains available for the 0.22 release and earlier; the docs below
+> describe that final release.
+
 ## Overview
 
 The llmd-fs-backend extends the native [vLLM Offloading Connector](#offloading-connector-docs) to support file system and object store backends, with the object store backend support provided by NIXL.


### PR DESCRIPTION
## What

`llmd-fs-connector==0.22` (llm-d v0.8 / vLLM v0.22) is the **final release** of the standalone llm-d FS connector. The filesystem offloading logic is now upstreamed into vLLM as the FS tier of the **multi-tier offloading connector** (`TieringOffloadingSpec`). All new features, fixes, and support continue in vLLM.

## Changes

- Add an `[!IMPORTANT]` banner to the top of the connector README (`kv_connectors/llmd_fs_backend/README.md`).
- Add a short note to the root README's **Connectors & Utilities** entry for `llmd-fs-backend`.
- Both link the [vLLM KV offloading guide](https://github.com/vllm-project/vllm/pull/44415).