### PR TITLE
fix(fs_backend): drop events gracefully when no ZMQ topic is configured

### DIFF
--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
@@ -139,14 +139,21 @@ class StorageEventPublisher:
     def _send_batch(self, packed_events: list[bytes], topic: str | None = None) -> None:
         """Send a batch of pre-packed events as a 3-frame ZMQ message.
 
-        Frames: ``[topic, sequence, payload]``.  Thread-safe; silently
-        drops the message if the publisher has been closed.
+        Frames: ``[topic, sequence, payload]``.  Thread-safe; silently drops
+        the message if the publisher has been closed or no topic is configured.
         """
         with self._send_lock:
             if self._closed:
                 return
 
             effective_topic = topic or self._topic
+            if not effective_topic:
+                logger.warning(
+                    "Cannot send event: no topic configured "
+                    "(model_name not provided to constructor or publish call)"
+                )
+                return
+
             payload = msgpack.packb([time.time(), packed_events], use_bin_type=True)
             self._seq += 1
             self._socket.send_multipart(

--- a/kv_connectors/llmd_fs_backend/tests/cpu/test_storage_events.py
+++ b/kv_connectors/llmd_fs_backend/tests/cpu/test_storage_events.py
@@ -384,14 +384,26 @@ def test_publish_blocks_removed_empty_hashes_is_noop(monkeypatch):
 
 
 def test_publisher_without_model_name(monkeypatch):
+    """Verify a publisher created without model_name:
+    - silently drops events when no topic can be resolved,
+    - publishes normally when an override model_name is given.
+    """
     ctx = FakeZMQContext()
     monkeypatch.setattr(event_publisher_module.zmq, "Context", lambda: ctx)
 
     publisher = StorageEventPublisher("tcp://*:5559")
     assert publisher._topic is None
 
-    publisher.publish_blocks_removed([0x1234], model_name="some-model")
+    # Without any topic: publish_blocks_stored is a no-op (no crash)
+    publisher.publish_blocks_stored([0x1234])
+    assert len(ctx.socket_instance.sent) == 0  # nothing sent
 
+    # Without any topic: publish_blocks_removed is a no-op (no crash)
+    publisher.publish_blocks_removed([0x1234])
+    assert len(ctx.socket_instance.sent) == 0  # still nothing sent
+
+    # With model_name override: sends normally
+    publisher.publish_blocks_removed([0x1234], model_name="some-model")
     topic, _, _ = ctx.socket_instance.sent[0]
     assert topic == b"kv@SHARED_STORAGE@some-model"
 


### PR DESCRIPTION
Fix StorageEventPublisher._send_batch() to gracefully drop events instead of crashing when no ZMQ topic (model_name) is configured.
