### PR TITLE
fix(make): fail early when no container runtime is available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,11 @@ TARGETARCH ?= $(shell go env GOARCH)
 
 PYTHON_EXE := $(shell command -v python3.12 || command -v python3)
 
-CONTAINER_TOOL := $(shell { command -v docker >/dev/null 2>&1 && echo docker; } || { command -v podman >/dev/null 2>&1 && echo podman; } || echo "")
+CONTAINER_TOOL := $(shell { command -v docker >/dev/null 2>&1 && echo docker; } || { command -v podman >/dev/null 2>&1 && echo podman; })
+
+ifeq ($(CONTAINER_TOOL),)
+$(error Neither docker nor podman is installed. Try: sudo apt install docker.io OR brew install docker)
+endif
 BUILDER := $(shell command -v buildah >/dev/null 2>&1 && echo buildah || echo $(CONTAINER_TOOL))
 UDS_TOKENIZER_IMAGE ?= llm-d-uds-tokenizer:e2e-test
 FS_BACKEND_NAME ?= llmd-fs-backend


### PR DESCRIPTION
When neither Docker nor Podman is installed, `CONTAINER_TOOL` was set to an empty string via `|| echo ""`. The `check-container-tool` target then ran `command -v ""`, which unexpectedly returns 0 (checking the shell itself), causing the check to silently pass. Subsequent targets would fail with confusing errors.

**Fix:**
- Removed `|| echo ""` from the `CONTAINER_TOOL` assignment.
- Added a top-level `ifeq` check with `$(error ...)` — `make` fails immediately at parse time if no container runtime is found, before any target runs.
- `check-container-tool` reverts to a simple `command -v` check (still useful if `CONTAINER_TOOL` is manually overridden to an invalid value).

**Impact:**
- No change when Docker or Podman is installed.
- Clear, immediate error message on environments without a container runtime, instead of cryptic failures mid-build.