### PR TITLE
feat(telemetry): align kv-cache tracing with the standard llm-d observability pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ NAMESPACE ?= hc4ai-operator
 TARGETOS ?= $(shell go env GOOS)
 TARGETARCH ?= $(shell go env GOARCH)
 
+# Build metadata injected into the version package via -ldflags.
+VERSION_PKG := github.com/llm-d/llm-d-kv-cache/version
+GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null)
+BUILD_REF ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo $(DEV_VERSION))
+LDFLAGS := -X '$(VERSION_PKG).CommitSHA=$(GIT_COMMIT)' -X '$(VERSION_PKG).BuildRef=$(BUILD_REF)'
+
 PYTHON_EXE := $(shell command -v python3.12 || command -v python3)
 
 CONTAINER_TOOL := $(shell { command -v docker >/dev/null 2>&1 && echo docker; } || { command -v podman >/dev/null 2>&1 && echo podman; } || echo "")
@@ -172,7 +178,7 @@ build-uds: check-go download-zmq ## Build
 	@printf "\033[33;1m==== Building ====\033[0m\n"
 	@go build ./pkg/...
 	@mkdir -p bin
-	@go build -o bin/$(PROJECT_NAME) ./examples/kv_events/online
+	@go build -ldflags "$(LDFLAGS)" -o bin/$(PROJECT_NAME) ./examples/kv_events/online
 	@echo "✅ Build succeeded"
 
 .PHONY:	image-build
@@ -500,7 +506,7 @@ define BUILD_EXAMPLE_TEMPLATE
 $(1): $$(SRC) | check-go
 	@echo "Building $$@..."
 	@mkdir -p $$(dir $$@)
-	@go build -o $$@ $(2)
+	@go build -ldflags "$(LDFLAGS)" -o $$@ $(2)
 	@echo "✅ Built $$@"
 endef
 

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,12 @@ go 1.25.0
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/dgraph-io/ristretto/v2 v2.4.0
-	github.com/docker/docker v28.5.2+incompatible
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fxamacker/cbor/v2 v2.9.2
 	github.com/go-logr/logr v1.4.3
 	github.com/go-zeromq/zmq4 v0.17.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/moby/moby/api v1.54.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/redis/go-redis/v9 v9.20.0
@@ -20,6 +20,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.uber.org/zap v1.28.0
@@ -75,7 +76,6 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
-	github.com/moby/moby/api v1.54.1 // indirect
 	github.com/moby/moby/client v0.4.0 // indirect
 	github.com/moby/patternmatcher v0.6.1 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,6 @@ github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa5
 github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
-github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
 github.com/docker/go-connections v0.6.0/go.mod h1:AahvXYshr6JgfUJGdDCs2b5EZG/vmaMAntpSFH5BFKE=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
@@ -239,6 +237,8 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 h1:4YsVu3B8+3qtWYYrsUY
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0/go.mod h1:+wnlSn0mD1ADVMe3v9Z/WIaiz6q6gL2J/ejaAmdmv80=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0 h1:qazEJlUOQzhCpzQpFETGby7EdqjI1wsd0W+6Gg1SCTU=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0/go.mod h1:fOD2Yefuxixkx3ahVNf0O/PERb6r4OlbxfATVnYvzCo=
+go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0 h1:bl2S7Ubua0Nms+D/gAmznQTd4dxxMA93aKbcpKqiTCs=
+go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0/go.mod h1:L0hRV50XdVIODHUfWEqGRCXQvj2rV82STVo12FMFBU0=
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
 go.opentelemetry.io/otel/sdk v1.44.0 h1:nHYwb9lK+fJPU/dnT6s7W7Z8itMWyqrnVfbheVYrZ58=

--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -89,7 +88,7 @@ func NewKVCacheIndexer(ctx context.Context, config *Config, tokenProcessor kvblo
 	}
 
 	// Wrap index with tracing instrumentation.
-	// When tracing is not configured, otel.Tracer() returns a no-op implementation.
+	// When tracing is not configured, the tracer is a no-op implementation.
 	kvBlockIndex = kvblock.NewTracedIndex(kvBlockIndex)
 
 	// override backend configs with the ones from the config, if the defaults are not used.
@@ -100,7 +99,7 @@ func NewKVCacheIndexer(ctx context.Context, config *Config, tokenProcessor kvblo
 	}
 
 	// Wrap scorer with tracing instrumentation.
-	// When tracing is not configured, otel.Tracer() returns a no-op implementation.
+	// When tracing is not configured, the tracer is a no-op implementation.
 	scorer = NewTracedScorer(scorer)
 
 	indexer := &Indexer{
@@ -243,7 +242,7 @@ func (k *Indexer) ScoreTokens(
 	podIdentifiers []string,
 	extraFeatures []*kvblock.BlockExtraFeatures,
 ) (map[string]float64, error) {
-	tracer := otel.Tracer(telemetry.InstrumentationName)
+	tracer := telemetry.Tracer("llm-d-kv-cache/pkg/kvcache")
 	ctx, span := tracer.Start(ctx, "llm_d.kv_cache.score_tokens",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)

--- a/pkg/kvcache/kvblock/traced_index.go
+++ b/pkg/kvcache/kvblock/traced_index.go
@@ -17,7 +17,6 @@ package kvblock
 import (
 	"context"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -37,7 +36,7 @@ func NewTracedIndex(next Index) Index {
 }
 
 func (t *tracedIndex) Add(ctx context.Context, engineKeys, requestKeys []BlockHash, entries []PodEntry) error {
-	tracer := otel.Tracer(telemetry.InstrumentationName)
+	tracer := telemetry.Tracer("llm-d-kv-cache/pkg/kvcache/kvblock")
 	ctx, span := tracer.Start(ctx, "llm_d.kv_cache.index.add",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
@@ -60,7 +59,7 @@ func (t *tracedIndex) Add(ctx context.Context, engineKeys, requestKeys []BlockHa
 }
 
 func (t *tracedIndex) Evict(ctx context.Context, key BlockHash, keyType KeyType, entries []PodEntry) error {
-	tracer := otel.Tracer(telemetry.InstrumentationName)
+	tracer := telemetry.Tracer("llm-d-kv-cache/pkg/kvcache/kvblock")
 	ctx, span := tracer.Start(ctx, "llm_d.kv_cache.index.evict",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
@@ -86,7 +85,7 @@ func (t *tracedIndex) Lookup(
 	requestKeys []BlockHash,
 	podIdentifierSet sets.Set[string],
 ) (map[BlockHash][]PodEntry, error) {
-	tracer := otel.Tracer(telemetry.InstrumentationName)
+	tracer := telemetry.Tracer("llm-d-kv-cache/pkg/kvcache/kvblock")
 	ctx, span := tracer.Start(ctx, "llm_d.kv_cache.index",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)

--- a/pkg/kvcache/traced_scorer.go
+++ b/pkg/kvcache/traced_scorer.go
@@ -19,7 +19,6 @@ package kvcache
 import (
 	"context"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -47,7 +46,7 @@ func (t *tracedScorer) Score(
 	keys []kvblock.BlockHash,
 	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
 ) (map[string]float64, error) {
-	tracer := otel.Tracer(telemetry.InstrumentationName)
+	tracer := telemetry.Tracer("llm-d-kv-cache/pkg/kvcache")
 	_, span := tracer.Start(ctx, "llm_d.kv_cache.scorer.compute",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)

--- a/pkg/telemetry/tracing.go
+++ b/pkg/telemetry/tracing.go
@@ -28,14 +28,19 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/klog/v2"
+
+	"github.com/llm-d/llm-d-kv-cache/version"
 )
 
 const (
@@ -57,9 +62,10 @@ func stripScheme(endpoint string) string {
 	return u.Host
 }
 
-// InitTracing initializes OpenTelemetry tracing with OTLP exporter.
+// InitTracing initializes OpenTelemetry tracing.
 // Configuration is done via environment variables:
 // - OTEL_SERVICE_NAME: Service name (default: llm-d-kv-cache)
+// - OTEL_TRACES_EXPORTER: Span exporter, "otlp" or "console" (default: otlp)
 // - OTEL_EXPORTER_OTLP_ENDPOINT: OTLP collector endpoint (default: http://localhost:4317)
 // - OTEL_TRACES_SAMPLER: Sampling strategy (default: parentbased_traceidratio)
 // - OTEL_TRACES_SAMPLER_ARG: Sampling ratio (default: 0.1 for 10%).
@@ -93,19 +99,16 @@ func InitTracing(ctx context.Context) (func(context.Context) error, error) {
 		"service", serviceName,
 		"samplingRatio", samplingRatio)
 
-	// Create OTLP trace exporter
-	exporter, err := otlptracegrpc.New(ctx,
-		otlptracegrpc.WithEndpoint(endpoint),
-		otlptracegrpc.WithInsecure(), // Use WithTLSCredentials() in production
-	)
+	exporter, err := newSpanExporter(ctx, endpoint, logger)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create OTLP trace exporter: %w", err)
+		return nil, fmt.Errorf("failed to create trace exporter: %w", err)
 	}
 
-	// Create resource with service name
+	// Create resource with service name and build version
 	res, err := resource.New(ctx,
 		resource.WithAttributes(
 			semconv.ServiceName(serviceName),
+			semconv.ServiceVersion(version.BuildRef),
 		),
 	)
 	if err != nil {
@@ -128,16 +131,62 @@ func InitTracing(ctx context.Context) (func(context.Context) error, error) {
 		propagation.Baggage{},
 	))
 
+	// Route OpenTelemetry's internal errors to the structured logger.
+	otel.SetErrorHandler(&errorHandler{logger: logger})
+
 	logger.Info("OpenTelemetry tracing initialized successfully")
 
 	// Return shutdown function
 	return tp.Shutdown, nil
 }
 
-// Tracer returns a tracer for the kv-cache-manager.
-// The tracer is identified by the instrumentation library name, which is
-// distinct from the service name. When used as a library, the host
-// application's tracer provider determines the service name.
-func Tracer() trace.Tracer {
-	return otel.Tracer(InstrumentationName)
+// Tracer returns a tracer for the given instrumentation scope, defaulting to
+// InstrumentationName. Build version and commit SHA are attached so every span
+// in a trace carries consistent scope metadata. When used as a library, the
+// host application's tracer provider determines the service name.
+func Tracer(scope ...string) trace.Tracer {
+	name := InstrumentationName
+	if len(scope) > 0 && scope[0] != "" {
+		name = scope[0]
+	}
+	return otel.Tracer(
+		name,
+		trace.WithInstrumentationVersion(version.BuildRef),
+		trace.WithInstrumentationAttributes(
+			attribute.String("commit-sha", version.CommitSHA),
+		),
+	)
+}
+
+// newSpanExporter creates a span exporter selected by OTEL_TRACES_EXPORTER.
+// Supported values are "otlp" (default) and "console"; unknown values fall back
+// to otlp.
+func newSpanExporter(ctx context.Context, endpoint string, logger logr.Logger) (sdktrace.SpanExporter, error) {
+	exporterType := os.Getenv("OTEL_TRACES_EXPORTER")
+	if exporterType == "" {
+		exporterType = "otlp"
+	}
+
+	switch exporterType {
+	case "console":
+		return stdouttrace.New(stdouttrace.WithPrettyPrint())
+	case "otlp":
+	default:
+		logger.Info("Unsupported OTEL_TRACES_EXPORTER, falling back to otlp", "value", exporterType)
+	}
+
+	return otlptracegrpc.New(ctx,
+		otlptracegrpc.WithEndpoint(endpoint),
+		otlptracegrpc.WithInsecure(), // Use WithTLSCredentials() in production
+	)
+}
+
+// errorHandler routes OpenTelemetry's internal errors to a structured logger
+// instead of the process stderr.
+type errorHandler struct {
+	logger logr.Logger
+}
+
+func (h *errorHandler) Handle(err error) {
+	h.logger.Error(err, "OpenTelemetry trace error")
 }

--- a/pkg/telemetry/tracing_test.go
+++ b/pkg/telemetry/tracing_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package telemetry_test
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/llm-d/llm-d-kv-cache/pkg/telemetry"
+	"github.com/llm-d/llm-d-kv-cache/version"
+)
+
+// recordScope starts and ends a single span from the given tracer and returns
+// the instrumentation scope recorded for it.
+func recordScope(t *testing.T, scope ...string) instrumentation.Scope {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	otel.SetTracerProvider(tp)
+
+	_, span := telemetry.Tracer(scope...).Start(context.Background(), "test")
+	span.End()
+
+	ended := recorder.Ended()
+	if len(ended) != 1 {
+		t.Fatalf("expected 1 recorded span, got %d", len(ended))
+	}
+	return ended[0].InstrumentationScope()
+}
+
+func TestTracerDefaultScope(t *testing.T) {
+	got := recordScope(t)
+
+	if got.Name != telemetry.InstrumentationName {
+		t.Errorf("scope name = %q, want %q", got.Name, telemetry.InstrumentationName)
+	}
+	if got.Version != version.BuildRef {
+		t.Errorf("scope version = %q, want %q", got.Version, version.BuildRef)
+	}
+}
+
+func TestTracerCustomScope(t *testing.T) {
+	const scope = "llm-d-kv-cache/pkg/kvcache"
+	got := recordScope(t, scope)
+
+	if got.Name != scope {
+		t.Errorf("scope name = %q, want %q", got.Name, scope)
+	}
+}
+
+func TestTracerEmptyScopeFallsBackToDefault(t *testing.T) {
+	got := recordScope(t, "")
+
+	if got.Name != telemetry.InstrumentationName {
+		t.Errorf("scope name = %q, want %q", got.Name, telemetry.InstrumentationName)
+	}
+}
+
+func TestTracerAttachesCommitSHA(t *testing.T) {
+	got := recordScope(t)
+
+	val, ok := got.Attributes.Value(attribute.Key("commit-sha"))
+	if !ok {
+		t.Fatal("scope is missing commit-sha attribute")
+	}
+	if val.AsString() != version.CommitSHA {
+		t.Errorf("commit-sha = %q, want %q", val.AsString(), version.CommitSHA)
+	}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package version exposes build metadata for kv-cache binaries. Values may be
+// injected at link time with -ldflags "-X .../version.BuildRef=... -X .../version.CommitSHA=...".
+// When not injected, they are populated from the Go build info embedded in the binary.
+package version
+
+import "runtime/debug"
+
+var (
+	// CommitSHA is the git commit the binary was built from.
+	CommitSHA string
+
+	// BuildRef is the build ref (tag or branch) the binary was built from.
+	BuildRef string
+)
+
+func init() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+
+	if BuildRef == "" {
+		BuildRef = info.Main.Version
+	}
+
+	if CommitSHA == "" {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				CommitSHA = setting.Value
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
Aligns kv-cache OpenTelemetry tracing with the shared llm-d observability conventions so that, when kv-cache is embedded as a library in a host service, its spans carry the same scope metadata (service, build version, commit) as the host's spans and correlate cleanly in a single end-to-end trace.

Fixed #652 

/cc @vMaroon 