### PR TITLE
fix(pvc-evictor): clean empty cache directories

### DIFF
--- a/kv_connectors/pvc_evictor/processes/deleter.py
+++ b/kv_connectors/pvc_evictor/processes/deleter.py
@@ -141,6 +141,40 @@ def delete_batch(file_paths: list[str], dry_run: bool, logger: logging.Logger) -
         return 0, 0, []
 
 
+def cleanup_empty_parent_dirs(deleted_paths: list[str], cache_path: str | Path, logger: logging.Logger) -> int:
+    """Remove empty FileMapper parent directories under cache_path.
+
+    Deleted cache files live below:
+        <cache_path>/<safe_model>_<sha>_r<rank>/<hhh>/<hh>_g<idx>/<hash>.bin
+
+    The cache root itself is kept as the deletion boundary.
+    """
+    cache_root = Path(cache_path).resolve(strict=False)
+    candidate_dirs: set[Path] = set()
+
+    for path_str in deleted_paths:
+        current = Path(path_str).resolve(strict=False).parent
+
+        while current != cache_root and current.is_relative_to(cache_root):
+            candidate_dirs.add(current)
+            current = current.parent
+
+    removed = 0
+    for directory in sorted(candidate_dirs, key=lambda path: len(path.parts), reverse=True):
+        try:
+            directory.rmdir()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            # Directory is non-empty or unavailable; leave it for a future batch.
+            continue
+
+        removed += 1
+        logger.debug("Removed empty cache directory: %s", directory)
+
+    return removed
+
+
 def delete_file_batch(
     batch: list[str],
     dry_run: bool,
@@ -174,6 +208,9 @@ def delete_file_batch(
                 event_publisher.publish_blocks_removed(hashes, model_name=model)
             except Exception:
                 logger.warning("Failed to publish deletion events", exc_info=True)
+
+    if deleted_paths and cache_path is not None and not dry_run:
+        cleanup_empty_parent_dirs(deleted_paths, cache_path, logger)
 
     total_files_deleted += deleted
     total_bytes_freed += freed

--- a/kv_connectors/pvc_evictor/tests/test_deleter.py
+++ b/kv_connectors/pvc_evictor/tests/test_deleter.py
@@ -63,6 +63,13 @@ def _write_config(cache_path: Path, base_dir_name: str, model_name: str) -> None
     (base_dir / "config.json").write_text(json.dumps({"model_name": model_name}))
 
 
+def _write_cache_file(cache_path: Path, relative_path: str) -> Path:
+    cache_file = cache_path / relative_path
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_bytes(b"x")
+    return cache_file
+
+
 # -- extract_block_hash tests --
 
 
@@ -235,6 +242,83 @@ def test_delete_file_batch_no_events_when_nothing_deleted(tmp_path, monkeypatch)
     delete_file_batch(files, False, logger, "P1", 0, 0, None, queue, publisher, str(cache_path))
 
     assert publisher.calls == []
+
+
+def test_delete_file_batch_cleans_empty_filemapper_dirs(tmp_path, monkeypatch):
+    cache_path = tmp_path / "models"
+    _write_config(cache_path, "model_aaaaaaaaaaaa", "model")
+
+    rank_dir = cache_path / "model_aaaaaaaaaaaa_r0"
+    bucket_dir = rank_dir / "abc"
+    first_file = _write_cache_file(cache_path, "model_aaaaaaaaaaaa_r0/abc/de_g0/abcdef0123456789.bin")
+    second_file = _write_cache_file(cache_path, "model_aaaaaaaaaaaa_r0/abc/ef_g0/1234567890abcdef.bin")
+
+    def fake_delete_batch(paths, dry_run, logger):
+        for path in paths:
+            Path(path).unlink()
+        return len(paths), len(paths), list(paths)
+
+    queue = FakeQueue()
+    logger = logging.getLogger("test_deleter")
+    monkeypatch.setattr(_deleter, "delete_batch", fake_delete_batch)
+
+    delete_file_batch(
+        [str(first_file), str(second_file)],
+        False,
+        logger,
+        "P1",
+        0,
+        0,
+        None,
+        queue,
+        None,
+        str(cache_path),
+    )
+
+    assert not first_file.parent.exists()
+    assert not second_file.parent.exists()
+    assert not bucket_dir.exists()
+    assert not rank_dir.exists()
+    assert cache_path.exists()
+    assert (cache_path / "model_aaaaaaaaaaaa" / "config.json").exists()
+
+
+def test_delete_file_batch_preserves_non_empty_parent_dirs(tmp_path, monkeypatch):
+    cache_path = tmp_path / "models"
+    _write_config(cache_path, "model_aaaaaaaaaaaa", "model")
+
+    rank_dir = cache_path / "model_aaaaaaaaaaaa_r0"
+    bucket_dir = rank_dir / "abc"
+    deleted_file = _write_cache_file(cache_path, "model_aaaaaaaaaaaa_r0/abc/de_g0/abcdef0123456789.bin")
+    surviving_file = _write_cache_file(cache_path, "model_aaaaaaaaaaaa_r0/abc/ef_g0/1234567890abcdef.bin")
+
+    def fake_delete_batch(paths, dry_run, logger):
+        for path in paths:
+            Path(path).unlink()
+        return len(paths), len(paths), list(paths)
+
+    queue = FakeQueue()
+    logger = logging.getLogger("test_deleter")
+    monkeypatch.setattr(_deleter, "delete_batch", fake_delete_batch)
+
+    delete_file_batch(
+        [str(deleted_file)],
+        False,
+        logger,
+        "P1",
+        0,
+        0,
+        None,
+        queue,
+        None,
+        str(cache_path),
+    )
+
+    assert not deleted_file.parent.exists()
+    assert surviving_file.exists()
+    assert bucket_dir.exists()
+    assert rank_dir.exists()
+    assert cache_path.exists()
 
 
 def test_delete_file_batch_publish_failure_is_fail_open(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- Remove empty FileMapper parent directories after a successful PVC evictor deletion batch.
- Keep cleanup bounded to `cache_path` so the cache root and model metadata directories are preserved.
- Add tests for fully empty directory cleanup and non-empty parent preservation.

Fixes #614

## Testing

- `uv run --with pytest python -m pytest kv_connectors/pvc_evictor/tests/test_deleter.py`
- `uv run --with pytest python -m pytest kv_connectors/pvc_evictor/tests`
- `uv run --with ruff ruff check kv_connectors/pvc_evictor/processes/deleter.py kv_connectors/pvc_evictor/tests/test_deleter.py`
- `uv run --with ruff ruff format --check kv_connectors/pvc_evictor/processes/deleter.py kv_connectors/pvc_evictor/tests/test_deleter.py`
