### PR TITLE
fix(kvevents): prevent panic in realignExtraFeatures with zero canonical blocks

### DIFF
--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -219,7 +219,10 @@ func (p *Pool) processRawMessage(ctx context.Context, msg *RawMessage) {
 // slice of the correct length.
 func realignExtraFeatures(engineFeatures []*kvblock.BlockExtraFeatures, canonicalBlockCount int) []*kvblock.BlockExtraFeatures {
 	engineBlockCount := len(engineFeatures)
-	if engineBlockCount == canonicalBlockCount {
+	if canonicalBlockCount == 0 {
+		return nil
+	}
+	if engineBlockCount == 0 || engineBlockCount == canonicalBlockCount {
 		return engineFeatures
 	}
 
@@ -348,7 +351,11 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 			// TokensToKVBlockKeys expects one entry per canonical block.
 			if extraFeatures != nil {
 				canonicalBlockCount := len(ev.Tokens) / p.tokenProcessor.BlockSize()
-				if len(extraFeatures) != canonicalBlockCount {
+				if canonicalBlockCount == 0 {
+					// Tokens don't fill a complete canonical block; no realignment needed
+					// since TokensToKVBlockKeys will produce zero keys anyway.
+					extraFeatures = nil
+				} else if len(extraFeatures) != canonicalBlockCount {
 					extraFeatures = realignExtraFeatures(extraFeatures, canonicalBlockCount)
 				}
 			}

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -392,6 +392,16 @@ func TestRealignExtraFeatures(t *testing.T) {
 		assert.Len(t, result[1].MMHashes, 1)
 		assert.Equal(t, "c", result[1].MMHashes[0].Hash)
 	})
+
+	t.Run("zero canonical blocks (engine BS < canonical BS)", func(t *testing.T) {
+		// 1 engine block → 0 canonical blocks: tokens < canonical block size.
+		// realignExtraFeatures returns an empty slice instead of panicking.
+		features := []*kvblock.BlockExtraFeatures{
+			{MMHashes: []kvblock.MMHash{{Hash: "img0"}}},
+		}
+		result := realignExtraFeatures(features, 0)
+		assert.Empty(t, result)
+	})
 }
 
 // TestCanonicalWritePath_ExtraKeysOneToMany verifies that events with ExtraKeys


### PR DESCRIPTION
Fix a runtime panic when processing multimodal BlockStored events whose token count is smaller than the indexer's canonical block size.

  ## Context

  The indexer uses a **canonical block size** (`TokenProcessorConfig.BlockSizeTokens`, default 16, operator-configured) to compute KV-block hashes, while the  inference engine (vLLM / SGLang) uses its own **engine block size** (reported in each event). The two are independently configured and may differ.

  When they differ, `realignExtraFeatures` converts per-engine-block extra features to per-canonical-block granularity so that `TokensToKVBlockKeys` receives correctly-sized input.

  ## Bug

  When `engine block size < canonical block size` and a BlockStored event contains fewer tokens than one canonical block:

      canonicalBlockCount = len(ev.Tokens) / canonicalBlockSize  // = 0
      realignExtraFeatures(extraFeatures, 0)
        → canonical := make([]*BlockExtraFeatures, 0)   // empty slice
        → else branch: canonical[0]                     // panic: index out of range

  ### Trigger conditions (all three required)

  1. **canonical block size > engine block size** — e.g. indexer uses 16, vLLM is configured with `block_size=8`
  2. **event token count < canonical block size** — e.g. 8 tokens in the event
  3. **event contains ExtraKeys** — multimodal content (images, etc.)

  ### Example

  - vLLM `block_size=8`, indexer `BlockSizeTokens=16`
  - A multimodal request produces a BlockStored event with 8 tokens, 1 block hash, and 1 extra key
  - `canonicalBlockCount = 8 / 16 = 0`
  - `len(extraFeatures) = 1 ≠ 0` → enters `realignExtraFeatures`
  - `canonical` slice has length 0 → write to `canonical[0]` panics

  **After the fix, multimodal events behave consistently with existing text-only events**: both are silently skipped when tokens don't fill a complete canonical block. This is a pre-existing design — partial blocks are intentionally not indexed, as noted in `handleDeviceTierUpdate`: *"partial-block events should just be skipped"*.
