### PR TITLE
Update PVC evictor image defaults for llm-d v0.8

### DIFF
--- a/kv_connectors/pvc_evictor/Dockerfile
+++ b/kv_connectors/pvc_evictor/Dockerfile
@@ -2,10 +2,13 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# llmd_fs_backend: required when STORAGE_EVENTS_ENDPOINT is set (#605 BlockRemoved).
+# llmd_fs_backend.event_publisher: required when STORAGE_EVENTS_ENDPOINT is set (#605 BlockRemoved).
 # Crawler discovery is path-only (#611) and does not import FileMapper/vLLM.
 # Build from kv_connectors/: podman build -f pvc_evictor/Dockerfile -t pvc-evictor:tag .
-COPY llmd_fs_backend/llmd_fs_backend/ /app/llmd_fs_backend/
+RUN python3 -m pip install --no-cache-dir msgpack pyzmq \
+    && mkdir -p /app/llmd_fs_backend \
+    && printf '%s\n' '# Minimal package init for pvc_evictor event publishing.' > /app/llmd_fs_backend/__init__.py
+COPY llmd_fs_backend/llmd_fs_backend/event_publisher.py /app/llmd_fs_backend/event_publisher.py
 
 COPY pvc_evictor/config.py pvc_evictor/evictor.py ./
 COPY pvc_evictor/utils/ ./utils/

--- a/kv_connectors/pvc_evictor/Makefile
+++ b/kv_connectors/pvc_evictor/Makefile
@@ -1,7 +1,10 @@
+IMAGE_REPOSITORY ?= quay.io/pvc-evictor/pvc-evictor
+IMAGE_TAG ?= llm-d-v0.8
+
 .PHONY: test docker-build
 
 test:
 	python3 -m pytest tests/ -v
 
 docker-build:
-	cd .. && podman build -f pvc_evictor/Dockerfile -t pvc-evictor:latest .
+	cd .. && podman build -f pvc_evictor/Dockerfile -t $(IMAGE_REPOSITORY):$(IMAGE_TAG) .

--- a/kv_connectors/pvc_evictor/Makefile
+++ b/kv_connectors/pvc_evictor/Makefile
@@ -1,5 +1,5 @@
 IMAGE_REPOSITORY ?= quay.io/pvc-evictor/pvc-evictor
-IMAGE_TAG ?= llm-d-v0.8
+IMAGE_TAG ?= latest
 
 .PHONY: test docker-build
 

--- a/kv_connectors/pvc_evictor/README.md
+++ b/kv_connectors/pvc_evictor/README.md
@@ -14,9 +14,7 @@ The chart defaults to the latest PVC Evictor image:
 quay.io/pvc-evictor/pvc-evictor:latest
 ```
 
-For reproducible llm-d v0.8 deployments, pin the image tag to `llm-d-v0.8`.
-The image includes `llmd_fs_backend.event_publisher` for optional
-`STORAGE_EVENTS_ENDPOINT` support (#605).
+For reproducible llm-d v0.x deployments, pin `image.tag` to `llm-d-v0.x`.
 
 ```bash
 helm install pvc-evictor ./helm \
@@ -199,7 +197,7 @@ By default, this builds `quay.io/pvc-evictor/pvc-evictor:latest`.
 Override the target when testing a local or development tag:
 
 ```bash
-make docker-build IMAGE_REPOSITORY=quay.io/pvc-evictor/pvc-evictor IMAGE_TAG=llm-d-v0.8
+make docker-build IMAGE_REPOSITORY=quay.io/pvc-evictor/pvc-evictor IMAGE_TAG=llm-d-v0.x
 ```
 
 ## Documentation

--- a/kv_connectors/pvc_evictor/README.md
+++ b/kv_connectors/pvc_evictor/README.md
@@ -8,15 +8,15 @@ The PVC Evictor is a multi-process Kubernetes deployment designed to automatical
 
 ## Quick Start
 
-The recommended image for llm-d v0.8 deployments is:
+The chart defaults to the latest PVC Evictor image:
 
 ```text
-quay.io/pvc-evictor/pvc-evictor:llm-d-v0.8
+quay.io/pvc-evictor/pvc-evictor:latest
 ```
 
-This image is built from `main` after the current FileMapper/fs_backend layout
-fix (#611) and includes `llmd_fs_backend.event_publisher` in the image for
-optional `STORAGE_EVENTS_ENDPOINT` support (#605).
+For reproducible llm-d v0.8 deployments, pin the image tag to `llm-d-v0.8`.
+The image includes `llmd_fs_backend.event_publisher` for optional
+`STORAGE_EVENTS_ENDPOINT` support (#605).
 
 ```bash
 helm install pvc-evictor ./helm \
@@ -195,11 +195,11 @@ Build image (from `kv_connectors/`):
 make docker-build
 ```
 
-By default, this builds `quay.io/pvc-evictor/pvc-evictor:llm-d-v0.8`.
+By default, this builds `quay.io/pvc-evictor/pvc-evictor:latest`.
 Override the target when testing a local or development tag:
 
 ```bash
-make docker-build IMAGE_REPOSITORY=quay.io/pvc-evictor/pvc-evictor IMAGE_TAG=latest
+make docker-build IMAGE_REPOSITORY=quay.io/pvc-evictor/pvc-evictor IMAGE_TAG=llm-d-v0.8
 ```
 
 ## Documentation

--- a/kv_connectors/pvc_evictor/README.md
+++ b/kv_connectors/pvc_evictor/README.md
@@ -8,6 +8,16 @@ The PVC Evictor is a multi-process Kubernetes deployment designed to automatical
 
 ## Quick Start
 
+The recommended image for llm-d v0.8 deployments is:
+
+```text
+quay.io/pvc-evictor/pvc-evictor:llm-d-v0.8
+```
+
+This image is built from `main` after the current FileMapper/fs_backend layout
+fix (#611) and includes `llmd_fs_backend.event_publisher` in the image for
+optional `STORAGE_EVENTS_ENDPOINT` support (#605).
+
 ```bash
 helm install pvc-evictor ./helm \
   --set pvc.name=my-vllm-cache \
@@ -183,6 +193,13 @@ Build image (from `kv_connectors/`):
 
 ```bash
 make docker-build
+```
+
+By default, this builds `quay.io/pvc-evictor/pvc-evictor:llm-d-v0.8`.
+Override the target when testing a local or development tag:
+
+```bash
+make docker-build IMAGE_REPOSITORY=quay.io/pvc-evictor/pvc-evictor IMAGE_TAG=latest
 ```
 
 ## Documentation

--- a/kv_connectors/pvc_evictor/README.md
+++ b/kv_connectors/pvc_evictor/README.md
@@ -197,7 +197,7 @@ By default, this builds `quay.io/pvc-evictor/pvc-evictor:latest`.
 Override the target when testing a local or development tag:
 
 ```bash
-make docker-build IMAGE_REPOSITORY=quay.io/pvc-evictor/pvc-evictor IMAGE_TAG=llm-d-v0.x
+make docker-build IMAGE_REPOSITORY=quay.io/pvc-evictor/pvc-evictor IMAGE_TAG=llm-d-v0.8
 ```
 
 ## Documentation

--- a/kv_connectors/pvc_evictor/helm/README.md
+++ b/kv_connectors/pvc_evictor/helm/README.md
@@ -13,6 +13,15 @@ This Helm chart deploys the PVC Evictor, a multi-process Kubernetes deployment t
 
 ### Quick Start
 
+By default, the chart uses:
+
+```text
+quay.io/pvc-evictor/pvc-evictor:llm-d-v0.8
+```
+
+Use this explicit tag for llm-d v0.8 deployments. It includes the current
+FileMapper/fs_backend layout fix and optional storage event support.
+
 ```bash
 # Install with required values
 helm install pvc-evictor ./helm \
@@ -65,6 +74,15 @@ Then install:
 helm install pvc-evictor ./helm -f my-values.yaml
 ```
 
+To test a different image tag, override the image fields:
+
+```bash
+helm install pvc-evictor ./helm \
+  --set pvc.name=my-kv-cache-pvc \
+  --set image.repository=quay.io/pvc-evictor/pvc-evictor \
+  --set image.tag=latest
+```
+
 ## Configuration
 
 ### Required Values
@@ -95,7 +113,7 @@ kubectl get pod <pod-name> -n <namespace> -o jsonpath='{.spec.containers[0].secu
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image.repository` | Container image repository | `quay.io/pvc-evictor/pvc-evictor` |
-| `image.tag` | Container image tag | `latest` |
+| `image.tag` | Container image tag | `llm-d-v0.8` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 
 #### PVC Configuration

--- a/kv_connectors/pvc_evictor/helm/README.md
+++ b/kv_connectors/pvc_evictor/helm/README.md
@@ -79,7 +79,7 @@ To pin a specific image tag, override the image fields:
 helm install pvc-evictor ./helm \
   --set pvc.name=my-kv-cache-pvc \
   --set image.repository=quay.io/pvc-evictor/pvc-evictor \
-  --set image.tag=llm-d-v0.x
+  --set image.tag=llm-d-v0.8
 ```
 
 ## Configuration

--- a/kv_connectors/pvc_evictor/helm/README.md
+++ b/kv_connectors/pvc_evictor/helm/README.md
@@ -16,11 +16,12 @@ This Helm chart deploys the PVC Evictor, a multi-process Kubernetes deployment t
 By default, the chart uses:
 
 ```text
-quay.io/pvc-evictor/pvc-evictor:llm-d-v0.8
+quay.io/pvc-evictor/pvc-evictor:latest
 ```
 
-Use this explicit tag for llm-d v0.8 deployments. It includes the current
-FileMapper/fs_backend layout fix and optional storage event support.
+For reproducible llm-d v0.8 deployments, pin `image.tag` to `llm-d-v0.8`.
+The image includes the current FileMapper/fs_backend layout fix and optional
+storage event support.
 
 ```bash
 # Install with required values
@@ -74,13 +75,13 @@ Then install:
 helm install pvc-evictor ./helm -f my-values.yaml
 ```
 
-To test a different image tag, override the image fields:
+To pin a specific image tag, override the image fields:
 
 ```bash
 helm install pvc-evictor ./helm \
   --set pvc.name=my-kv-cache-pvc \
   --set image.repository=quay.io/pvc-evictor/pvc-evictor \
-  --set image.tag=latest
+  --set image.tag=llm-d-v0.8
 ```
 
 ## Configuration
@@ -113,7 +114,7 @@ kubectl get pod <pod-name> -n <namespace> -o jsonpath='{.spec.containers[0].secu
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image.repository` | Container image repository | `quay.io/pvc-evictor/pvc-evictor` |
-| `image.tag` | Container image tag | `llm-d-v0.8` |
+| `image.tag` | Container image tag | `latest` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 
 #### PVC Configuration

--- a/kv_connectors/pvc_evictor/helm/README.md
+++ b/kv_connectors/pvc_evictor/helm/README.md
@@ -19,9 +19,7 @@ By default, the chart uses:
 quay.io/pvc-evictor/pvc-evictor:latest
 ```
 
-For reproducible llm-d v0.8 deployments, pin `image.tag` to `llm-d-v0.8`.
-The image includes the current FileMapper/fs_backend layout fix and optional
-storage event support.
+For reproducible llm-d v0.x deployments, pin `image.tag` to `llm-d-v0.x`.
 
 ```bash
 # Install with required values
@@ -81,7 +79,7 @@ To pin a specific image tag, override the image fields:
 helm install pvc-evictor ./helm \
   --set pvc.name=my-kv-cache-pvc \
   --set image.repository=quay.io/pvc-evictor/pvc-evictor \
-  --set image.tag=llm-d-v0.8
+  --set image.tag=llm-d-v0.x
 ```
 
 ## Configuration

--- a/kv_connectors/pvc_evictor/helm/values.yaml
+++ b/kv_connectors/pvc_evictor/helm/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 image:
   repository: quay.io/pvc-evictor/pvc-evictor
   pullPolicy: IfNotPresent
-  tag: "llm-d-v0.8"
+  tag: "latest"
 
 # Service account to use
 serviceAccountName: default

--- a/kv_connectors/pvc_evictor/helm/values.yaml
+++ b/kv_connectors/pvc_evictor/helm/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 image:
   repository: quay.io/pvc-evictor/pvc-evictor
   pullPolicy: IfNotPresent
-  tag: "latest"
+  tag: "llm-d-v0.8"
 
 # Service account to use
 serviceAccountName: default


### PR DESCRIPTION
This PR updates the PVC Evictor image setup for llm-d v0.8.

Changed the Helm default image tag to llm-d-v0.8, updated relevant README files and made docker-build default to updated image.
Kept llmd_fs_backend.event_publisher available in the PVC Evictor image for STORAGE_EVENTS_ENDPOINT, without copying the full backend package.

Verified python3 -m pytest kv_connectors/pvc_evictor/tests -q , local and cluster smoke tests.

Once this merges I'll push to quay the llm-d-v0.8 and latest tags.
