### PR TITLE
fix(fs_backend): sync block_size_factor with default offloaded block size

### DIFF
--- a/kv_connectors/llmd_fs_backend/README.md
+++ b/kv_connectors/llmd_fs_backend/README.md
@@ -100,7 +100,7 @@ make image-fs-backend-push IMAGE_TAG_BASE=<your-base-container-registry> FS_BACK
 ### Connector parameters
 
 - `shared_storage_path`: base path for storing and loading the KV data files.
-- `block_size`: number of tokens stored per file (must be in granulaity of GPU block size).
+- `block_size`: number of tokens stored per file (must be in granularity of GPU block size, default: `256`).
 - `threads_per_gpu`: number of I/O threads per GPU
 - `max_staging_memory_gb`: total staging memory limit
 - `max_write_queued_seconds`: maximum time budget (in seconds) for queued writes before excess writes are dropped (default: `30.0`, set to `0` to disable). The actual write queue depth limit is computed dynamically as `threads_per_gpu * max_write_queued_seconds / avg_write_duration`. For example, with 64 threads and `max_write_queued_seconds=30`: on fast NVMe storage (20ms avg write) the limit is ~96,000 (effectively unlimited), while on slow block storage (2s avg write) the limit is ~960. Dropped writes result in cache misses on future reads, not data loss.

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
@@ -75,6 +75,15 @@ class SharedStorageOffloadingSpec(OffloadingSpec):
         )
         self.gpu_blocks_per_file = self.offloaded_block_size // self.hash_block_size
 
+        # vLLM's OffloadingSpec base only derives block_size_factor when
+        # "block_size" is explicitly present in extra_config, leaving it at 1
+        # otherwise — but we default offloaded_block_size ourselves, so the
+        # scheduler must be kept in sync. With a stale factor of 1 the
+        # scheduler emits one offload key per GPU block while the worker
+        # consumes one key per file, misaligning keys across KV cache groups
+        # on hybrid models (https://github.com/llm-d/llm-d-kv-cache/issues/656).
+        self.block_size_factor = self.gpu_blocks_per_file
+
         self.read_preferring_ratio = float(
             self.extra_config.get(
                 "read_preferring_ratio", DEFAULT_READ_PREFERRING_WORKERS_RATIO

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
@@ -75,13 +75,8 @@ class SharedStorageOffloadingSpec(OffloadingSpec):
         )
         self.gpu_blocks_per_file = self.offloaded_block_size // self.hash_block_size
 
-        # vLLM's OffloadingSpec base only derives block_size_factor when
-        # "block_size" is explicitly present in extra_config, leaving it at 1
-        # otherwise — but we default offloaded_block_size ourselves, so the
-        # scheduler must be kept in sync. With a stale factor of 1 the
-        # scheduler emits one offload key per GPU block while the worker
-        # consumes one key per file, misaligning keys across KV cache groups
-        # on hybrid models (https://github.com/llm-d/llm-d-kv-cache/issues/656).
+        # Dont leave block size to default value of 1 when
+        # block_size is not set in extra_config
         self.block_size_factor = self.gpu_blocks_per_file
 
         self.read_preferring_ratio = float(

--- a/kv_connectors/llmd_fs_backend/tests/test_spec.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_spec.py
@@ -1,0 +1,124 @@
+# Copyright 2025 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scheduler/worker config consistency tests for SharedStorageOffloadingSpec."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    SlidingWindowSpec,
+)
+
+from llmd_fs_backend.spec import (
+    DEFAULT_STORAGE_BLOCK_SIZE,
+    SharedStorageOffloadingSpec,
+)
+
+pytestmark = pytest.mark.no_cuda_required
+
+GPU_BLOCK_SIZE = 16
+
+
+def make_vllm_config(extra_config: dict) -> SimpleNamespace:
+    """Minimal stand-in exposing the attributes OffloadingSpec/FileMapper read."""
+    return SimpleNamespace(
+        model_config=SimpleNamespace(model="test/hybrid-model"),
+        cache_config=SimpleNamespace(
+            block_size=GPU_BLOCK_SIZE,
+            cache_dtype="auto",
+            enable_prefix_caching=True,
+            hash_block_size=None,
+        ),
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=1,
+            pipeline_parallel_size=1,
+            prefill_context_parallel_size=1,
+            decode_context_parallel_size=1,
+            world_size=1,
+            rank=0,
+        ),
+        kv_transfer_config=SimpleNamespace(kv_connector_extra_config=extra_config),
+    )
+
+
+def make_hybrid_kv_cache_config() -> KVCacheConfig:
+    """Two KV cache groups (full attention + sliding window), Gemma-style."""
+    attn_args = dict(
+        block_size=GPU_BLOCK_SIZE,
+        num_kv_heads=8,
+        head_size=128,
+        dtype=torch.bfloat16,
+    )
+    return KVCacheConfig(
+        num_blocks=128,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                layer_names=["layers.0.attn"],
+                kv_cache_spec=FullAttentionSpec(**attn_args),
+            ),
+            KVCacheGroupSpec(
+                layer_names=["layers.1.attn"],
+                kv_cache_spec=SlidingWindowSpec(**attn_args, sliding_window=512),
+            ),
+        ],
+    )
+
+
+def make_spec(tmp_path, extra_config: dict) -> SharedStorageOffloadingSpec:
+    extra_config = {"shared_storage_path": str(tmp_path), **extra_config}
+    return SharedStorageOffloadingSpec(
+        make_vllm_config(extra_config), make_hybrid_kv_cache_config()
+    )
+
+
+def test_default_block_size_syncs_scheduler_factor(tmp_path):
+    """Without "block_size" in extra_config, vLLM's OffloadingSpec leaves
+    block_size_factor at 1 while this backend defaults to
+    DEFAULT_STORAGE_BLOCK_SIZE tokens per file. The spec must reconcile the
+    two, or the scheduler emits one offload key per GPU block while the
+    worker consumes one key per file — tripping the group_idx assertion in
+    _build_transfer on hybrid models (issue #656).
+    """
+    spec = make_spec(tmp_path, {})
+    assert spec.gpu_blocks_per_file == DEFAULT_STORAGE_BLOCK_SIZE // GPU_BLOCK_SIZE
+    assert spec.block_size_factor == spec.gpu_blocks_per_file
+
+
+def test_explicit_block_size_keeps_factor_in_sync(tmp_path):
+    spec = make_spec(tmp_path, {"block_size": 128})
+    assert spec.gpu_blocks_per_file == 128 // GPU_BLOCK_SIZE
+    assert spec.block_size_factor == spec.gpu_blocks_per_file
+
+
+def test_scheduler_config_sees_offloaded_block_size(tmp_path):
+    """The vLLM scheduler derives per-group offloaded block sizes from
+    block_size_factor; they must match the worker's per-file token span."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
+        SchedulerOffloadConfig,
+    )
+
+    spec = make_spec(tmp_path, {})
+    config = SchedulerOffloadConfig.from_spec(spec)
+    assert config.block_size_factor == spec.gpu_blocks_per_file
+    for group_config in config.kv_group_configs:
+        assert (
+            group_config.offloaded_block_size
+            == spec.gpu_blocks_per_file * group_config.gpu_block_size
+        )


### PR DESCRIPTION
When block_size is absent from kv_connector_extra_config, the fs backend defaults offloaded_block_size to 256 tokens, but vLLM's OffloadingSpec base class only derives block_size_factor when block_size is explicitly present, leaving it at 1. The scheduler then emits one offload key per GPU block while the worker consumes one key per file (gpu_blocks_per_file blocks), so on hybrid models (e.g. Gemma with sliding-window + full-attention KV cache groups) the second group's key slice lands inside the first group's keys and every transfer fails with:

    AssertionError: Expected group_idx=1 but key encodes 0

Set block_size_factor = gpu_blocks_per_file in
SharedStorageOffloadingSpec so the scheduler and worker always agree on the per-file key granularity, regardless of whether block_size is configured explicitly. On single-group models the old mismatch did not assert but silently named files after the wrong block hashes, crippling the offload hit rate.

Fixes #656