### PR TITLE
fix(kvevents): support map-encoded vLLM KV events (vLLM #42892 compatibility)

### DIFF
--- a/pkg/kvevents/engineadapter/vllm_adapter.go
+++ b/pkg/kvevents/engineadapter/vllm_adapter.go
@@ -110,7 +110,7 @@ type msgpackVLLMEventBatch struct {
 func (v *VLLMAdapter) decodeVLLMEvent(rawEventBytes []byte) (kvevents.GenericEvent, error) {
 	var decoded any
 	if err := msgpack.Unmarshal(rawEventBytes, &decoded); err != nil {
-		return nil, fmt.Errorf("failed to decode tagged union: %w", err)
+		return nil, fmt.Errorf("failed to decode vLLM event: %w", err)
 	}
 
 	var fields []any
@@ -173,9 +173,13 @@ var (
 // omitted trailing field in the array encoding. Unknown tags are passed
 // through so converter lookup reports them uniformly.
 func mapEventToFields(ev map[string]any) ([]any, error) {
-	tag, ok := ev["type"].(string)
+	rawTag, exists := ev["type"]
+	if !exists {
+		return nil, fmt.Errorf("map-encoded event is missing the %q tag", "type")
+	}
+	tag, ok := rawTag.(string)
 	if !ok {
-		return nil, fmt.Errorf("map-encoded event tag (%q) is not a string: %T", "type", ev["type"])
+		return nil, fmt.Errorf("map-encoded event tag (%q) is not a string: %T", "type", rawTag)
 	}
 
 	var order []string

--- a/pkg/kvevents/engineadapter/vllm_adapter.go
+++ b/pkg/kvevents/engineadapter/vllm_adapter.go
@@ -27,14 +27,11 @@ import (
 // VLLMAdapter implements the kvevents.EngineAdapter interface for vLLM engines.
 // It parses raw transport messages (topic + msgpack payload) into domain events.
 //
-// Older vLLM serializes events using msgspec with array_like=True and
-// omit_defaults=True, producing positional msgpack arrays where trailing default
-// fields may be absent; newer vLLM (vllm-project/vllm#42892) dropped array_like
-// and emits tagged field-name maps instead. To maintain forward and backward
-// compatibility across vLLM versions (either encoding, new fields appended or
-// trailing fields omitted), we decode into []any -- normalizing maps to the
-// positional layout -- and extract fields positionally with length guards
-// instead of using fixed structs.
+// vLLM emits events either as positional msgpack arrays with trailing defaults
+// omitted (msgspec array_like=True) or, since vllm-project/vllm#42892, as
+// field-name maps tagged under "type". Both decode into the same positional
+// []any layout, extracted with length guards instead of fixed structs, so the
+// converters stay encoding-agnostic and tolerate appended or omitted fields.
 type VLLMAdapter struct {
 	eventConverters map[string]func([]any) (kvevents.GenericEvent, error)
 }
@@ -98,19 +95,13 @@ type msgpackVLLMEventBatch struct {
 	DataParallelRank *int `msgpack:",omitempty"`
 }
 
-// decodeVLLMEvent decodes a single vLLM event from msgpack bytes into a domain event.
-// It performs a single unmarshal and passes the decoded fields to the appropriate
-// converter, avoiding double-decode overhead.
-//
-// Two encodings are supported:
-//   - positional arrays: vLLM < v0.x encoded events with msgspec array_like=True
-//   - tagged maps: vLLM dropped array_like in vllm-project/vllm#42892, so newer
-//     versions emit field-name maps with the tag under the "type" key. These are
-//     normalized to the positional layout so the converters stay encoding-agnostic.
+// decodeVLLMEvent decodes a single vLLM event from msgpack bytes and dispatches
+// it to the matching converter. Map-encoded events are first normalized to the
+// positional []any layout the converters consume.
 func (v *VLLMAdapter) decodeVLLMEvent(rawEventBytes []byte) (kvevents.GenericEvent, error) {
 	var decoded any
 	if err := msgpack.Unmarshal(rawEventBytes, &decoded); err != nil {
-		return nil, fmt.Errorf("failed to decode vLLM event: %w", err)
+		return nil, fmt.Errorf("unmarshal event payload: %w", err)
 	}
 
 	var fields []any
@@ -120,19 +111,6 @@ func (v *VLLMAdapter) decodeVLLMEvent(rawEventBytes []byte) (kvevents.GenericEve
 	case map[string]any:
 		var err error
 		if fields, err = mapEventToFields(ev); err != nil {
-			return nil, err
-		}
-	case map[any]any:
-		strKeyed := make(map[string]any, len(ev))
-		for k, val := range ev {
-			s, ok := k.(string)
-			if !ok {
-				return nil, fmt.Errorf("map-encoded event key is not a string: %T", k)
-			}
-			strKeyed[s] = val
-		}
-		var err error
-		if fields, err = mapEventToFields(strKeyed); err != nil {
 			return nil, err
 		}
 	default:
@@ -156,9 +134,8 @@ func (v *VLLMAdapter) decodeVLLMEvent(rawEventBytes []byte) (kvevents.GenericEve
 	return converter(fields)
 }
 
-// Field-name order of map-encoded events, mirroring the positional layouts
-// documented on the converters (msgspec emits fields in definition order, but
-// maps are accessed by name so only the converters' expectations matter here).
+// Field-name order of map-encoded events, mirroring the converters' positional
+// layouts.
 var (
 	blockStoredFieldOrder = []string{
 		"block_hashes", "parent_block_hash", "token_ids", "block_size",
@@ -168,10 +145,9 @@ var (
 	blockRemovedFieldOrder = []string{"block_hashes", "medium", "group_idx"}
 )
 
-// mapEventToFields normalizes a map-encoded vLLM event into the positional
-// []any layout the converters consume. Absent fields become nil, matching an
-// omitted trailing field in the array encoding. Unknown tags are passed
-// through so converter lookup reports them uniformly.
+// mapEventToFields normalizes a map-encoded vLLM event to positional []any.
+// Absent fields become nil (same as an omitted trailing array field); unknown
+// tags pass through so converter lookup reports them uniformly.
 func mapEventToFields(ev map[string]any) ([]any, error) {
 	rawTag, exists := ev["type"]
 	if !exists {

--- a/pkg/kvevents/engineadapter/vllm_adapter.go
+++ b/pkg/kvevents/engineadapter/vllm_adapter.go
@@ -27,11 +27,14 @@ import (
 // VLLMAdapter implements the kvevents.EngineAdapter interface for vLLM engines.
 // It parses raw transport messages (topic + msgpack payload) into domain events.
 //
-// vLLM serializes events using msgspec with array_like=True and omit_defaults=True,
-// producing positional msgpack arrays where trailing default fields may be absent.
-// To maintain forward and backward compatibility across vLLM versions (new fields
-// appended or trailing fields omitted), we decode into []any and extract fields
-// positionally with length guards instead of using fixed structs.
+// Older vLLM serializes events using msgspec with array_like=True and
+// omit_defaults=True, producing positional msgpack arrays where trailing default
+// fields may be absent; newer vLLM (vllm-project/vllm#42892) dropped array_like
+// and emits tagged field-name maps instead. To maintain forward and backward
+// compatibility across vLLM versions (either encoding, new fields appended or
+// trailing fields omitted), we decode into []any -- normalizing maps to the
+// positional layout -- and extract fields positionally with length guards
+// instead of using fixed structs.
 type VLLMAdapter struct {
 	eventConverters map[string]func([]any) (kvevents.GenericEvent, error)
 }
@@ -96,12 +99,44 @@ type msgpackVLLMEventBatch struct {
 }
 
 // decodeVLLMEvent decodes a single vLLM event from msgpack bytes into a domain event.
-// It performs a single unmarshal into []any and passes the decoded fields to the
-// appropriate converter, avoiding double-decode overhead.
+// It performs a single unmarshal and passes the decoded fields to the appropriate
+// converter, avoiding double-decode overhead.
+//
+// Two encodings are supported:
+//   - positional arrays: vLLM < v0.x encoded events with msgspec array_like=True
+//   - tagged maps: vLLM dropped array_like in vllm-project/vllm#42892, so newer
+//     versions emit field-name maps with the tag under the "type" key. These are
+//     normalized to the positional layout so the converters stay encoding-agnostic.
 func (v *VLLMAdapter) decodeVLLMEvent(rawEventBytes []byte) (kvevents.GenericEvent, error) {
-	var fields []any
-	if err := msgpack.Unmarshal(rawEventBytes, &fields); err != nil {
+	var decoded any
+	if err := msgpack.Unmarshal(rawEventBytes, &decoded); err != nil {
 		return nil, fmt.Errorf("failed to decode tagged union: %w", err)
+	}
+
+	var fields []any
+	switch ev := decoded.(type) {
+	case []any:
+		fields = ev
+	case map[string]any:
+		var err error
+		if fields, err = mapEventToFields(ev); err != nil {
+			return nil, err
+		}
+	case map[any]any:
+		strKeyed := make(map[string]any, len(ev))
+		for k, val := range ev {
+			s, ok := k.(string)
+			if !ok {
+				return nil, fmt.Errorf("map-encoded event key is not a string: %T", k)
+			}
+			strKeyed[s] = val
+		}
+		var err error
+		if fields, err = mapEventToFields(strKeyed); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("event is neither an array nor a map: %T", decoded)
 	}
 
 	if len(fields) < 1 {
@@ -119,6 +154,48 @@ func (v *VLLMAdapter) decodeVLLMEvent(rawEventBytes []byte) (kvevents.GenericEve
 	}
 
 	return converter(fields)
+}
+
+// Field-name order of map-encoded events, mirroring the positional layouts
+// documented on the converters (msgspec emits fields in definition order, but
+// maps are accessed by name so only the converters' expectations matter here).
+var (
+	blockStoredFieldOrder = []string{
+		"block_hashes", "parent_block_hash", "token_ids", "block_size",
+		"lora_id", "medium", "lora_name", "extra_keys", "group_idx",
+		"kv_cache_spec_kind", "kv_cache_spec_sliding_window",
+	}
+	blockRemovedFieldOrder = []string{"block_hashes", "medium", "group_idx"}
+)
+
+// mapEventToFields normalizes a map-encoded vLLM event into the positional
+// []any layout the converters consume. Absent fields become nil, matching an
+// omitted trailing field in the array encoding. Unknown tags are passed
+// through so converter lookup reports them uniformly.
+func mapEventToFields(ev map[string]any) ([]any, error) {
+	tag, ok := ev["type"].(string)
+	if !ok {
+		return nil, fmt.Errorf("map-encoded event tag (%q) is not a string: %T", "type", ev["type"])
+	}
+
+	var order []string
+	switch tag {
+	case eventTagBlockStored:
+		order = blockStoredFieldOrder
+	case eventTagBlockRemoved:
+		order = blockRemovedFieldOrder
+	case eventTagAllBlocksCleared:
+		// no payload fields
+	default:
+		return []any{tag}, nil
+	}
+
+	fields := make([]any, 0, len(order)+1)
+	fields = append(fields, tag)
+	for _, name := range order {
+		fields = append(fields, ev[name])
+	}
+	return fields, nil
 }
 
 // fieldAt returns the element at index i from fields, or nil if out of bounds.

--- a/pkg/kvevents/engineadapter/vllm_adapter_test.go
+++ b/pkg/kvevents/engineadapter/vllm_adapter_test.go
@@ -611,3 +611,103 @@ func TestVLLMEventBatch_NestedArrayEvents(t *testing.T) {
 	assert.Equal(t, []uint32{1, 2, 3}, blockStored.Tokens)
 	assert.Equal(t, "gpu", blockStored.DeviceTier)
 }
+
+// TestVLLMParseMessage_MapEncodedBlockStored verifies the map encoding emitted
+// by newer vLLM (vllm-project/vllm#42892 dropped msgspec array_like=True):
+// events arrive as field-name maps with the tag under "type".
+func TestVLLMParseMessage_MapEncodedBlockStored(t *testing.T) {
+	adapter := NewVLLMAdapter()
+
+	groupIdx := 0
+	blockStoredEvent := map[string]any{
+		"type":              "BlockStored",
+		"block_hashes":      []any{uint64(100), uint64(101)},
+		"parent_block_hash": uint64(99),
+		"token_ids":         []uint32{1, 2, 3},
+		"block_size":        16,
+		"lora_id":           nil,
+		"medium":            "CPU",
+		"lora_name":         nil,
+		"extra_keys":        nil,
+		"group_idx":         groupIdx,
+		// kv_cache_spec_* omitted, as with omit_defaults.
+	}
+	payload, err := msgpack.Marshal([]any{1234567890.0, []any{blockStoredEvent}, nil})
+	require.NoError(t, err)
+
+	podID, modelName, eventBatch, err := adapter.ParseMessage(&kvevents.RawMessage{
+		Topic:   "kv@pod-1@llama-2-7b",
+		Payload: payload,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "pod-1", podID)
+	assert.Equal(t, "llama-2-7b", modelName)
+	require.Len(t, eventBatch.Events, 1)
+
+	blockStored, ok := eventBatch.Events[0].(*kvevents.BlockStoredEvent)
+	require.True(t, ok)
+	assert.Equal(t, []uint64{100, 101}, blockStored.BlockHashes)
+	assert.Equal(t, uint64(99), blockStored.ParentHash)
+	assert.Equal(t, []uint32{1, 2, 3}, blockStored.Tokens)
+	assert.Equal(t, 16, blockStored.BlockSize)
+	assert.Equal(t, "CPU", blockStored.DeviceTier)
+	require.NotNil(t, blockStored.GroupIdx)
+	assert.Equal(t, 0, *blockStored.GroupIdx)
+}
+
+// TestVLLMParseMessage_MapEncodedBlockRemovedAndCleared covers the remaining
+// map-encoded event kinds, mixed with an array-encoded event in one batch.
+func TestVLLMParseMessage_MapEncodedBlockRemovedAndCleared(t *testing.T) {
+	adapter := NewVLLMAdapter()
+
+	removed := map[string]any{
+		"type":         "BlockRemoved",
+		"block_hashes": []any{uint64(100)},
+		"medium":       "CPU",
+	}
+	cleared := map[string]any{"type": "AllBlocksCleared"}
+	arrayStored := []any{
+		"BlockStored", []any{uint64(7)}, nil, []uint32{9}, 1, nil, "GPU", nil, nil,
+	}
+	payload, err := msgpack.Marshal(
+		[]any{1234567890.0, []any{removed, cleared, arrayStored}, nil})
+	require.NoError(t, err)
+
+	_, _, eventBatch, err := adapter.ParseMessage(&kvevents.RawMessage{
+		Topic:   "kv@pod-1@m",
+		Payload: payload,
+	})
+	require.NoError(t, err)
+	require.Len(t, eventBatch.Events, 3)
+
+	blockRemoved, ok := eventBatch.Events[0].(*kvevents.BlockRemovedEvent)
+	require.True(t, ok)
+	assert.Equal(t, []uint64{100}, blockRemoved.BlockHashes)
+	assert.Equal(t, "CPU", blockRemoved.DeviceTier)
+
+	_, ok = eventBatch.Events[1].(*kvevents.AllBlocksClearedEvent)
+	require.True(t, ok)
+
+	_, ok = eventBatch.Events[2].(*kvevents.BlockStoredEvent)
+	require.True(t, ok)
+}
+
+// TestVLLMParseMessage_MapEncodedErrors pins the error behavior for malformed
+// map-encoded events.
+func TestVLLMParseMessage_MapEncodedErrors(t *testing.T) {
+	adapter := NewVLLMAdapter()
+
+	for name, event := range map[string]any{
+		"unknown tag":    map[string]any{"type": "SomethingNew"},
+		"missing tag":    map[string]any{"block_hashes": []any{uint64(1)}},
+		"non-string tag": map[string]any{"type": 7},
+	} {
+		payload, err := msgpack.Marshal([]any{0.0, []any{event}, nil})
+		require.NoError(t, err, name)
+		_, _, _, err = adapter.ParseMessage(&kvevents.RawMessage{
+			Topic:   "kv@pod-1@m",
+			Payload: payload,
+		})
+		require.Error(t, err, name)
+	}
+}

--- a/pkg/kvevents/engineadapter/vllm_adapter_test.go
+++ b/pkg/kvevents/engineadapter/vllm_adapter_test.go
@@ -693,21 +693,33 @@ func TestVLLMParseMessage_MapEncodedBlockRemovedAndCleared(t *testing.T) {
 }
 
 // TestVLLMParseMessage_MapEncodedErrors pins the error behavior for malformed
-// map-encoded events.
+// map-encoded events: each failure mode reports a distinct, actionable error.
 func TestVLLMParseMessage_MapEncodedErrors(t *testing.T) {
 	adapter := NewVLLMAdapter()
 
-	for name, event := range map[string]any{
-		"unknown tag":    map[string]any{"type": "SomethingNew"},
-		"missing tag":    map[string]any{"block_hashes": []any{uint64(1)}},
-		"non-string tag": map[string]any{"type": 7},
+	for name, tc := range map[string]struct {
+		event   any
+		wantErr string
+	}{
+		"unknown tag": {
+			event:   map[string]any{"type": "SomethingNew"},
+			wantErr: "unknown vLLM event tag: SomethingNew",
+		},
+		"missing tag": {
+			event:   map[string]any{"block_hashes": []any{uint64(1)}},
+			wantErr: `missing the "type" tag`,
+		},
+		"non-string tag": {
+			event:   map[string]any{"type": 7},
+			wantErr: "is not a string",
+		},
 	} {
-		payload, err := msgpack.Marshal([]any{0.0, []any{event}, nil})
+		payload, err := msgpack.Marshal([]any{0.0, []any{tc.event}, nil})
 		require.NoError(t, err, name)
 		_, _, _, err = adapter.ParseMessage(&kvevents.RawMessage{
 			Topic:   "kv@pod-1@m",
 			Payload: payload,
 		})
-		require.Error(t, err, name)
+		require.ErrorContains(t, err, tc.wantErr, name)
 	}
 }


### PR DESCRIPTION
## What

vLLM dropped `array_like=True` from its KV cache event structs in [vllm-project/vllm#42892](https://github.com/vllm-project/vllm/pull/42892) (merged 2026-06-09). Newer vLLM versions therefore publish each KV event as a **field-name map** with the tag under the `"type"` key, instead of the positional array this adapter decodes. Result: every KV event from a new vLLM fails to parse (`failed to decode tagged union`), and the index receives nothing.

## How

`decodeVLLMEvent` now accepts both encodings: map-encoded events are normalized to the existing positional `[]any` layout before dispatch, so the converters — and their forward/backward-compatibility guards (length-guarded optional trailing fields) — stay encoding-agnostic and untouched. Absent map fields become `nil`, exactly like an omitted trailing array field. Positional arrays from older vLLM versions keep working unchanged; unknown tags keep flowing through the existing converter-lookup error path.

## Validation

- New unit tests: map-encoded `BlockStored` (full + omitted optional fields), `BlockRemoved`, `AllBlocksCleared`, a mixed array/map batch, and malformed map events (missing / non-string tag).
- `go test ./pkg/kvevents/...` green; `golangci-lint run` clean on the package.
- End-to-end against a **real captured stream** from a live vLLM serve run on a commit after #42892 (map encoding; multi-turn traffic with CPU offload stores and real LRU evictions): all 313 frames parse, and replaying them through the real `kvevents.Pool → kvblock.InMemoryIndex` path indexes and evicts every block correctly (71/71 live blocks CPU-matchable, 516/516 evicted blocks cleared).

AI assistance was used for implementation and tests; all changes reviewed and verified by the submitter.
