### PR TITLE
style(fs-backend): fix clang-format break in thread_pool.cpp

### DIFF
--- a/kv_connectors/llmd_fs_backend/csrc/storage/thread_pool.cpp
+++ b/kv_connectors/llmd_fs_backend/csrc/storage/thread_pool.cpp
@@ -31,7 +31,6 @@
 #include "numa_utils.hpp"
 #include "logger.hpp"
 
-
 // Define static thread-local members
 thread_local StagingBufferInfo ThreadPool::m_staging_buffer{};
 thread_local at::cuda::CUDAStream ThreadPool::m_thread_stream =


### PR DESCRIPTION
## What

`#589` removed `MIN_STAGING_BUFFER_SIZE` from `thread_pool.cpp` but left a double blank line behind. clang-format (v21, pinned in `.pre-commit-config.yaml`) flags it, so the repo-wide `pre-commit run --all-files` lint gate currently **fails on every PR**.

This collapses the double blank line to restore a green lint gate.

## Verification

```
pre-commit run clang-format --all-files
clang-format.............................................................Passed
```