### PR TITLE
fix(fs_backend) bypass uniformity assertion to support explicit block_size on hybrid models

### DIFF
--- a/kv_connectors/llmd_fs_backend/README.md
+++ b/kv_connectors/llmd_fs_backend/README.md
@@ -100,7 +100,7 @@ make image-fs-backend-push IMAGE_TAG_BASE=<your-base-container-registry> FS_BACK
 ### Connector parameters
 
 - `shared_storage_path`: base path for storing and loading the KV data files.
-- `block_size`: number of tokens stored per file (must be in granularity of GPU block size, default: `256`).
+- `block_size`: number of tokens stored per file (must be a multiple of the block hash granularity, default: `256`). On hybrid models whose KV cache groups use different GPU block sizes, each group stores `block_size / hash_block_size` GPU blocks per file, so the per-file token count scales with the group's block size.
 - `threads_per_gpu`: number of I/O threads per GPU
 - `max_staging_memory_gb`: total staging memory limit
 - `max_write_queued_seconds`: maximum time budget (in seconds) for queued writes before excess writes are dropped (default: `30.0`, set to `0` to disable). The actual write queue depth limit is computed dynamically as `threads_per_gpu * max_write_queued_seconds / avg_write_duration`. For example, with 64 threads and `max_write_queued_seconds=30`: on fast NVMe storage (20ms avg write) the limit is ~96,000 (effectively unlimited), while on slow block storage (2s avg write) the limit is ~960. Dropped writes result in cache misses on future reads, not data loss.

--- a/kv_connectors/llmd_fs_backend/README.md
+++ b/kv_connectors/llmd_fs_backend/README.md
@@ -100,7 +100,7 @@ make image-fs-backend-push IMAGE_TAG_BASE=<your-base-container-registry> FS_BACK
 ### Connector parameters
 
 - `shared_storage_path`: base path for storing and loading the KV data files.
-- `block_size`: number of tokens stored per file (must be a multiple of the block hash granularity, default: `256`). On hybrid models whose KV cache groups use different GPU block sizes, each group stores `block_size / hash_block_size` GPU blocks per file, so the per-file token count scales with the group's block size.
+- `block_size`: target number of tokens per file at the block-hash granularity (must be a multiple of `hash_block_size`, default: `256`). Each KV cache group stores `block_size / hash_block_size` GPU blocks per file, so on hybrid models whose groups use different GPU block sizes the actual per-file token count scales with each group's block size.
 - `threads_per_gpu`: number of I/O threads per GPU
 - `max_staging_memory_gb`: total staging memory limit
 - `max_write_queued_seconds`: maximum time budget (in seconds) for queued writes before excess writes are dropped (default: `30.0`, set to `0` to disable). The actual write queue depth limit is computed dynamically as `threads_per_gpu * max_write_queued_seconds / avg_write_duration`. For example, with 64 threads and `max_write_queued_seconds=30`: on fast NVMe storage (20ms avg write) the limit is ~96,000 (effectively unlimited), while on slow block storage (2s avg write) the limit is ~960. Dropped writes result in cache misses on future reads, not data loss.

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
@@ -45,7 +45,17 @@ class SharedStorageOffloadingSpec(OffloadingSpec):
     """
 
     def __init__(self, vllm_config: VllmConfig, kv_cache_config: KVCacheConfig):
-        super().__init__(vllm_config, kv_cache_config)
+        # Hide "block_size" from the base class to bypass the uniformity
+        # assertion on hybrid models (we derive the factor ourselves below).
+        kv_transfer_config = vllm_config.kv_transfer_config
+        assert kv_transfer_config is not None
+        extra_config = kv_transfer_config.kv_connector_extra_config
+        hidden_block_size = extra_config.pop("block_size", None)
+        try:
+            super().__init__(vllm_config, kv_cache_config)
+        finally:
+            if hidden_block_size is not None:
+                extra_config["block_size"] = hidden_block_size
 
         self._manager: OffloadingManager | None = None
         # worker-side
@@ -75,8 +85,7 @@ class SharedStorageOffloadingSpec(OffloadingSpec):
         )
         self.gpu_blocks_per_file = self.offloaded_block_size // self.hash_block_size
 
-        # Dont leave block size to default value of 1 when
-        # block_size is not set in extra_config
+        # Derive block_size_factor from file layout instead of base class.
         self.block_size_factor = self.gpu_blocks_per_file
 
         self.read_preferring_ratio = float(

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
@@ -75,13 +75,8 @@ class SharedStorageOffloadingSpec(OffloadingSpec):
         )
         self.gpu_blocks_per_file = self.offloaded_block_size // self.hash_block_size
 
-        # vLLM's OffloadingSpec base only derives block_size_factor when
-        # "block_size" is explicitly present in extra_config, leaving it at 1
-        # otherwise — but we default offloaded_block_size ourselves, so the
-        # scheduler must be kept in sync. With a stale factor of 1 the
-        # scheduler emits one offload key per GPU block while the worker
-        # consumes one key per file, misaligning keys across KV cache groups
-        # on hybrid models (https://github.com/llm-d/llm-d-kv-cache/issues/656).
+        # Dont leave block size to default value of 1 when
+        # block_size is not set in extra_config
         self.block_size_factor = self.gpu_blocks_per_file
 
         self.read_preferring_ratio = float(

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
@@ -75,8 +75,13 @@ class SharedStorageOffloadingSpec(OffloadingSpec):
         )
         self.gpu_blocks_per_file = self.offloaded_block_size // self.hash_block_size
 
-        # Dont leave block size to default value of 1 when
-        # block_size is not set in extra_config
+        # vLLM's OffloadingSpec base only derives block_size_factor when
+        # "block_size" is explicitly present in extra_config, leaving it at 1
+        # otherwise — but we default offloaded_block_size ourselves, so the
+        # scheduler must be kept in sync. With a stale factor of 1 the
+        # scheduler emits one offload key per GPU block while the worker
+        # consumes one key per file, misaligning keys across KV cache groups
+        # on hybrid models (https://github.com/llm-d/llm-d-kv-cache/issues/656).
         self.block_size_factor = self.gpu_blocks_per_file
 
         self.read_preferring_ratio = float(

--- a/kv_connectors/llmd_fs_backend/tests/test_spec.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_spec.py
@@ -57,34 +57,40 @@ def make_vllm_config(extra_config: dict) -> SimpleNamespace:
     )
 
 
-def make_hybrid_kv_cache_config() -> KVCacheConfig:
-    """Two KV cache groups (full attention + sliding window), Gemma-style."""
-    attn_args = dict(
-        block_size=GPU_BLOCK_SIZE,
-        num_kv_heads=8,
-        head_size=128,
-        dtype=torch.bfloat16,
-    )
+def make_hybrid_kv_cache_config(
+    swa_block_size: int = GPU_BLOCK_SIZE,
+) -> KVCacheConfig:
+    """Two KV cache groups (full attention + sliding window), Gemma-style.
+
+    Pass a different swa_block_size to simulate hybrid models whose groups
+    do not share one GPU block size.
+    """
+    attn_args = dict(num_kv_heads=8, head_size=128, dtype=torch.bfloat16)
     return KVCacheConfig(
         num_blocks=128,
         kv_cache_tensors=[],
         kv_cache_groups=[
             KVCacheGroupSpec(
                 layer_names=["layers.0.attn"],
-                kv_cache_spec=FullAttentionSpec(**attn_args),
+                kv_cache_spec=FullAttentionSpec(block_size=GPU_BLOCK_SIZE, **attn_args),
             ),
             KVCacheGroupSpec(
                 layer_names=["layers.1.attn"],
-                kv_cache_spec=SlidingWindowSpec(**attn_args, sliding_window=512),
+                kv_cache_spec=SlidingWindowSpec(
+                    block_size=swa_block_size, sliding_window=512, **attn_args
+                ),
             ),
         ],
     )
 
 
-def make_spec(tmp_path, extra_config: dict) -> SharedStorageOffloadingSpec:
+def make_spec(
+    tmp_path, extra_config: dict, swa_block_size: int = GPU_BLOCK_SIZE
+) -> SharedStorageOffloadingSpec:
     extra_config = {"shared_storage_path": str(tmp_path), **extra_config}
     return SharedStorageOffloadingSpec(
-        make_vllm_config(extra_config), make_hybrid_kv_cache_config()
+        make_vllm_config(extra_config),
+        make_hybrid_kv_cache_config(swa_block_size),
     )
 
 
@@ -104,6 +110,29 @@ def test_default_block_size_syncs_scheduler_factor(tmp_path):
 def test_explicit_block_size_keeps_factor_in_sync(tmp_path):
     spec = make_spec(tmp_path, {"block_size": 128})
     assert spec.gpu_blocks_per_file == 128 // GPU_BLOCK_SIZE
+    assert spec.block_size_factor == spec.gpu_blocks_per_file
+
+
+def test_explicit_block_size_with_non_uniform_groups(tmp_path):
+    """Hybrid models whose KV cache groups have different GPU block sizes
+    (e.g. Gemma) must accept an explicit "block_size": vLLM's OffloadingSpec
+    base asserts group-uniformity when it sees that key, so the spec hides
+    it from the base class (issue #657). Files are sized in hash_block_size
+    (= GCD of group block sizes) granularity instead.
+    """
+    # str value: kv_connector_extra_config arrives JSON-decoded as-is
+    spec = make_spec(tmp_path, {"block_size": "256"}, swa_block_size=2 * GPU_BLOCK_SIZE)
+    # hash_block_size = gcd(16, 32) = 16
+    assert spec.hash_block_size == GPU_BLOCK_SIZE
+    assert spec.gpu_blocks_per_file == 256 // GPU_BLOCK_SIZE
+    assert spec.block_size_factor == spec.gpu_blocks_per_file
+    # the user-facing config must be restored after the base-class detour
+    assert spec.extra_config["block_size"] == "256"
+
+
+def test_default_block_size_with_non_uniform_groups(tmp_path):
+    spec = make_spec(tmp_path, {}, swa_block_size=2 * GPU_BLOCK_SIZE)
+    assert spec.gpu_blocks_per_file == DEFAULT_STORAGE_BLOCK_SIZE // GPU_BLOCK_SIZE
     assert spec.block_size_factor == spec.gpu_blocks_per_file
 
 


### PR DESCRIPTION
LLM's base class OffloadingSpec intercepts block_size from extra_config and asserts that all KV cache groups share a uniform GPU block size to compute the block_size_factor.

However, the llmd_fs_backend doesn't require this uniformity because it handles mapping independently by slicing blocks in hash_block_size (the greatest common divisor of all groups' block sizes) granularity, and derives block_size_factor from the layout configuration instead.

Solution
This PR updates the custom SharedStorageOffloadingSpec class to:

Temporarily hide "block_size" from the base constructor super().__init__(vllm_config, kv_cache_config) so that the base class uniformity check is bypassed.
Restore "block_size" in extra_config inside a finally block to preserve user configurations.
Compute block_size_factor dynamically based on the file layout rather than relying on the base class's derived value.
This ensures that default and explicit block size settings behave identically on hybrid models.

Fixes #657,#656 